### PR TITLE
(BETA) https link in the installer (?)

### DIFF
--- a/install-deps.sh
+++ b/install-deps.sh
@@ -669,7 +669,7 @@ function run_installer()
 	function build_parity()
 	{
 		info "Downloading Parity..."
-		git clone git@github.com:ethcore/parity
+		git clone https://github.com/ethcore/parity
 		cd parity
 		git submodule init
 		git submodule update


### PR DESCRIPTION
this issue:
https://gitter.im/ethcore/parity?at=56ba3aae9f5549965ee202b0

lexansoft 22:14
Please make sure you have the correct access rights
and the repository exists.
Error: Failed to download resource "parity"
Failure while executing: git clone --branch beta git@github.com:ethcore/parity.git /Library/Caches/Homebrew/parity--git
Error: No such keg: /usr/local/Cellar/parity