### PR TITLE
optimization of U256

### DIFF
--- a/sync/src/chain.rs
+++ b/sync/src/chain.rs
@@ -927,13 +927,13 @@ impl ChainSync {
 		if reverse {
 			number = min(last, number);
 		} else {
-			number = max(1, number);
+			number = max(0, number);
 		}
 		let max_count = min(MAX_HEADERS_TO_SEND, max_headers);
 		let mut count = 0;
 		let mut data = Bytes::new();
 		let inc = (skip + 1) as BlockNumber;
-		while number <= last && number > 0 && count < max_count {
+		while number <= last && number >= 0 && count < max_count {
 			if let Some(mut hdr) = io.chain().block_header(BlockId::Number(number)) {
 				data.append(&mut hdr);
 				count += 1;

--- a/sync/src/chain.rs
+++ b/sync/src/chain.rs
@@ -933,13 +933,13 @@ impl ChainSync {
 		let mut count = 0;
 		let mut data = Bytes::new();
 		let inc = (skip + 1) as BlockNumber;
-		while number <= last && number >= 0 && count < max_count {
+		while number <= last && count < max_count {
 			if let Some(mut hdr) = io.chain().block_header(BlockId::Number(number)) {
 				data.append(&mut hdr);
 				count += 1;
 			}
 			if reverse {
-				if number <= inc {
+				if number <= inc || number == 0 {
 					break;
 				}
 				number -= inc;
@@ -1541,5 +1541,54 @@ mod tests {
 		let data = &io.queue[0].data.clone();
 		let result = sync.on_peer_new_block(&mut io, 0, &UntrustedRlp::new(&data));
 		assert!(result.is_ok());
+	}
+
+	#[test]
+	fn returns_requested_block_headers() {
+		let mut client = TestBlockChainClient::new();
+		client.add_blocks(100, false);
+		let mut queue = VecDeque::new();
+		let io = TestIo::new(&mut client, &mut queue, None);
+
+		let mut rlp = RlpStream::new_list(4);
+		rlp.append(&0u64);
+		rlp.append(&10u64);
+		rlp.append(&0u64);
+		rlp.append(&0u64);
+		let data = rlp.out();
+
+		let response = ChainSync::return_block_headers(&io, &UntrustedRlp::new(&data));
+
+		assert!(response.is_ok());
+		let (_, rlp_stream) = response.unwrap().unwrap();
+		let response_data = rlp_stream.out();
+		let rlp = UntrustedRlp::new(&response_data);
+		assert!(rlp.at(0).is_ok());
+		assert!(rlp.at(9).is_ok());
+	}
+
+	#[test]
+	fn returns_requested_block_headers_reverse() {
+		let mut client = TestBlockChainClient::new();
+		client.add_blocks(100, false);
+		let mut queue = VecDeque::new();
+		let io = TestIo::new(&mut client, &mut queue, None);
+
+		let mut rlp = RlpStream::new_list(4);
+		rlp.append(&15u64);
+		rlp.append(&15u64);
+		rlp.append(&0u64);
+		rlp.append(&1u64);
+		let data = rlp.out();
+
+		let response = ChainSync::return_block_headers(&io, &UntrustedRlp::new(&data));
+
+		assert!(response.is_ok());
+		let (_, rlp_stream) = response.unwrap().unwrap();
+		let response_data = rlp_stream.out();
+		let rlp = UntrustedRlp::new(&response_data);
+		assert!(rlp.at(0).is_ok());
+		assert!(rlp.at(14).is_ok());
+		assert!(!rlp.at(15).is_ok());
 	}
 }

--- a/util/benches/bigint.rs
+++ b/util/benches/bigint.rs
@@ -29,9 +29,18 @@ use test::{Bencher, black_box};
 use ethcore_util::uint::*;
 
 #[bench]
-fn u256_first_degree(b: &mut test::Bencher) {
+fn u256_add(b: &mut Bencher) {
 	b.iter(|| {
 		let n = black_box(10000);
 		(0..n).fold(U256::zero(), |old, new| { old.overflowing_add(U256::from(new)).0 })
 	});
 }
+
+#[bench]
+fn u256_sub(b: &mut Bencher) {
+	b.iter(|| {
+		let n = black_box(10000);
+		(0..n).fold(U256::zero(), |old, new| { old.overflowing_add(U256::from(new)).0 })
+	});
+}
+

--- a/util/benches/bigint.rs
+++ b/util/benches/bigint.rs
@@ -1,0 +1,37 @@
+// Copyright 2015, 2016 Ethcore (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+//! benchmarking for rlp
+//! should be started with:
+//! ```bash
+//! multirust run nightly cargo bench
+//! ```
+
+#![feature(test)]
+
+extern crate test;
+extern crate ethcore_util;
+
+use test::{Bencher, black_box};
+use ethcore_util::uint::*;
+
+#[bench]
+fn u256_first_degree(b: &mut test::Bencher) {
+	b.iter(|| {
+		let n = black_box(10000);
+		(0..n).fold(U256::zero(), |old, new| { old.overflowing_add(U256::from(new)).0 })
+	});
+}

--- a/util/benches/bigint.rs
+++ b/util/benches/bigint.rs
@@ -21,6 +21,7 @@
 //! ```
 
 #![feature(test)]
+#![feature(asm)]
 
 extern crate test;
 extern crate ethcore_util;
@@ -40,7 +41,24 @@ fn u256_add(b: &mut Bencher) {
 fn u256_sub(b: &mut Bencher) {
 	b.iter(|| {
 		let n = black_box(10000);
-		(0..n).fold(U256::zero(), |old, new| { old.overflowing_add(U256::from(new)).0 })
+		(0..n).fold(U256::zero(), |old, new| { old.overflowing_sub(U256::from(new)).0 })
+	});
+}
+
+#[bench]
+fn u256_mul(b: &mut Bencher) {
+	b.iter(|| {
+		let n = black_box(10000);
+		(0..n).fold(U256([12345u64, 0u64, 0u64, 0u64]), |old, new| { old.overflowing_mul(U256::from(new)).0 })
+	});
+}
+
+
+#[bench]
+fn u128_mul(b: &mut Bencher) {
+	b.iter(|| {
+		let n = black_box(10000);
+		(0..n).fold(U128([12345u64, 0u64]), |old, new| { old.overflowing_mul(U128::from(new)).0 })
 	});
 }
 

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -16,6 +16,7 @@
 
 #![warn(missing_docs)]
 #![cfg_attr(feature="dev", feature(plugin))]
+#![cfg_attr(feature="dev", feature(asm))]
 #![cfg_attr(feature="dev", plugin(clippy))]
 
 // Clippy settings

--- a/util/src/uint.rs
+++ b/util/src/uint.rs
@@ -91,13 +91,13 @@ macro_rules! overflowing_add_u256_asm {
 		unsafe {
 			asm!("
 				xor %al, %al
-				adc $9, %r8
-				adc $10, %r9
-				adc $11, %r10
-				adc $12, %r11
-				adc $$0, %al"
-				: "={r8}"(result[0]), "={r9}"(result[1]), "={r10}"(result[2]), "={r11}"(result[3]), "={al}"(overflow)
-				: "{r8}"(self_t[0]), "{r9}"(self_t[1]), "{r10}"(self_t[2]), "{r11}"(self_t[3]), "m"(other_t[0]), "m"(other_t[1]), "m"(other_t[2]), "m"(other_t[3])
+                adc $9, $0
+                adc $10, $1
+                adc $11, $2
+                adc $12, $3
+                adc $$0, %al"
+             	: "=r"(result[0]), "=r"(result[1]), "=r"(result[2]), "=r"(result[3]), "={al}"(overflow)
+				: "0"(self_t[0]), "1"(self_t[1]), "2"(self_t[2]), "3"(self_t[3]), "mr"(other_t[0]), "mr"(other_t[1]), "mr"(other_t[2]), "mr"(other_t[3])
 				:
 				:
 			);


### PR DESCRIPTION
before
```
test u256_add ... bench:     140,001 ns/iter (+/- 9,659)
test u256_mul ... bench:   4,179,748 ns/iter (+/- 420,781)
test u256_sub ... bench:     475,245 ns/iter (+/- 30,205)
```

after
```
test u256_add ... bench:     109,593 ns/iter (+/- 4,050)
test u256_mul ... bench:     818,250 ns/iter (+/- 26,664)
test u256_sub ... bench:     109,403 ns/iter (+/- 3,300)
```