### PR TITLE
Make clippy an optional dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ matrix:
   fast_finish: true
   include:
   - rust: nightly
-    env: FEATURES="--features ethcore/json-tests" KCOV_FEATURES="" TARGETS="-p ethash -p ethcore-util -p ethcore -p ethsync -p ethcore-rpc -p parity" ARCHIVE_SUFFIX="-${TRAVIS_OS_NAME}-${TRAVIS_TAG}"
+    env: FEATURES='--features "ethcore/json-tests dev"' KCOV_FEATURES="" TARGETS="-p ethash -p ethcore-util -p ethcore -p ethsync -p ethcore-rpc -p parity" ARCHIVE_SUFFIX="-${TRAVIS_OS_NAME}-${TRAVIS_TAG}"
 cache:
   apt: true
   directories:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -167,7 +167,6 @@ dependencies = [
 name = "ethcore"
 version = "0.9.99"
 dependencies = [
- "clippy 0.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethash 0.9.99",
@@ -186,7 +185,6 @@ dependencies = [
 name = "ethcore-rpc"
 version = "0.9.99"
 dependencies = [
- "clippy 0.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethcore 0.9.99",
  "ethcore-util 0.9.99",
  "ethsync 0.9.99",
@@ -204,7 +202,6 @@ name = "ethcore-util"
 version = "0.9.99"
 dependencies = [
  "arrayvec 0.3.15 (registry+https://github.com/rust-lang/crates.io-index)",
- "clippy 0.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam 0.2.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "elastic-array 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -232,7 +229,6 @@ dependencies = [
 name = "ethsync"
 version = "0.9.99"
 dependencies = [
- "clippy 0.0.41 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethcore 0.9.99",
  "ethcore-util 0.9.99",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,7 @@ rustc-serialize = "0.3"
 docopt = "0.6"
 docopt_macros = "0.6"
 ctrlc = { git = "https://github.com/tomusdrw/rust-ctrlc.git" }
-clippy = "0.0.41"
+clippy = { version = "0.0.41", optional = true }
 ethcore-util = { path = "util" }
 ethcore = { path = "ethcore" }
 ethsync = { path = "sync" }
@@ -23,6 +23,7 @@ target_info = "0.1"
 [features]
 default = ["rpc"]
 rpc = ["ethcore-rpc"]
+dev = ["clippy", "ethcore/dev", "ethcore-util/dev", "ethsync/dev", "ethcore-rpc/dev"]
 
 [[bin]]
 path = "parity/main.rs"

--- a/ethcore/Cargo.toml
+++ b/ethcore/Cargo.toml
@@ -18,7 +18,7 @@ ethcore-util = { path = "../util" }
 evmjit = { path = "../evmjit", optional = true }
 ethash = { path = "../ethash" }
 num_cpus = "0.2"
-clippy = "0.0.41"
+clippy = { version = "0.0.41", optional = true }
 crossbeam = "0.1.5"
 lazy_static = "0.1"
 
@@ -27,3 +27,4 @@ jit = ["evmjit"]
 evm-debug = []
 json-tests = []
 test-heavy = []
+dev = ["clippy"]

--- a/ethcore/src/lib.rs
+++ b/ethcore/src/lib.rs
@@ -17,9 +17,8 @@
 #![warn(missing_docs)]
 #![feature(cell_extras)]
 #![feature(augmented_assignments)]
-#![feature(plugin)]
-// Clippy
-#![plugin(clippy)]
+#![cfg_attr(feature="dev", feature(plugin))]
+#![cfg_attr(feature="dev", plugin(clippy))]
 // TODO [todr] not really sure
 #![allow(needless_range_loop)]
 // Shorter than if-else

--- a/parity/main.rs
+++ b/parity/main.rs
@@ -19,7 +19,7 @@
 #![warn(missing_docs)]
 #![feature(plugin)]
 #![plugin(docopt_macros)]
-#![plugin(clippy)]
+#![cfg_attr(feature="dev", plugin(clippy))]
 extern crate docopt;
 extern crate rustc_serialize;
 extern crate ethcore_util as util;

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -16,6 +16,10 @@ jsonrpc-http-server = "1.1.2"
 ethcore-util = { path = "../util" }
 ethcore = { path = "../ethcore" }
 ethsync = { path = "../sync" }
-clippy = "0.0.41"
+clippy = { version = "0.0.41", optional = true }
 target_info = "0.1.0"
 rustc-serialize = "0.3"
+
+[features]
+default = []
+dev = ["clippy", "ethcore/dev", "ethcore-util/dev", "ethsync/dev"]

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -18,7 +18,7 @@
 #![warn(missing_docs)]
 #![feature(custom_derive, custom_attribute, plugin)]
 #![plugin(serde_macros)]
-#![plugin(clippy)]
+#![cfg_attr(feature="dev", plugin(clippy))]
 
 extern crate rustc_serialize;
 extern crate target_info;

--- a/sync/Cargo.toml
+++ b/sync/Cargo.toml
@@ -10,8 +10,12 @@ authors = ["Ethcore <admin@ethcore.io"]
 [dependencies]
 ethcore-util = { path = "../util" }
 ethcore = { path = ".." }
-clippy = "0.0.41"
+clippy = { version = "0.0.41", optional = true }
 log = "0.3"
 env_logger = "0.3"
 time = "0.1.34"
 rand = "0.3.13"
+
+[features]
+default = []
+dev = ["clippy", "ethcore/dev", "ethcore-util/dev"]

--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -15,9 +15,9 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 #![warn(missing_docs)]
-#![feature(plugin)]
+#![cfg_attr(feature="dev", feature(plugin))]
+#![cfg_attr(feature="dev", plugin(clippy))]
 #![feature(augmented_assignments)]
-#![plugin(clippy)]
 // Keeps consistency (all lines with `.clone()`) and helpful when changing ref to non-ref.
 #![allow(clone_on_copy)]
 

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -26,7 +26,11 @@ crossbeam = "0.2"
 slab = { git = "https://github.com/arkpar/slab.git" }
 sha3 = { path = "sha3" }
 serde = "0.6.7"
-clippy = "0.0.41"
+clippy = { version = "0.0.41", optional = true }
 json-tests = { path = "json-tests" }
 target_info = "0.1.0"
 igd = "0.4.2"
+
+[features]
+default = []
+dev = ["clippy"]

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -18,10 +18,10 @@
 #![feature(op_assign_traits)]
 #![feature(augmented_assignments)]
 #![feature(associated_consts)]
-#![feature(plugin)]
+#![cfg_attr(feature="dev", feature(plugin))]
+#![cfg_attr(feature="dev", plugin(clippy))]
 #![feature(catch_panic)]
 // Clippy settings
-#![plugin(clippy)]
 // TODO [todr] not really sure
 #![allow(needless_range_loop)]
 // Shorter than if-else


### PR DESCRIPTION
It can be run locally with `cargo build --features dev`, but there's no need to include it in the standard build.

Untested, since aster/quasi haven't yet been updated for the current nightly. Will test when that happens.