### PR TITLE
api changes

### DIFF
--- a/ethcore/src/blockchain.rs
+++ b/ethcore/src/blockchain.rs
@@ -23,24 +23,6 @@ use extras::*;
 use transaction::*;
 use views::*;
 
-/// Uniquely identifies block.
-pub enum BlockId {
-	/// Block's sha3.
-	/// Querying by hash is always faster.
-	Hash(H256),
-	/// Block number within canon blockchain.
-	Number(BlockNumber)
-}
-
-/// Uniquely identifies transaction.
-pub enum TransactionId {
-	/// Transaction's sha3.
-	Hash(H256),
-	/// Block id and transaction index within this block.
-	/// Querying by block position is always faster.
-	Location(BlockId, usize)
-}
-
 /// Represents a tree route between `from` block and `to` block:
 pub struct TreeRoute {
 	/// A vector of hashes of all blocks, ordered from `from` to `to`.
@@ -129,18 +111,8 @@ pub trait BlockProvider {
 	}
 
 	/// Get transaction with given transaction hash.
-	fn transaction(&self, id: TransactionId) -> Option<LocalizedTransaction> {
-		match id {
-			TransactionId::Hash(ref hash) => self.transaction_address(hash),
-			TransactionId::Location(BlockId::Hash(hash), index) => Some(TransactionAddress {
-				block_hash: hash,
-				index: index
-			}),
-			TransactionId::Location(BlockId::Number(number), index) => self.block_hash(number).map(|hash| TransactionAddress {
-				block_hash: hash,
-				index: index
-			})
-		}.and_then(|address| self.block(&address.block_hash).and_then(|bytes| BlockView::new(&bytes).localized_transaction_at(address.index)))
+	fn transaction(&self, address: &TransactionAddress) -> Option<LocalizedTransaction> {
+		self.block(&address.block_hash).and_then(|bytes| BlockView::new(&bytes).localized_transaction_at(address.index))
 	}
 
 	/// Get a list of transactions for a given block.

--- a/ethcore/src/blockchain.rs
+++ b/ethcore/src/blockchain.rs
@@ -859,7 +859,7 @@ mod tests {
 		let transactions = bc.transactions(&b1_hash).unwrap();
 		assert_eq!(transactions.len(), 7);
 		for t in transactions {
-			assert_eq!(bc.transaction(&t.hash()).unwrap(), t);
+			assert_eq!(bc.transaction(&bc.transaction_address(&t.hash()).unwrap()).unwrap(), t);
 		}
 	}
 }

--- a/ethcore/src/client.rs
+++ b/ethcore/src/client.rs
@@ -18,7 +18,7 @@
 
 use util::*;
 use rocksdb::{Options, DB, DBCompactionStyle};
-use blockchain::{BlockChain, BlockProvider, CacheSize, TransactionId};
+use blockchain::{BlockChain, BlockProvider, CacheSize};
 use views::BlockView;
 use error::*;
 use header::BlockNumber;
@@ -32,7 +32,26 @@ use env_info::LastHashes;
 use verification::*;
 use block::*;
 use transaction::LocalizedTransaction;
+use extras::TransactionAddress;
 pub use blockchain::TreeRoute;
+
+/// Uniquely identifies block.
+pub enum BlockId {
+	/// Block's sha3.
+	/// Querying by hash is always faster.
+	Hash(H256),
+	/// Block number within canon blockchain.
+	Number(BlockNumber)
+}
+
+/// Uniquely identifies transaction.
+pub enum TransactionId {
+	/// Transaction's sha3.
+	Hash(H256),
+	/// Block id and transaction index within this block.
+	/// Querying by block position is always faster.
+	Location(BlockId, usize)
+}
 
 /// General block status
 #[derive(Debug, Eq, PartialEq)]
@@ -70,40 +89,24 @@ impl fmt::Display for BlockChainInfo {
 
 /// Blockchain database client. Owns and manages a blockchain and a block queue.
 pub trait BlockChainClient : Sync + Send {
-	/// Get raw block header data by block header hash.
-	fn block_header(&self, hash: &H256) -> Option<Bytes>;
+	/// Get raw block header data by block id.
+	fn block_header(&self, id: BlockId) -> Option<Bytes>;
 
-	/// Get raw block body data by block header hash.
+	/// Get raw block body data by block id.
 	/// Block body is an RLP list of two items: uncles and transactions.
-	fn block_body(&self, hash: &H256) -> Option<Bytes>;
+	fn block_body(&self, id: BlockId) -> Option<Bytes>;
 
 	/// Get raw block data by block header hash.
-	fn block(&self, hash: &H256) -> Option<Bytes>;
+	fn block(&self, id: BlockId) -> Option<Bytes>;
 
 	/// Get block status by block header hash.
-	fn block_status(&self, hash: &H256) -> BlockStatus;
+	fn block_status(&self, id: BlockId) -> BlockStatus;
 
 	/// Get block total difficulty.
-	fn block_total_difficulty(&self, hash: &H256) -> Option<U256>;
+	fn block_total_difficulty(&self, id: BlockId) -> Option<U256>;
 
 	/// Get address code.
 	fn code(&self, address: &Address) -> Option<Bytes>;
-
-	/// Get raw block header data by block number.
-	fn block_header_at(&self, n: BlockNumber) -> Option<Bytes>;
-
-	/// Get raw block body data by block number.
-	/// Block body is an RLP list of two items: uncles and transactions.
-	fn block_body_at(&self, n: BlockNumber) -> Option<Bytes>;
-
-	/// Get raw block data by block number.
-	fn block_at(&self, n: BlockNumber) -> Option<Bytes>;
-
-	/// Get block status by block number.
-	fn block_status_at(&self, n: BlockNumber) -> BlockStatus;
-
-	/// Get block total difficulty.
-	fn block_total_difficulty_at(&self, n: BlockNumber) -> Option<U256>;
 
 	/// Get transaction with given hash.
 	fn transaction(&self, id: TransactionId) -> Option<LocalizedTransaction>;
@@ -132,7 +135,7 @@ pub trait BlockChainClient : Sync + Send {
 
 	/// Get the best block header.
 	fn best_block_header(&self) -> Bytes {
-		self.block_header(&self.chain_info().best_block_hash).unwrap()
+		self.block_header(BlockId::Hash(self.chain_info().best_block_hash)).unwrap()
 	}
 }
 
@@ -332,68 +335,62 @@ impl Client {
 	pub fn configure_cache(&self, pref_cache_size: usize, max_cache_size: usize) {
 		self.chain.write().unwrap().configure_cache(pref_cache_size, max_cache_size);
 	}
+
+	fn block_hash(&self, id: BlockId) -> Option<H256> {
+		match id {
+			BlockId::Hash(hash) => Some(hash),
+			BlockId::Number(number) => self.chain.read().unwrap().block_hash(number)
+		}
+	}
 }
 
 impl BlockChainClient for Client {
-	fn block_header(&self, hash: &H256) -> Option<Bytes> {
-		self.chain.read().unwrap().block(hash).map(|bytes| BlockView::new(&bytes).rlp().at(0).as_raw().to_vec())
+	fn block_header(&self, id: BlockId) -> Option<Bytes> {
+		self.block_hash(id).and_then(|hash| self.chain.read().unwrap().block(&hash).map(|bytes| BlockView::new(&bytes).rlp().at(0).as_raw().to_vec()))
 	}
 
-	fn block_body(&self, hash: &H256) -> Option<Bytes> {
-		self.chain.read().unwrap().block(hash).map(|bytes| {
-			let rlp = Rlp::new(&bytes);
-			let mut body = RlpStream::new();
-			body.append_raw(rlp.at(1).as_raw(), 1);
-			body.append_raw(rlp.at(2).as_raw(), 1);
-			body.out()
+	fn block_body(&self, id: BlockId) -> Option<Bytes> {
+		self.block_hash(id).and_then(|hash| {
+			self.chain.read().unwrap().block(&hash).map(|bytes| {
+				let rlp = Rlp::new(&bytes);
+				let mut body = RlpStream::new();
+				body.append_raw(rlp.at(1).as_raw(), 1);
+				body.append_raw(rlp.at(2).as_raw(), 1);
+				body.out()
+			})
 		})
 	}
 
-	fn block(&self, hash: &H256) -> Option<Bytes> {
-		self.chain.read().unwrap().block(hash)
+	fn block(&self, id: BlockId) -> Option<Bytes> {
+		self.block_hash(id).and_then(|hash| {
+			self.chain.read().unwrap().block(&hash)
+		})
 	}
 
-	fn block_status(&self, hash: &H256) -> BlockStatus {
-		if self.chain.read().unwrap().is_known(&hash) {
-			BlockStatus::InChain 
-		} else { 
-			self.block_queue.read().unwrap().block_status(hash) 
+	fn block_status(&self, id: BlockId) -> BlockStatus {
+		match self.block_hash(id) {
+			Some(ref hash) if self.chain.read().unwrap().is_known(hash) => BlockStatus::InChain,
+			Some(hash) => self.block_queue.read().unwrap().block_status(&hash),
+			None => BlockStatus::Unknown
 		}
 	}
 	
-	fn block_total_difficulty(&self, hash: &H256) -> Option<U256> {
-		self.chain.read().unwrap().block_details(hash).map(|d| d.total_difficulty)
+	fn block_total_difficulty(&self, id: BlockId) -> Option<U256> {
+		self.block_hash(id).and_then(|hash| self.chain.read().unwrap().block_details(&hash)).map(|d| d.total_difficulty)
 	}
 
 	fn code(&self, address: &Address) -> Option<Bytes> {
 		self.state().code(address)
 	}
 
-	fn block_header_at(&self, n: BlockNumber) -> Option<Bytes> {
-		self.chain.read().unwrap().block_hash(n).and_then(|h| self.block_header(&h))
-	}
-
-	fn block_body_at(&self, n: BlockNumber) -> Option<Bytes> {
-		self.chain.read().unwrap().block_hash(n).and_then(|h| self.block_body(&h))
-	}
-
-	fn block_at(&self, n: BlockNumber) -> Option<Bytes> {
-		self.chain.read().unwrap().block_hash(n).and_then(|h| self.block(&h))
-	}
-
-	fn block_status_at(&self, n: BlockNumber) -> BlockStatus {
-		match self.chain.read().unwrap().block_hash(n) {
-			Some(h) => self.block_status(&h),
-			None => BlockStatus::Unknown
-		}
-	}
-
-	fn block_total_difficulty_at(&self, n: BlockNumber) -> Option<U256> {
-		self.chain.read().unwrap().block_hash(n).and_then(|h| self.block_total_difficulty(&h))
-	}
-
 	fn transaction(&self, id: TransactionId) -> Option<LocalizedTransaction> {
-		self.chain.read().unwrap().transaction(id)
+		match id {
+			TransactionId::Hash(ref hash) => self.chain.read().unwrap().transaction_address(hash),
+			TransactionId::Location(id, index) => self.block_hash(id).map(|hash| TransactionAddress {
+				block_hash: hash,
+				index: index
+			})
+		}.and_then(|address| self.chain.read().unwrap().transaction(&address))
 	}
 
 	fn tree_route(&self, from: &H256, to: &H256) -> Option<TreeRoute> {
@@ -413,7 +410,7 @@ impl BlockChainClient for Client {
 		if self.chain.read().unwrap().is_known(&header.hash()) {
 			return Err(ImportError::AlreadyInChain);
 		}
-		if self.block_status(&header.parent_hash) == BlockStatus::Unknown {
+		if self.block_status(BlockId::Hash(header.parent_hash)) == BlockStatus::Unknown {
 			return Err(ImportError::UnknownParent);
 		}
 		self.block_queue.write().unwrap().import_block(bytes)

--- a/ethcore/src/client.rs
+++ b/ethcore/src/client.rs
@@ -37,7 +37,7 @@ use extras::TransactionAddress;
 pub use blockchain::TreeRoute;
 
 /// Uniquely identifies block.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum BlockId {
 	/// Block's sha3.
 	/// Querying by hash is always faster.
@@ -51,7 +51,7 @@ pub enum BlockId {
 }
 
 /// Uniquely identifies transaction.
-#[derive(Debug, PartialEq)]
+#[derive(Debug, PartialEq, Clone)]
 pub enum TransactionId {
 	/// Transaction's sha3.
 	Hash(H256),

--- a/ethcore/src/client.rs
+++ b/ethcore/src/client.rs
@@ -37,15 +37,21 @@ use extras::TransactionAddress;
 pub use blockchain::TreeRoute;
 
 /// Uniquely identifies block.
+#[derive(Debug, PartialEq)]
 pub enum BlockId {
 	/// Block's sha3.
 	/// Querying by hash is always faster.
 	Hash(H256),
 	/// Block number within canon blockchain.
-	Number(BlockNumber)
+	Number(BlockNumber),
+	/// Earliest block (genesis).
+	Earliest,
+	/// Latest mined block.
+	Latest
 }
 
 /// Uniquely identifies transaction.
+#[derive(Debug, PartialEq)]
 pub enum TransactionId {
 	/// Transaction's sha3.
 	Hash(H256),
@@ -347,7 +353,9 @@ impl Client {
 	fn block_hash(&self, id: BlockId) -> Option<H256> {
 		match id {
 			BlockId::Hash(hash) => Some(hash),
-			BlockId::Number(number) => self.chain.read().unwrap().block_hash(number)
+			BlockId::Number(number) => self.chain.read().unwrap().block_hash(number),
+			BlockId::Earliest => self.chain.read().unwrap().block_hash(0),
+			BlockId::Latest => Some(self.chain.read().unwrap().best_block_hash())
 		}
 	}
 }

--- a/ethcore/src/tests/client.rs
+++ b/ethcore/src/tests/client.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-use client::{BlockChainClient,Client};
+use client::{BlockChainClient, Client, BlockId};
 use tests::helpers::*;
 use common::*;
 
@@ -44,7 +44,7 @@ fn imports_good_block() {
 	client.flush_queue();
 	client.import_verified_blocks(&IoChannel::disconnected());
 
-	let block = client.block_header_at(1).unwrap();
+	let block = client.block_header(BlockId::Number(1)).unwrap();
 	assert!(!block.is_empty());
 }
 
@@ -53,7 +53,7 @@ fn query_none_block() {
 	let dir = RandomTempPath::new();
 	let client = Client::new(get_test_spec(), dir.as_path(), IoChannel::disconnected()).unwrap();
 
-    let non_existant = client.block_header_at(188);
+    let non_existant = client.block_header(BlockId::Number(188));
 	assert!(non_existant.is_none());
 }
 
@@ -61,7 +61,7 @@ fn query_none_block() {
 fn query_bad_block() {
 	let client_result = get_test_client_with_blocks(vec![get_bad_state_dummy_block()]);
 	let client = client_result.reference();
-	let bad_block:Option<Bytes> = client.block_header_at(1);
+	let bad_block:Option<Bytes> = client.block_header(BlockId::Number(1));
 
 	assert!(bad_block.is_none());
 }
@@ -80,7 +80,7 @@ fn returns_chain_info() {
 fn imports_block_sequence() {
 	let client_result = generate_dummy_client(6);
 	let client = client_result.reference();
-	let block = client.block_header_at(5).unwrap();
+	let block = client.block_header(BlockId::Number(5)).unwrap();
 
 	assert!(!block.is_empty());
 }

--- a/rpc/src/v1/impls/eth.rs
+++ b/rpc/src/v1/impls/eth.rs
@@ -183,8 +183,12 @@ impl Eth for EthClient {
 			})
 	}
 
-	fn transaction_by_block_number_and_index(&self, _params: Params) -> Result<Value, Error> {
-		unimplemented!()
+	fn transaction_by_block_number_and_index(&self, params: Params) -> Result<Value, Error> {
+		from_params::<(BlockNumber, Index)>(params)
+			.and_then(|(number, index)| match self.client.transaction(TransactionId::Location(number.into(), index.value())) {
+				Some(t) => to_value(&Transaction::from(t)),
+				None => Ok(Value::Null)
+			})
 	}
 }
 

--- a/rpc/src/v1/impls/eth.rs
+++ b/rpc/src/v1/impls/eth.rs
@@ -23,7 +23,6 @@ use util::uint::*;
 use util::sha3::*;
 use ethcore::client::*;
 use ethcore::views::*;
-use ethcore::blockchain::{BlockId, TransactionId};
 use ethcore::ethereum::denominations::shannon;
 use v1::traits::{Eth, EthFilter};
 use v1::types::{Block, BlockTransactions, BlockNumber, Bytes, SyncStatus, SyncInfo, Transaction, OptionalValue, Index};
@@ -110,7 +109,7 @@ impl Eth for EthClient {
 
 	fn block_transaction_count(&self, params: Params) -> Result<Value, Error> {
 		from_params::<(H256,)>(params)
-			.and_then(|(hash,)| match self.client.block(&hash) {
+			.and_then(|(hash,)| match self.client.block(BlockId::Hash(hash)) {
 				Some(bytes) => to_value(&BlockView::new(&bytes).transactions_count()),
 				None => Ok(Value::Null)
 			})
@@ -118,7 +117,7 @@ impl Eth for EthClient {
 
 	fn block_uncles_count(&self, params: Params) -> Result<Value, Error> {
 		from_params::<(H256,)>(params)
-			.and_then(|(hash,)| match self.client.block(&hash) {
+			.and_then(|(hash,)| match self.client.block(BlockId::Hash(hash)) {
 				Some(bytes) => to_value(&BlockView::new(&bytes).uncles_count()),
 				None => Ok(Value::Null)
 			})
@@ -132,7 +131,7 @@ impl Eth for EthClient {
 
 	fn block(&self, params: Params) -> Result<Value, Error> {
 		from_params::<(H256, bool)>(params)
-			.and_then(|(hash, include_txs)| match (self.client.block(&hash), self.client.block_total_difficulty(&hash)) {
+			.and_then(|(hash, include_txs)| match (self.client.block(BlockId::Hash(hash.clone())), self.client.block_total_difficulty(BlockId::Hash(hash))) {
 				(Some(bytes), Some(total_difficulty)) => {
 					let block_view = BlockView::new(&bytes);
 					let view = block_view.header_view();

--- a/rpc/src/v1/traits/eth.rs
+++ b/rpc/src/v1/traits/eth.rs
@@ -50,8 +50,11 @@ pub trait Eth: Sized + Send + Sync + 'static {
 	/// Returns content of the storage at given address.
 	fn storage_at(&self, _: Params) -> Result<Value, Error> { rpc_unimplemented!() }
 
-	/// Returns block with given index / hash.
-	fn block(&self, _: Params) -> Result<Value, Error> { rpc_unimplemented!() }
+	/// Returns block with given hash.
+	fn block_by_hash(&self, _: Params) -> Result<Value, Error> { rpc_unimplemented!() }
+
+	/// Returns block with given number.
+	fn block_by_number(&self, _: Params) -> Result<Value, Error> { rpc_unimplemented!() }
 	
 	/// Returns the number of transactions sent from given address at given time (block number).
 	fn transaction_count(&self, _: Params) -> Result<Value, Error> { rpc_unimplemented!() }
@@ -135,8 +138,8 @@ pub trait Eth: Sized + Send + Sync + 'static {
 		delegate.add_method("eth_sendTransaction", Eth::send_transaction);
 		delegate.add_method("eth_call", Eth::call);
 		delegate.add_method("eth_estimateGas", Eth::estimate_gas);
-		delegate.add_method("eth_getBlockByHash", Eth::block);
-		delegate.add_method("eth_getBlockByNumber", Eth::block);
+		delegate.add_method("eth_getBlockByHash", Eth::block_by_hash);
+		delegate.add_method("eth_getBlockByNumber", Eth::block_by_number);
 		delegate.add_method("eth_getTransactionByHash", Eth::transaction_by_hash);
 		delegate.add_method("eth_getTransactionByBlockHashAndIndex", Eth::transaction_by_block_hash_and_index);
 		delegate.add_method("eth_getTransactionByBlockNumberAndIndex", Eth::transaction_by_block_number_and_index);

--- a/rpc/src/v1/types/block_number.rs
+++ b/rpc/src/v1/types/block_number.rs
@@ -16,6 +16,7 @@
 
 use serde::{Deserialize, Deserializer, Error};
 use serde::de::Visitor;
+use ethcore::client::BlockId;
 
 /// Represents rpc api block number param.
 #[derive(Debug, PartialEq)]
@@ -53,8 +54,20 @@ impl Visitor for BlockNumberVisitor {
 	}
 }
 
+impl Into<BlockId> for BlockNumber {
+	fn into(self) -> BlockId {
+		match self {
+			BlockNumber::Num(n) => BlockId::Number(n),
+			BlockNumber::Earliest => BlockId::Earliest,
+			BlockNumber::Latest => BlockId::Latest,
+			BlockNumber::Pending => BlockId::Latest // TODO: change this once blockid support pending
+		}
+	}
+}
+
 #[cfg(test)]
 mod tests {
+	use ethcore::client::BlockId;
 	use super::*;
 	use serde_json;
 
@@ -63,6 +76,14 @@ mod tests {
 		let s = r#"["0xa", "10", "latest", "earliest", "pending"]"#;
 		let deserialized: Vec<BlockNumber> = serde_json::from_str(s).unwrap();
 		assert_eq!(deserialized, vec![BlockNumber::Num(10), BlockNumber::Num(10), BlockNumber::Latest, BlockNumber::Earliest, BlockNumber::Pending])
+	}
+
+	#[test]
+	fn block_number_into() {
+		assert_eq!(BlockId::Number(100), BlockNumber::Num(100).into());
+		assert_eq!(BlockId::Earliest, BlockNumber::Earliest.into());
+		assert_eq!(BlockId::Latest, BlockNumber::Latest.into());
+		assert_eq!(BlockId::Latest, BlockNumber::Pending.into());
 	}
 }
 

--- a/sync/src/chain.rs
+++ b/sync/src/chain.rs
@@ -1061,6 +1061,7 @@ impl ChainSync {
 						for block_hash in route.blocks {
 							let mut hash_rlp = RlpStream::new_list(2);
 							let difficulty = chain.block_total_difficulty(BlockId::Hash(block_hash.clone())).expect("Mallformed block without a difficulty on the chain!");
+		
 							hash_rlp.append(&block_hash);
 							hash_rlp.append(&difficulty);
 							rlp_stream.append_raw(&hash_rlp.out(), 1);

--- a/sync/src/tests/chain.rs
+++ b/sync/src/tests/chain.rs
@@ -15,7 +15,7 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 use util::*;
-use ethcore::client::{BlockChainClient};
+use ethcore::client::{BlockChainClient, BlockId};
 use io::SyncIo;
 use chain::{SyncState};
 use super::helpers::*;
@@ -27,7 +27,7 @@ fn two_peers() {
 	net.peer_mut(1).chain.add_blocks(1000, false);
 	net.peer_mut(2).chain.add_blocks(1000, false);
 	net.sync();
-	assert!(net.peer(0).chain.block_at(1000).is_some());
+	assert!(net.peer(0).chain.block(BlockId::Number(1000)).is_some());
 	assert_eq!(net.peer(0).chain.blocks.read().unwrap().deref(), net.peer(1).chain.blocks.read().unwrap().deref());
 }
 
@@ -60,7 +60,7 @@ fn empty_blocks() {
 		net.peer_mut(2).chain.add_blocks(5, n % 2 == 0);
 	}
 	net.sync();
-	assert!(net.peer(0).chain.block_at(1000).is_some());
+	assert!(net.peer(0).chain.block(BlockId::Number(1000)).is_some());
 	assert_eq!(net.peer(0).chain.blocks.read().unwrap().deref(), net.peer(1).chain.blocks.read().unwrap().deref());
 }
 

--- a/sync/src/tests/helpers.rs
+++ b/sync/src/tests/helpers.rs
@@ -80,7 +80,9 @@ impl TestBlockChainClient {
 	fn block_hash(&self, id: BlockId) -> Option<H256> {
 		match id {
 			BlockId::Hash(hash) => Some(hash),
-			BlockId::Number(n) => self.numbers.read().unwrap().get(&(n as usize)).cloned()
+			BlockId::Number(n) => self.numbers.read().unwrap().get(&(n as usize)).cloned(),
+			BlockId::Earliest => self.numbers.read().unwrap().get(&0).cloned(),
+			BlockId::Latest => self.numbers.read().unwrap().get(&(self.numbers.read().unwrap().len() - 1)).cloned()
 		}
 	}
 }


### PR DESCRIPTION
- removed `*_at` methods from client api. Instead accept `BlockId` which is either block number or hash
- moved `BlockId` and `TransactionId` to `client.rs`. Blockchain doesn't have to know about them.
- added two new types of `BlockId` - `Earliest` and `Latest` (same as in cpp implementation)
- implemented jsonrpc methods `eth_getTransactionByBlockNumberAndIndex` and `eth_getBlockByHash`