### PR TITLE
Fixed a race condition when connecting peer disconnects immediately

### DIFF
--- a/util/src/network/host.rs
+++ b/util/src/network/host.rs
@@ -579,7 +579,7 @@ impl<Message> Host<Message> where Message: Send + Sync + Clone {
 			}
 		}
 		if kill {
-			self.kill_connection(token, io, true); //TODO: mark connection as dead an check in kill_connection
+			self.kill_connection(token, io, true);
 			return;
 		} else if create_session {
 			self.start_session(token, io);
@@ -621,7 +621,7 @@ impl<Message> Host<Message> where Message: Send + Sync + Clone {
 			}
 		}
 		if kill {
-			self.kill_connection(token, io, true); //TODO: mark connection as dead an check in kill_connection
+			self.kill_connection(token, io, true);
 		}
 		for p in ready_data {
 			let h = self.handlers.read().unwrap().get(p).unwrap().clone();
@@ -685,6 +685,7 @@ impl<Message> Host<Message> where Message: Send + Sync + Clone {
 	fn kill_connection(&self, token: StreamToken, io: &IoContext<NetworkIoMessage<Message>>, remote: bool) {
 		let mut to_disconnect: Vec<ProtocolId> = Vec::new();
 		let mut failure_id = None;
+		let mut deregister = false;
 		match token {
 			FIRST_HANDSHAKE ... LAST_HANDSHAKE => {
 				let handshakes = self.handshakes.write().unwrap();
@@ -693,7 +694,7 @@ impl<Message> Host<Message> where Message: Send + Sync + Clone {
 					if !handshake.expired() {
 						handshake.set_expired();
 						failure_id = Some(handshake.id().clone());
-						io.deregister_stream(token).expect("Error deregistering stream");
+						deregister = true;
 					}
 				}
 			},
@@ -711,7 +712,7 @@ impl<Message> Host<Message> where Message: Send + Sync + Clone {
 						}
 						s.set_expired();
 						failure_id = Some(s.id().clone());
-						io.deregister_stream(token).expect("Error deregistering stream");
+						deregister = true;
 					}
 				}
 			},
@@ -725,6 +726,9 @@ impl<Message> Host<Message> where Message: Send + Sync + Clone {
 		for p in to_disconnect {
 			let h = self.handlers.read().unwrap().get(p).unwrap().clone();
 			h.disconnected(&NetworkContext::new(io, p, Some(token), self.sessions.clone()), &token);
+		}
+		if deregister {
+			io.deregister_stream(token).expect("Error deregistering stream");
 		}
 	}
 


### PR DESCRIPTION
Handler must be notified of disconnect before removing a session from the list. Otherwise it may end up sending something to an expired id.
Also removed some TODOs which are already done.
Fixes #487 