### PR TITLE
optimization of U256

### DIFF
--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -39,6 +39,7 @@ target_info = "0.1"
 [features]
 default = []
 dev = ["clippy"]
+x64asm = []
 
 [build-dependencies]
 vergen = "*"

--- a/util/benches/bigint.rs
+++ b/util/benches/bigint.rs
@@ -29,9 +29,18 @@ use test::{Bencher, black_box};
 use ethcore_util::uint::*;
 
 #[bench]
-fn u256_first_degree(b: &mut test::Bencher) {
+fn u256_add(b: &mut Bencher) {
 	b.iter(|| {
 		let n = black_box(10000);
 		(0..n).fold(U256::zero(), |old, new| { old.overflowing_add(U256::from(new)).0 })
 	});
 }
+
+#[bench]
+fn u256_sub(b: &mut Bencher) {
+	b.iter(|| {
+		let n = black_box(10000);
+		(0..n).fold(U256::zero(), |old, new| { old.overflowing_add(U256::from(new)).0 })
+	});
+}
+

--- a/util/benches/bigint.rs
+++ b/util/benches/bigint.rs
@@ -37,13 +37,6 @@ fn u256_add(b: &mut Bencher) {
 	});
 }
 
-#[bench]
-fn u256_uber_add(b: &mut Bencher) {
-	b.iter(|| {
-		let n = black_box(10000);
-		(0..n).fold(U256::from(1234599u64), |old, new| { old.uber_add(U256::from(new)).0 })
-	});
-}
 
 #[bench]
 fn u256_sub(b: &mut Bencher) {

--- a/util/benches/bigint.rs
+++ b/util/benches/bigint.rs
@@ -1,0 +1,37 @@
+// Copyright 2015, 2016 Ethcore (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+//! benchmarking for rlp
+//! should be started with:
+//! ```bash
+//! multirust run nightly cargo bench
+//! ```
+
+#![feature(test)]
+
+extern crate test;
+extern crate ethcore_util;
+
+use test::{Bencher, black_box};
+use ethcore_util::uint::*;
+
+#[bench]
+fn u256_first_degree(b: &mut test::Bencher) {
+	b.iter(|| {
+		let n = black_box(10000);
+		(0..n).fold(U256::zero(), |old, new| { old.overflowing_add(U256::from(new)).0 })
+	});
+}

--- a/util/benches/bigint.rs
+++ b/util/benches/bigint.rs
@@ -33,7 +33,15 @@ use ethcore_util::uint::*;
 fn u256_add(b: &mut Bencher) {
 	b.iter(|| {
 		let n = black_box(10000);
-		(0..n).fold(U256::zero(), |old, new| { old.overflowing_add(U256::from(new)).0 })
+		(0..n).fold(U256::from(1234599u64), |old, new| { old.overflowing_add(U256::from(new)).0 })
+	});
+}
+
+#[bench]
+fn u256_uber_add(b: &mut Bencher) {
+	b.iter(|| {
+		let n = black_box(10000);
+		(0..n).fold(U256::from(1234599u64), |old, new| { old.uber_add(U256::from(new)).0 })
 	});
 }
 
@@ -41,7 +49,7 @@ fn u256_add(b: &mut Bencher) {
 fn u256_sub(b: &mut Bencher) {
 	b.iter(|| {
 		let n = black_box(10000);
-		(0..n).fold(U256::zero(), |old, new| { old.overflowing_sub(U256::from(new)).0 })
+		(0..n).fold(U256::from(::std::u64::MAX), |old, new| { old.overflowing_sub(U256::from(new)).0 })
 	});
 }
 

--- a/util/benches/bigint.rs
+++ b/util/benches/bigint.rs
@@ -21,6 +21,7 @@
 //! ```
 
 #![feature(test)]
+#![feature(asm)]
 
 extern crate test;
 extern crate ethcore_util;
@@ -40,7 +41,24 @@ fn u256_add(b: &mut Bencher) {
 fn u256_sub(b: &mut Bencher) {
 	b.iter(|| {
 		let n = black_box(10000);
-		(0..n).fold(U256::zero(), |old, new| { old.overflowing_add(U256::from(new)).0 })
+		(0..n).fold(U256::zero(), |old, new| { old.overflowing_sub(U256::from(new)).0 })
+	});
+}
+
+#[bench]
+fn u256_mul(b: &mut Bencher) {
+	b.iter(|| {
+		let n = black_box(10000);
+		(0..n).fold(U256([12345u64, 0u64, 0u64, 0u64]), |old, new| { old.overflowing_mul(U256::from(new)).0 })
+	});
+}
+
+
+#[bench]
+fn u128_mul(b: &mut Bencher) {
+	b.iter(|| {
+		let n = black_box(10000);
+		(0..n).fold(U128([12345u64, 0u64]), |old, new| { old.overflowing_mul(U128::from(new)).0 })
 	});
 }
 

--- a/util/benches/bigint.rs
+++ b/util/benches/bigint.rs
@@ -25,6 +25,7 @@
 
 extern crate test;
 extern crate ethcore_util;
+extern crate rand;
 
 use test::{Bencher, black_box};
 use ethcore_util::uint::*;
@@ -33,7 +34,7 @@ use ethcore_util::uint::*;
 fn u256_add(b: &mut Bencher) {
 	b.iter(|| {
 		let n = black_box(10000);
-		(0..n).fold(U256([12345u64, 0u64, 0u64, 0u64]), |old, new| { old.overflowing_add(U256::from(new)).0 })
+		(0..n).fold(U256([rand::random::<u64>(), rand::random::<u64>(), rand::random::<u64>(), rand::random::<u64>()]), |old, new| { old.overflowing_add(U256::from(new)).0 })
 	});
 }
 
@@ -42,7 +43,7 @@ fn u256_add(b: &mut Bencher) {
 fn u256_sub(b: &mut Bencher) {
 	b.iter(|| {
 		let n = black_box(10000);
-		(0..n).fold(U256([::std::u64::MAX, 0u64, 0u64, 0u64]), |old, new| { old.overflowing_sub(U256::from(new)).0 })
+		(0..n).fold(U256([rand::random::<u64>(), rand::random::<u64>(), rand::random::<u64>(), rand::random::<u64>()]), |old, new| { old.overflowing_sub(U256::from(new)).0 })
 	});
 }
 
@@ -50,7 +51,7 @@ fn u256_sub(b: &mut Bencher) {
 fn u256_mul(b: &mut Bencher) {
 	b.iter(|| {
 		let n = black_box(10000);
-		(0..n).fold(U256([12345u64, 0u64, 0u64, 0u64]), |old, new| { old.overflowing_mul(U256::from(new)).0 })
+		(0..n).fold(U256([rand::random::<u64>(), rand::random::<u64>(), rand::random::<u64>(), rand::random::<u64>()]), |old, new| { old.overflowing_mul(U256::from(new)).0 })
 	});
 }
 

--- a/util/benches/bigint.rs
+++ b/util/benches/bigint.rs
@@ -33,7 +33,7 @@ use ethcore_util::uint::*;
 fn u256_add(b: &mut Bencher) {
 	b.iter(|| {
 		let n = black_box(10000);
-		(0..n).fold(U256::from(1234599u64), |old, new| { old.overflowing_add(U256::from(new)).0 })
+		(0..n).fold(U256([12345u64, 0u64, 0u64, 0u64]), |old, new| { old.overflowing_add(U256::from(new)).0 })
 	});
 }
 
@@ -42,7 +42,7 @@ fn u256_add(b: &mut Bencher) {
 fn u256_sub(b: &mut Bencher) {
 	b.iter(|| {
 		let n = black_box(10000);
-		(0..n).fold(U256::from(::std::u64::MAX), |old, new| { old.overflowing_sub(U256::from(new)).0 })
+		(0..n).fold(U256([::std::u64::MAX, 0u64, 0u64, 0u64]), |old, new| { old.overflowing_sub(U256::from(new)).0 })
 	});
 }
 

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -16,6 +16,7 @@
 
 #![warn(missing_docs)]
 #![cfg_attr(feature="dev", feature(plugin))]
+#![cfg_attr(feature="dev", feature(asm))]
 #![cfg_attr(feature="dev", plugin(clippy))]
 
 // Clippy settings

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -16,7 +16,7 @@
 
 #![warn(missing_docs)]
 #![cfg_attr(feature="dev", feature(plugin))]
-#![cfg_attr(feature="dev", feature(asm))]
+#![cfg_attr(feature="x64asm", feature(asm))]
 #![cfg_attr(feature="dev", plugin(clippy))]
 
 // Clippy settings

--- a/util/src/uint.rs
+++ b/util/src/uint.rs
@@ -51,7 +51,7 @@ macro_rules! impl_map_from {
 	}
 }
 
-#[cfg(not(all(feature="x64asm", target_arch = "x86_64")))]
+#[cfg(not(all(feature="x64asm", target_arch="x86_64")))]
 macro_rules! uint_overflowing_add {
 	($name:ident, $n_words:expr, $self_expr: expr, $other: expr) => ({
 		uint_overflowing_add_reg!($name, $n_words, $self_expr, $other)
@@ -89,7 +89,7 @@ macro_rules! uint_overflowing_add_reg {
 }
 
 
-#[cfg(all(feature="x64asm", target_arch = "x86_64"))]
+#[cfg(all(feature="x64asm", target_arch="x86_64"))]
 macro_rules! uint_overflowing_add {
 	(U256, $n_words: expr, $self_expr: expr, $other: expr) => ({
 		let mut result: [u64; 4] = unsafe { mem::uninitialized() };
@@ -119,7 +119,7 @@ macro_rules! uint_overflowing_add {
 	)
 }
 
-#[cfg(not(all(feature="x64asm", target_arch = "x86_64")))]
+#[cfg(not(all(feature="x64asm", target_arch="x86_64")))]
 macro_rules! uint_overflowing_sub {
 	($name:ident, $n_words: expr, $self_expr: expr, $other: expr) => ({
 		let res = overflowing!((!$other).overflowing_add(From::from(1u64)));
@@ -128,7 +128,7 @@ macro_rules! uint_overflowing_sub {
 	})
 }
 
-#[cfg(all(feature="x64asm", target_arch = "x86_64"))]
+#[cfg(all(feature="x64asm", target_arch="x86_64"))]
 macro_rules! uint_overflowing_sub {
 	(U256, $n_words: expr, $self_expr: expr, $other: expr) => ({
 		let mut result: [u64; 4] = unsafe { mem::uninitialized() };
@@ -158,7 +158,7 @@ macro_rules! uint_overflowing_sub {
 	})
 }
 
-#[cfg(all(feature="x64asm", target_arch = "x86_64"))]
+#[cfg(all(feature="x64asm", target_arch="x86_64"))]
 macro_rules! uint_overflowing_mul {
 	(U256, $n_words: expr, $self_expr: expr, $other: expr) => ({
 		let mut result: [u64; 4] = unsafe { mem::uninitialized() };
@@ -222,7 +222,7 @@ macro_rules! uint_overflowing_mul {
 				adc $$0, %rdx
 				or %rdx, %rcx
 
-                cmpq $$0, %rcx
+				cmpq $$0, %rcx
 				jne 2f
 
 				popcnt $8, %rcx
@@ -257,7 +257,7 @@ macro_rules! uint_overflowing_mul {
 	)
 }
 
-#[cfg(not(all(feature="x64asm", target_arch = "x86_64")))]
+#[cfg(not(all(feature="x64asm", target_arch="x86_64")))]
 macro_rules! uint_overflowing_mul {
 	($name:ident, $n_words: expr, $self_expr: expr, $other: expr) => ({
 		uint_overflowing_mul_reg!($name, $n_words, $self_expr, $other)
@@ -1468,5 +1468,26 @@ mod tests {
 	fn display_uint_zero() {
 		assert_eq!(format!("{}", U256::from(0)), "0");
 	}
+
+
+    #[test]
+    fn u256_multi_adds() {
+        let (result, _) = U256([0, 0, 0, 0]).overflowing_add(U256([0, 0, 0, 0]));
+        assert_eq!(result, U256([0, 0, 0, 0]));
+
+        let (result, _) = U256([0, 0, 0, 1]).overflowing_add(U256([0, 0, 0, 1]));
+        assert_eq!(result, U256([0, 0, 0, 2]));
+
+        let (result, overflow) = U256([0, 0, 2, 1]).overflowing_add(U256([0, 0, 3, 1]));
+        assert_eq!(result, U256([0, 0, 5, 2]));
+        assert!(!overflow);
+
+        let (_, overflow) = U256([::std::u64::MAX, ::std::u64::MAX, ::std::u64::MAX, ::std::u64::MAX])
+			.overflowing_add(U256([::std::u64::MAX, ::std::u64::MAX, ::std::u64::MAX, ::std::u64::MAX]));
+        assert!(overflow);
+
+        let (_, overflow) = U256([0, 0, 0, ::std::u64::MAX]).overflowing_add(U256([0, 0, 0, ::std::u64::MAX]));
+        assert!(overflow);
+    }
 }
 

--- a/util/src/uint.rs
+++ b/util/src/uint.rs
@@ -1560,7 +1560,34 @@ mod tests {
         assert_eq!(U256([1, 0, 0, 0]), result);
 	}
 
+    #[test]
+    fn u256_multi_muls_overflow() {
+        let (_, overflow) = U256([1, 0, 0, 0]).overflowing_mul(U256([0, 0, 0, 0]));
+        assert!(!overflow);
 
+        let (_, overflow) = U256([1, 0, 0, 0]).overflowing_mul(U256([0, 0, 0, ::std::u64::MAX]));
+        assert!(!overflow);
 
+        let (_, overflow) = U256([0, 1, 0, 0]).overflowing_mul(U256([0, 0, 0, ::std::u64::MAX]));
+        assert!(!overflow);
+
+        let (_, overflow) = U256([0, 1, 0, 0]).overflowing_mul(U256([0, 1, 0, 0]));
+        assert!(!overflow);
+
+        let (_, overflow) = U256([0, 1, 0, ::std::u64::MAX]).overflowing_mul(U256([0, 1, 0, ::std::u64::MAX]));
+        assert!(overflow);
+
+        let (_, overflow) = U256([0, ::std::u64::MAX, 0, 0]).overflowing_mul(U256([0, ::std::u64::MAX, 0, 0]));
+        assert!(!overflow);
+
+        let (_, overflow) = U256([1, 0, 0, 0]).overflowing_mul(U256([10, 0, 0, 0]));
+        assert!(!overflow);
+
+        let (_, overflow) = U256([2, 0, 0, 0]).overflowing_mul(U256([0, 0, 0, ::std::u64::MAX / 2]));
+        assert!(!overflow);
+
+        let (_, overflow) = U256([0, 0, 8, 0]).overflowing_mul(U256([0, 0, 7, 0]));
+        assert!(overflow);
+    }
 }
 

--- a/util/src/uint.rs
+++ b/util/src/uint.rs
@@ -165,7 +165,7 @@ macro_rules! uint_overflowing_mul {
 		let self_t: &[u64; 4] = unsafe { &mem::transmute($self_expr) };
 		let other_t: &[u64; 4] = unsafe { &mem::transmute($other) };
 
-		let overflow: u8;
+		let overflow: u64;
 		unsafe {
 			asm!("
 				mov $5, %rax
@@ -222,25 +222,25 @@ macro_rules! uint_overflowing_mul {
 				adc $$0, %rdx
 				or %rdx, %rcx
 
-				cmpq $$0, %rcx
+                cmpq $$0, %rcx
 				jne 2f
 
 				mov $8, %rax
 				cmpq $$0, %rax
-				sete %cl
+				setne %cl
 
 				mov $7, %rax
 				cmpq $$0, %rax
-				sete %dl
+				setne %dl
 				or %dl, %cl
 
 				mov $3, %rax
 				cmpq $$0, %rax
-				sete %dl
+				setne %dl
 
 				mov $2, %rax
 				cmpq $$0, %rax
-			    sete %bl
+			    setne %bl
 			    or %bl, %dl
 
 			    and %dl, %cl
@@ -253,7 +253,7 @@ macro_rules! uint_overflowing_mul {
 				: /* $5 */ "m"(self_t[0]), /* $6 */ "m"(self_t[1]), /* $7 */  "m"(self_t[2]),
 				  /* $8 */ "m"(self_t[3]), /* $9 */ "m"(other_t[0]), /* $10 */ "m"(other_t[1]),
 				  /* $11 */ "m"(other_t[2]), /* $12 */ "m"(other_t[3])
-				: "rax", "rdx"
+           		: "rax", "rdx", "rbx"
 				:
 
 			);
@@ -740,23 +740,8 @@ macro_rules! construct_uint {
 			type Output = $name;
 
 			fn add(self, other: $name) -> $name {
-				let $name(ref me) = self;
-				let $name(ref you) = other;
-				let mut ret = [0u64; $n_words];
-				let mut carry = [0u64; $n_words];
-				let mut b_carry = false;
-				for i in 0..$n_words {
-					if i < $n_words - 1 {
-						ret[i] = me[i].wrapping_add(you[i]);
-						if ret[i] < me[i] {
-							carry[i + 1] = 1;
-							b_carry = true;
-						}
-					} else {
-						ret[i] = me[i] + you[i];
-					}
-				}
-				if b_carry { $name(ret) + $name(carry) } else { $name(ret) }
+				let (result, _) = self.overflowing_add(other);
+				result
 			}
 		}
 
@@ -765,8 +750,7 @@ macro_rules! construct_uint {
 
 			#[inline]
 			fn sub(self, other: $name) -> $name {
-				let (result, overflow) = self.overflowing_sub(other);
-				panic_on_overflow!(overflow);
+				let (result, _) = self.overflowing_sub(other);
 				result
 			}
 		}
@@ -775,15 +759,9 @@ macro_rules! construct_uint {
 			type Output = $name;
 
 			fn mul(self, other: $name) -> $name {
-				let mut res = $name::from(0u64);
-				// TODO: be more efficient about this
-				for i in 0..(2 * $n_words) {
-					let v = self.mul_u32((other >> (32 * i)).low_u32());
-					let (r, overflow) = v.overflowing_shl(32 * i as u32);
-					panic_on_overflow!(overflow);
-					res = res + r;
-				}
-				res
+				let (result, overflow) = self.overflowing_mul(other);
+				panic_on_overflow!(overflow);
+				result
 			}
 		}
 

--- a/util/src/uint.rs
+++ b/util/src/uint.rs
@@ -91,13 +91,13 @@ macro_rules! overflowing_add_u256_asm {
 		unsafe {
 			asm!("
 				xor %al, %al
-				adc $9, %r8
-				adc $10, %r9
-				adc $11, %r10
-				adc $12, %r11
-				adc $$0, %al"
-				: "={r8}"(result[0]), "={r9}"(result[1]), "={r10}"(result[2]), "={r11}"(result[3]), "={al}"(overflow)
-				: "{r8}"(self_t[0]), "{r9}"(self_t[1]), "{r10}"(self_t[2]), "{r11}"(self_t[3]), "m"(other_t[0]), "m"(other_t[1]), "m"(other_t[2]), "m"(other_t[3])
+                adc $9, $0
+                adc $10, $1
+                adc $11, $2
+                adc $12, $3
+                adc $$0, %al"
+             	: "=r"(result[0]), "=r"(result[1]), "=r"(result[2]), "=r"(result[3]), "={al}"(overflow)
+				: "0"(self_t[0]), "1"(self_t[1]), "2"(self_t[2]), "3"(self_t[3]), "mr"(other_t[0]), "mr"(other_t[1]), "mr"(other_t[2]), "mr"(other_t[3])
 				:
 				:
 			);

--- a/util/src/uint.rs
+++ b/util/src/uint.rs
@@ -765,9 +765,9 @@ macro_rules! construct_uint {
 
 			#[inline]
 			fn sub(self, other: $name) -> $name {
-				panic_on_overflow!(self < other);
-				let res = overflowing!((!other).overflowing_add(From::from(1u64)));
-				overflowing!(self.overflowing_add(res))
+				let (result, overflow) = self.overflowing_sub(other);
+				panic_on_overflow!(overflow);
+				result
 			}
 		}
 

--- a/util/src/uint.rs
+++ b/util/src/uint.rs
@@ -1489,5 +1489,32 @@ mod tests {
         let (_, overflow) = U256([0, 0, 0, ::std::u64::MAX]).overflowing_add(U256([0, 0, 0, ::std::u64::MAX]));
         assert!(overflow);
     }
+
+
+    #[test]
+    fn u256_multi_subs() {
+        let (result, _) = U256([0, 0, 0, 0]).overflowing_sub(U256([0, 0, 0, 0]));
+        assert_eq!(result, U256([0, 0, 0, 0]));
+
+        let (result, _) = U256([0, 0, 0, 1]).overflowing_sub(U256([0, 0, 0, 1]));
+        assert_eq!(result, U256([0, 0, 0, 0]));
+
+        let (_, overflow) = U256([0, 0, 2, 1]).overflowing_sub(U256([0, 0, 3, 1]));
+        assert!(overflow);
+
+        let (result, overflow) = U256([::std::u64::MAX, ::std::u64::MAX, ::std::u64::MAX, ::std::u64::MAX])
+                                .overflowing_sub(U256([::std::u64::MAX/2, ::std::u64::MAX/2, ::std::u64::MAX/2, ::std::u64::MAX/2]));
+        assert!(!overflow);
+        assert_eq!(U256([::std::u64::MAX/2+1, ::std::u64::MAX/2+1, ::std::u64::MAX/2+1, ::std::u64::MAX/2+1]), result);
+
+        let (result, overflow) = U256([0, 0, 0, 1]).overflowing_sub(U256([0, 0, 1, 0]));
+        assert!(!overflow);
+        assert_eq!(U256([0, 0, ::std::u64::MAX, 0]), result);
+
+        let (result, overflow) = U256([0, 0, 0, 1]).overflowing_sub(U256([1, 0, 0, 0]));
+        assert!(!overflow);
+        assert_eq!(U256([::std::u64::MAX, ::std::u64::MAX, ::std::u64::MAX, 0]), result);
+    }
+
 }
 

--- a/util/src/uint.rs
+++ b/util/src/uint.rs
@@ -225,25 +225,17 @@ macro_rules! uint_overflowing_mul {
                 cmpq $$0, %rcx
 				jne 2f
 
-				mov $8, %rax
-				cmpq $$0, %rax
-				setne %cl
+				popcnt $8, %rcx
+				popcnt $7, %rax
+				add %rax, %rcx
+				jrcxz 2f
 
-				mov $7, %rax
-				cmpq $$0, %rax
-				setne %dl
-				or %dl, %cl
+				popcnt $12, %rcx
+				popcnt $11, %rax
+				add %rax, %rcx
+				jrcxz 2f
 
-				mov $3, %rax
-				cmpq $$0, %rax
-				setne %dl
-
-				mov $2, %rax
-				cmpq $$0, %rax
-			    setne %bl
-			    or %bl, %dl
-
-			    and %dl, %cl
+				mov $$1, %rcx
 
 			    2:
 			    "
@@ -740,7 +732,8 @@ macro_rules! construct_uint {
 			type Output = $name;
 
 			fn add(self, other: $name) -> $name {
-				let (result, _) = self.overflowing_add(other);
+				let (result, overflow) = self.overflowing_add(other);
+				panic_on_overflow!(overflow);
 				result
 			}
 		}
@@ -750,7 +743,8 @@ macro_rules! construct_uint {
 
 			#[inline]
 			fn sub(self, other: $name) -> $name {
-				let (result, _) = self.overflowing_sub(other);
+				let (result, overflow) = self.overflowing_sub(other);
+				panic_on_overflow!(overflow);
 				result
 			}
 		}

--- a/util/src/uint.rs
+++ b/util/src/uint.rs
@@ -222,8 +222,7 @@ macro_rules! uint_overflowing_mul {
 				adc $$0, %rdx
 				or %rdx, %rcx
 
-				cmpq $$0, %rcx
-				jne 2f
+				jrcxz 2f
 
 				mov $8, %rax
 				cmpq $$0, %rax
@@ -233,6 +232,8 @@ macro_rules! uint_overflowing_mul {
 				cmpq $$0, %rax
 				sete %dl
 				or %dl, %cl
+
+				jrcxz 2f
 
 				mov $3, %rax
 				cmpq $$0, %rax

--- a/util/src/uint.rs
+++ b/util/src/uint.rs
@@ -588,6 +588,7 @@ macro_rules! construct_uint {
 		}
 
 		impl $name {
+			#[allow(dead_code)] // not used when multiplied with inline assembly
 			/// Multiplication by u32
 			fn mul_u32(self, other: u32) -> Self {
 				let $name(ref arr) = self;
@@ -609,6 +610,7 @@ macro_rules! construct_uint {
 				$name(ret) + $name(carry)
 			}
 
+			#[allow(dead_code)] // not used when multiplied with inline assembly
 			/// Overflowing multiplication by u32
 			fn overflowing_mul_u32(self, other: u32) -> (Self, bool) {
 				let $name(ref arr) = self;

--- a/util/src/uint.rs
+++ b/util/src/uint.rs
@@ -168,7 +168,6 @@ macro_rules! uint_overflowing_mul {
 		let overflow: u8;
 		unsafe {
 			asm!("
-                clc
 				mov $5, %rax
 				mulq $9
 				mov %rax, $0
@@ -176,77 +175,59 @@ macro_rules! uint_overflowing_mul {
 
 				mov $6, %rax
 				mulq $9
-				clc
-				adc %rax, $1
+				add %rax, $1
 				mov %rdx, $2
 
 				mov $5, %rax
-				pushf
 				mulq $10
-				popf
-				adc %rax, $1
+				add %rax, $1
 				adc %rdx, $2
 
 				mov $6, %rax
 				mulq $10
-				clc
-				adc %rax, $2
+				add %rax, $2
 				mov %rdx, $3
 
 				mov $7, %rax
 				mulq $9
-				clc
-				adc %rax, $2
+				add %rax, $2
 				adc %rdx, $3
 
 				mov $5, %rax
 				mulq $11
-				clc
-    			adc %rax, $2
+    			add %rax, $2
 				adc %rdx, $3
 
 				mov $8, %rax
-				pushf
 				mulq $9
-				popf
 				adc %rax, $3
 				adc $$0, %rdx
 				mov %rdx, %rcx
-				clc
 
 				mov $7, %rax
-				pushf
 				mulq $10
-				popf
-				adc %rax, $3
+				add %rax, $3
 				adc $$0, %rdx
 				or %rdx, %rcx
-				clc
 
 				mov $6, %rax
-				pushf
 				mulq $11
-				popf
-				adc %rax, $3
+				add %rax, $3
 				adc $$0, %rdx
 				or %rdx, %rcx
-				clc
 
 				mov $5, %rax
-				pushf
 				mulq $12
-				popf
-				adc %rax, $3
+				add %rax, $3
 				adc $$0, %rdx
 				or %rdx, %rcx
-				clc
 
 				cmpq $$0, %rcx
 				jne 2f
 
 				mov $8, %rax
 				cmpq $$0, %rax
-				setz %cl
+				sete %cl
 
 				mov $7, %rax
 				cmpq $$0, %rax
@@ -264,7 +245,8 @@ macro_rules! uint_overflowing_mul {
 
 			    and %dl, %cl
 
-			    2:              "
+			    2:
+			    "
 				: /* $0 */ "={r8}"(result[0]), /* $1 */ "={r9}"(result[1]), /* $2 */ "={r10}"(result[2]),
 				  /* $3 */ "={r11}"(result[3]), /* $4 */  "={rcx}"(overflow)
 

--- a/util/src/uint.rs
+++ b/util/src/uint.rs
@@ -226,16 +226,30 @@ macro_rules! uint_overflowing_mul {
 				jne 2f
 
 				popcnt $8, %rcx
-				popcnt $7, %rax
-				add %rax, %rcx
-				jrcxz 2f
+				jrcxz 12f
 
 				popcnt $12, %rcx
 				popcnt $11, %rax
 				add %rax, %rcx
-				jrcxz 2f
+				popcnt $10, %rax
+				add %rax, %rcx
+				jmp 2f
 
-				mov $$1, %rcx
+				12:
+				popcnt $12, %rcx
+				jrcxz 11f
+
+				popcnt $7, %rcx
+				popcnt $6, %rax
+				add %rax, %rcx
+
+				cmpq $$0, %rcx
+				jne 2f
+
+				11:
+				popcnt $11, %rcx
+				jrcxz 2f
+				popcnt $7, %rcx
 
 			    2:
 			    "
@@ -1569,7 +1583,7 @@ mod tests {
         assert!(!overflow);
 
         let (_, overflow) = U256([0, 1, 0, 0]).overflowing_mul(U256([0, 0, 0, ::std::u64::MAX]));
-        assert!(!overflow);
+        assert!(overflow);
 
         let (_, overflow) = U256([0, 1, 0, 0]).overflowing_mul(U256([0, 1, 0, 0]));
         assert!(!overflow);

--- a/util/src/uint.rs
+++ b/util/src/uint.rs
@@ -222,7 +222,8 @@ macro_rules! uint_overflowing_mul {
 				adc $$0, %rdx
 				or %rdx, %rcx
 
-				jrcxz 2f
+				cmpq $$0, %rcx
+				jne 2f
 
 				mov $8, %rax
 				cmpq $$0, %rax
@@ -232,8 +233,6 @@ macro_rules! uint_overflowing_mul {
 				cmpq $$0, %rax
 				sete %dl
 				or %dl, %cl
-
-				jrcxz 2f
 
 				mov $3, %rax
 				cmpq $$0, %rax

--- a/util/src/uint.rs
+++ b/util/src/uint.rs
@@ -1516,5 +1516,51 @@ mod tests {
         assert_eq!(U256([::std::u64::MAX, ::std::u64::MAX, ::std::u64::MAX, 0]), result);
     }
 
+
+	#[test]
+	fn u256_multi_muls() {
+        let (result, _) = U256([0, 0, 0, 0]).overflowing_mul(U256([0, 0, 0, 0]));
+        assert_eq!(U256([0, 0, 0, 0]), result);
+
+        let (result, _) = U256([1, 0, 0, 0]).overflowing_mul(U256([1, 0, 0, 0]));
+        assert_eq!(U256([1, 0, 0, 0]), result);
+
+        let (result, _) = U256([5, 0, 0, 0]).overflowing_mul(U256([5, 0, 0, 0]));
+        assert_eq!(U256([25, 0, 0, 0]), result);
+
+        let (result, _) = U256([0, 5, 0, 0]).overflowing_mul(U256([0, 5, 0, 0]));
+        assert_eq!(U256([0, 0, 25, 0]), result);
+
+        let (result, _) = U256([0, 0, 0, 1]).overflowing_mul(U256([1, 0, 0, 0]));
+        assert_eq!(U256([0, 0, 0, 1]), result);
+
+        let (result, _) = U256([0, 0, 0, 5]).overflowing_mul(U256([2, 0, 0, 0]));
+        assert_eq!(U256([0, 0, 0, 10]), result);
+
+        let (result, _) = U256([0, 0, 1, 0]).overflowing_mul(U256([0, 5, 0, 0]));
+        assert_eq!(U256([0, 0, 0, 5]), result);
+
+        let (result, _) = U256([0, 0, 8, 0]).overflowing_mul(U256([0, 0, 7, 0]));
+        assert_eq!(U256([0, 0, 0, 0]), result);
+
+        let (result, _) = U256([2, 0, 0, 0]).overflowing_mul(U256([0, 5, 0, 0]));
+        assert_eq!(U256([0, 10, 0, 0]), result);
+
+        let (result, _) = U256([::std::u64::MAX, 0, 0, 0]).overflowing_mul(U256([::std::u64::MAX, 0, 0, 0]));
+        assert_eq!(U256([1, ::std::u64::MAX-1, 0, 0]), result);
+
+        let (result, _) = U256([0, 0, 0, ::std::u64::MAX]).overflowing_mul(U256([0, 0, 0, ::std::u64::MAX]));
+        assert_eq!(U256([0, 0, 0, 0]), result);
+
+        let (result, _) = U256([1, 0, 0, 0]).overflowing_mul(U256([0, 0, 0, ::std::u64::MAX]));
+        assert_eq!(U256([0, 0, 0, ::std::u64::MAX]), result);
+
+        let (result, _) = U256([::std::u64::MAX, ::std::u64::MAX, ::std::u64::MAX, ::std::u64::MAX])
+			.overflowing_mul(U256([::std::u64::MAX, ::std::u64::MAX, ::std::u64::MAX, ::std::u64::MAX]));
+        assert_eq!(U256([1, 0, 0, 0]), result);
+	}
+
+
+
 }
 

--- a/util/src/uint.rs
+++ b/util/src/uint.rs
@@ -51,7 +51,7 @@ macro_rules! impl_map_from {
 	}
 }
 
-#[cfg(not(all(feature="dev", target_arch = "x86_64")))]
+#[cfg(not(all(feature="x64asm", target_arch = "x86_64")))]
 macro_rules! uint_overflowing_add {
 	($name:ident, $n_words:expr, $self_expr: expr, $other: expr) => ({
 		uint_overflowing_add_reg!($name, $n_words, $self_expr, $other)
@@ -89,7 +89,7 @@ macro_rules! uint_overflowing_add_reg {
 }
 
 
-#[cfg(all(feature="dev", target_arch = "x86_64"))]
+#[cfg(all(feature="x64asm", target_arch = "x86_64"))]
 macro_rules! uint_overflowing_add {
 	(U256, $n_words: expr, $self_expr: expr, $other: expr) => ({
 		let mut result: [u64; 4] = unsafe { mem::uninitialized() };
@@ -119,7 +119,7 @@ macro_rules! uint_overflowing_add {
 	)
 }
 
-#[cfg(not(all(feature="dev", target_arch = "x86_64")))]
+#[cfg(not(all(feature="x64asm", target_arch = "x86_64")))]
 macro_rules! uint_overflowing_sub {
 	($name:ident, $n_words: expr, $self_expr: expr, $other: expr) => ({
 		let res = overflowing!((!$other).overflowing_add(From::from(1u64)));
@@ -128,7 +128,7 @@ macro_rules! uint_overflowing_sub {
 	})
 }
 
-#[cfg(all(feature="dev", target_arch = "x86_64"))]
+#[cfg(all(feature="x64asm", target_arch = "x86_64"))]
 macro_rules! uint_overflowing_sub {
 	(U256, $n_words: expr, $self_expr: expr, $other: expr) => ({
 		let mut result: [u64; 4] = unsafe { mem::uninitialized() };
@@ -158,7 +158,7 @@ macro_rules! uint_overflowing_sub {
 	})
 }
 
-#[cfg(all(feature="dev", target_arch = "x86_64"))]
+#[cfg(all(feature="x64asm", target_arch = "x86_64"))]
 macro_rules! uint_overflowing_mul {
 	(U256, $n_words: expr, $self_expr: expr, $other: expr) => ({
 		let mut result: [u64; 4] = unsafe { mem::uninitialized() };
@@ -283,7 +283,7 @@ macro_rules! uint_overflowing_mul {
 	)
 }
 
-#[cfg(not(all(feature="dev", target_arch = "x86_64")))]
+#[cfg(not(all(feature="x64asm", target_arch = "x86_64")))]
 macro_rules! uint_overflowing_mul {
 	($name:ident, $n_words: expr, $self_expr: expr, $other: expr) => ({
 		uint_overflowing_mul_reg!($name, $n_words, $self_expr, $other)

--- a/util/src/uint.rs
+++ b/util/src/uint.rs
@@ -97,17 +97,19 @@ macro_rules! uint_overflowing_add {
 		let other_t: &[u64; 4] = unsafe { &mem::transmute($other) };
 
 		let overflow: u8;
-		unsafe {
-			asm!("
-                adc $9, $0
-                adc $10, $1
-                adc $11, $2
-                adc $12, $3
-                setc %al"
-             	: "=r"(result[0]), "=r"(result[1]), "=r"(result[2]), "=r"(result[3]), "={al}"(overflow)
-				: "0"(self_t[0]), "1"(self_t[1]), "2"(self_t[2]), "3"(self_t[3]), "mr"(other_t[0]), "mr"(other_t[1]), "mr"(other_t[2]), "mr"(other_t[3])
-				:
-				:
+        unsafe {
+            asm!("
+                adc $9, %r8
+                adc $10, %r9
+                adc $11, %r10
+                adc $12, %r11
+                setc %al
+                "
+            : "={r8}"(result[0]), "={r9}"(result[1]), "={r10}"(result[2]), "={r11}"(result[3]), "={al}"(overflow)
+            : "{r8}"(self_t[0]), "{r9}"(self_t[1]), "{r10}"(self_t[2]), "{r11}"(self_t[3]),
+			  "m"(other_t[0]), "m"(other_t[1]), "m"(other_t[2]), "m"(other_t[3])
+            :
+            :
 			);
 		}
 		(U256(result), overflow != 0)
@@ -522,14 +524,17 @@ macro_rules! construct_uint {
 			}
 
 			/// Optimized instructions
+			#[inline(always)]
 			fn overflowing_add(self, other: $name) -> ($name, bool) {
 				uint_overflowing_add!($name, $n_words, self, other)
 			}
 
+			#[inline(always)]
 			fn overflowing_sub(self, other: $name) -> ($name, bool) {
 				uint_overflowing_sub!($name, $n_words, self, other)
 			}
 
+			#[inline(always)]
 			fn overflowing_mul(self, other: $name) -> ($name, bool) {
 				uint_overflowing_mul!($name, $n_words, self, other)
 			}


### PR DESCRIPTION
before
```
test u256_add ... bench:     139,774 ns/iter (+/- 8,128)
test u256_mul ... bench:   4,915,555 ns/iter (+/- 436,083)
test u256_sub ... bench:     757,326 ns/iter (+/- 47,169)

```

after
```
test u256_add ... bench:      36,160 ns/iter (+/- 2,217)
test u256_mul ... bench:     104,526 ns/iter (+/- 3,128)
test u256_sub ... bench:      35,494 ns/iter (+/- 1,163)
```