### PR TITLE
Updated jsonrpc-core, finally builds on nightly

### DIFF
--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -11,7 +11,7 @@ authors = ["Ethcore <admin@ethcore.io"]
 serde = "0.6.7"
 serde_macros = "0.6.10"
 serde_json = "0.6.0"
-jsonrpc-core = "1.1"
+jsonrpc-core = "1.1.1"
 jsonrpc-http-server = "1.1"
 ethcore-util = { path = "../util" }
 ethcore = { path = "../ethcore" }


### PR DESCRIPTION
As debris/jsonrpc-core#4 is closed in jsonrpc-core 1.1.1, this update finally allowed me to build and run it with nightly.20160212223239