### PR TITLE
Remove unneeded code, fix minor potential issue with length.

### DIFF
--- a/util/src/network/discovery.rs
+++ b/util/src/network/discovery.rs
@@ -276,9 +276,6 @@ impl Discovery {
 	}
 
 	pub fn writable(&mut self) {
-		if self.send_queue.is_empty() {
-			return;
-		}
 		while !self.send_queue.is_empty() {
 			let data = self.send_queue.pop_front().unwrap();
 			match self.udp_socket.send_to(&data.payload, &data.address) {

--- a/util/src/network/node_table.rs
+++ b/util/src/network/node_table.rs
@@ -163,7 +163,7 @@ impl Display for Node {
 impl FromStr for Node {
 	type Err = UtilError;
 	fn from_str(s: &str) -> Result<Self, Self::Err> {
-		let (id, endpoint) = if &s[0..8] == "enode://" && s.len() > 136 && &s[136..137] == "@" {
+		let (id, endpoint) = if s.len() > 136 && &s[0..8] == "enode://" && &s[136..137] == "@" {
 			(try!(NodeId::from_str(&s[8..136])), try!(NodeEndpoint::from_str(&s[137..])))
 		}
 		else {


### PR DESCRIPTION
- remove unneeded condition prior to equivalent guard.
- check for length prior to dereferencing a range.
