### PR TITLE
Blockchain module cleanup

### DIFF
--- a/ethcore/src/blockchain/best_block.rs
+++ b/ethcore/src/blockchain/best_block.rs
@@ -1,23 +1,30 @@
+// Copyright 2015, 2016 Ethcore (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
 use util::hash::H256;
 use util::uint::U256;
 use header::BlockNumber;
 
-/// Information about best block gathered together
+/// Best block info.
 #[derive(Default)]
 pub struct BestBlock {
+	/// Best block hash.
 	pub hash: H256,
+	/// Best block number.
 	pub number: BlockNumber,
+	/// Best block total difficulty.
 	pub total_difficulty: U256
 }
-
-impl BestBlock {
-	pub fn new() -> BestBlock { Default::default() }
-}
-		
-		//BestBlock {
-			//hash: H256::new(),
-			//number: 0,
-			//total_difficulty: U256::from(0)
-		//}
-	//}
-//}

--- a/ethcore/src/blockchain/best_block.rs
+++ b/ethcore/src/blockchain/best_block.rs
@@ -1,0 +1,23 @@
+use util::hash::H256;
+use util::uint::U256;
+use header::BlockNumber;
+
+/// Information about best block gathered together
+#[derive(Default)]
+pub struct BestBlock {
+	pub hash: H256,
+	pub number: BlockNumber,
+	pub total_difficulty: U256
+}
+
+impl BestBlock {
+	pub fn new() -> BestBlock { Default::default() }
+}
+		
+		//BestBlock {
+			//hash: H256::new(),
+			//number: 0,
+			//total_difficulty: U256::from(0)
+		//}
+	//}
+//}

--- a/ethcore/src/blockchain/block_info.rs
+++ b/ethcore/src/blockchain/block_info.rs
@@ -1,0 +1,19 @@
+use util::hash::H256;
+use util::uint::U256;
+use header::BlockNumber;
+
+pub struct BlockInfo {
+	pub hash: H256,
+	pub number: BlockNumber,
+	pub total_difficulty: U256,
+	pub location: BlockLocation
+}
+
+pub enum BlockLocation {
+	CanonChain,
+	Branch,
+	BranchBecomingCanonChain {
+		ancestor: H256,
+		route: Vec<H256>
+	}
+}

--- a/ethcore/src/blockchain/block_info.rs
+++ b/ethcore/src/blockchain/block_info.rs
@@ -1,19 +1,48 @@
+// Copyright 2015, 2016 Ethcore (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
 use util::hash::H256;
 use util::uint::U256;
 use header::BlockNumber;
 
+/// Brief info about inserted block.
 pub struct BlockInfo {
+	/// Block hash.
 	pub hash: H256,
+	/// Block number.
 	pub number: BlockNumber,
+	/// Total block difficulty.
 	pub total_difficulty: U256,
+	/// Block location in blockchain.
 	pub location: BlockLocation
 }
 
+/// Describes location of newly inserted block.
 pub enum BlockLocation {
+	/// It's part of the canon chain.
 	CanonChain,
+	/// It's not a part of the canon chain.
 	Branch,
+	/// It's part of the fork which should become canon chain,
+	/// because it's total difficulty is higher than current
+	/// canon chain difficulty.
 	BranchBecomingCanonChain {
+		/// Hash of the newest common ancestor with old canon chain.
 		ancestor: H256,
+		/// Hashes of the blocks between ancestor and this block.
 		route: Vec<H256>
 	}
 }

--- a/ethcore/src/blockchain/blockchain.rs
+++ b/ethcore/src/blockchain/blockchain.rs
@@ -488,25 +488,24 @@ impl BlockChain {
 			hash: hash,
 			number: number,
 			total_difficulty: total_difficulty,
-			location: match is_new_best {
-				false => BlockLocation::Branch,
-				true => {
-					// on new best block we need to make sure that all ancestors
-					// are moved to "canon chain"
-					// find the route between old best block and the new one
-					let best_hash = self.best_block_hash();
-					let route = self.tree_route(best_hash, parent_hash);
+			location: if is_new_best {
+				// on new best block we need to make sure that all ancestors
+				// are moved to "canon chain"
+				// find the route between old best block and the new one
+				let best_hash = self.best_block_hash();
+				let route = self.tree_route(best_hash, parent_hash);
 
-					assert_eq!(number, parent_details.number + 1);
+				assert_eq!(number, parent_details.number + 1);
 
-					match route.blocks.len() {
-						0 => BlockLocation::CanonChain,
-						_ => BlockLocation::BranchBecomingCanonChain {
-							ancestor: route.ancestor,
-							route: route.blocks.into_iter().skip(route.index).collect()
-						}
+				match route.blocks.len() {
+					0 => BlockLocation::CanonChain,
+					_ => BlockLocation::BranchBecomingCanonChain {
+						ancestor: route.ancestor,
+						route: route.blocks.into_iter().skip(route.index).collect()
 					}
 				}
+			} else {
+				BlockLocation::Branch
 			}
 		}
 	}

--- a/ethcore/src/blockchain/blockchain.rs
+++ b/ethcore/src/blockchain/blockchain.rs
@@ -588,7 +588,20 @@ impl BlockChain {
 
 	/// This functions returns modified blocks blooms.
 	///
-	/// TODO: this function needs comprehensive description.
+	/// To accelerate blooms lookups, blomms are stored in multiple 
+	/// layers (BLOOM_LEVELS, currently 3). 
+	/// ChainFilter is responsible for building and rebuilding these layers.
+	/// It returns them in HashMap, where values are Blooms and
+	/// keys are BloomIndexes. BloomIndex represents bloom location on one
+	/// of these layers.
+	/// 
+	/// To reduce number of queries to databse, block blooms are stored
+	/// in BlocksBlooms structure which contains info about several 
+	/// (BLOOM_INDEX_SIZE, currently 16) consecutive blocks blooms.
+	/// 
+	/// Later, BloomIndexer is used to map bloom location on filter layer (BloomIndex)
+	/// to bloom location in database (BlocksBloomLocation).
+	/// 
 	fn prepare_block_blooms_update(&self, block_bytes: &[u8], info: &BlockInfo) -> HashMap<H256, BlocksBlooms> {
 		let block = BlockView::new(block_bytes);
 		let header = block.header_view();

--- a/ethcore/src/blockchain/bloom_indexer.rs
+++ b/ethcore/src/blockchain/bloom_indexer.rs
@@ -1,0 +1,43 @@
+use util::hash::H256;
+use chainfilter::BloomIndex;
+use extras::BlocksBloomLocation;
+
+pub struct BloomIndexer {
+	index_size: usize,
+	levels: u8,
+}
+
+impl BloomIndexer {
+	pub fn new(index_size: usize, levels: u8) -> Self {
+		BloomIndexer {
+			index_size: index_size,
+			levels: levels
+		}
+	}
+
+	/// Calculates bloom's position in database.
+	pub fn location(&self, bloom_index: &BloomIndex) -> BlocksBloomLocation {
+		use std::{mem, ptr};
+		
+		let hash = unsafe {
+			let mut hash: H256 = mem::zeroed();
+			ptr::copy(&[bloom_index.index / self.index_size] as *const usize as *const u8, hash.as_mut_ptr(), 8);
+			hash[8] = bloom_index.level;
+			hash.reverse();
+			hash
+		};
+
+		BlocksBloomLocation {
+			hash: hash,
+			index: bloom_index.index % self.index_size
+		}
+	}
+
+	pub fn index_size(&self) -> usize {
+		self.index_size
+	}
+
+	pub fn levels(&self) -> u8 {
+		self.levels
+	}
+}

--- a/ethcore/src/blockchain/bloom_indexer.rs
+++ b/ethcore/src/blockchain/bloom_indexer.rs
@@ -1,13 +1,39 @@
+// Copyright 2015, 2016 Ethcore (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
 use util::hash::H256;
 use chainfilter::BloomIndex;
-use extras::BlocksBloomLocation;
 
+/// Represents location of block bloom in extras database.
+#[derive(Debug, PartialEq)]
+pub struct BlocksBloomLocation {
+	/// Unique hash of BlocksBloom
+	pub hash: H256,
+	/// Index within BlocksBloom
+	pub index: usize,
+}
+
+/// Should be used to localize blocks blooms in extras database.
 pub struct BloomIndexer {
 	index_size: usize,
 	levels: u8,
 }
 
 impl BloomIndexer {
+	/// Plain constructor.
 	pub fn new(index_size: usize, levels: u8) -> Self {
 		BloomIndexer {
 			index_size: index_size,
@@ -33,11 +59,44 @@ impl BloomIndexer {
 		}
 	}
 
+	/// Returns index size.
 	pub fn index_size(&self) -> usize {
 		self.index_size
 	}
 
+	/// Returns number of cache levels.
 	pub fn levels(&self) -> u8 {
 		self.levels
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use std::str::FromStr;
+	use util::hash::{H256, FixedHash};
+	use chainfilter::BloomIndex;
+	use blockchain::bloom_indexer::{BloomIndexer, BlocksBloomLocation};
+
+	#[test]
+	fn test_bloom_indexer() {
+		let bi = BloomIndexer::new(16, 3);
+
+		let index = BloomIndex::new(0, 0);
+		assert_eq!(bi.location(&index), BlocksBloomLocation {
+			hash: H256::new(),
+			index: 0
+		});
+
+		let index = BloomIndex::new(1, 0);
+		assert_eq!(bi.location(&index), BlocksBloomLocation {
+			hash: H256::from_str("0000000000000000000000000000000000000000000000010000000000000000").unwrap(),
+			index: 0
+		});
+
+		let index = BloomIndex::new(0, 299_999);
+		assert_eq!(bi.location(&index), BlocksBloomLocation {
+			hash: H256::from_str("000000000000000000000000000000000000000000000000000000000000493d").unwrap(),
+			index: 15
+		});
 	}
 }

--- a/ethcore/src/blockchain/cache.rs
+++ b/ethcore/src/blockchain/cache.rs
@@ -1,0 +1,23 @@
+
+
+/// Represents blockchain's in-memory cache size in bytes.
+#[derive(Debug)]
+pub struct CacheSize {
+	/// Blocks cache size.
+	pub blocks: usize,
+	/// BlockDetails cache size.
+	pub block_details: usize,
+	/// Transaction addresses cache size.
+	pub transaction_addresses: usize,
+	/// Logs cache size.
+	pub block_logs: usize,
+	/// Blooms cache size.
+	pub blocks_blooms: usize,
+	/// Block receipts size.
+	pub block_receipts: usize,
+}
+
+impl CacheSize {
+	/// Total amount used by the cache.
+	pub fn total(&self) -> usize { self.blocks + self.block_details + self.transaction_addresses + self.block_logs + self.blocks_blooms }
+}

--- a/ethcore/src/blockchain/cache.rs
+++ b/ethcore/src/blockchain/cache.rs
@@ -1,4 +1,18 @@
+// Copyright 2015, 2016 Ethcore (UK) Ltd.
+// This file is part of Parity.
 
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 /// Represents blockchain's in-memory cache size in bytes.
 #[derive(Debug)]

--- a/ethcore/src/blockchain/mod.rs
+++ b/ethcore/src/blockchain/mod.rs
@@ -1,0 +1,10 @@
+pub mod blockchain;
+mod best_block;
+mod block_info;
+mod bloom_indexer;
+mod cache;
+mod tree_route;
+
+pub use self::blockchain::{BlockProvider, BlockChain};
+pub use self::cache::CacheSize;
+pub use self::tree_route::TreeRoute;

--- a/ethcore/src/blockchain/mod.rs
+++ b/ethcore/src/blockchain/mod.rs
@@ -1,9 +1,28 @@
+// Copyright 2015, 2016 Ethcore (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Blockchain database.
+
 pub mod blockchain;
 mod best_block;
 mod block_info;
 mod bloom_indexer;
 mod cache;
 mod tree_route;
+mod update;
 
 pub use self::blockchain::{BlockProvider, BlockChain};
 pub use self::cache::CacheSize;

--- a/ethcore/src/blockchain/tree_route.rs
+++ b/ethcore/src/blockchain/tree_route.rs
@@ -1,0 +1,13 @@
+use util::hash::H256;
+
+/// Represents a tree route between `from` block and `to` block:
+#[derive(Debug)]
+pub struct TreeRoute {
+	/// A vector of hashes of all blocks, ordered from `from` to `to`.
+	pub blocks: Vec<H256>,
+	/// Best common ancestor of these blocks.
+	pub ancestor: H256,
+	/// An index where best common ancestor would be.
+	pub index: usize,
+}
+

--- a/ethcore/src/blockchain/tree_route.rs
+++ b/ethcore/src/blockchain/tree_route.rs
@@ -1,3 +1,19 @@
+// Copyright 2015, 2016 Ethcore (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
 use util::hash::H256;
 
 /// Represents a tree route between `from` block and `to` block:

--- a/ethcore/src/blockchain/update.rs
+++ b/ethcore/src/blockchain/update.rs
@@ -8,14 +8,14 @@ use extras::{BlockDetails, BlockReceipts, TransactionAddress, BlocksBlooms};
 pub struct ExtrasUpdate {
 	/// Block info.
 	pub info: BlockInfo,
-	/// Numbers of blocks to update in block hashes cache.
+	/// Modified block hashes.
 	pub block_hashes: HashMap<BlockNumber, H256>,
-	/// Hashes of blocks to update in block details cache.
+	/// Modified block details.
 	pub block_details: HashMap<H256, BlockDetails>,
-	/// Hashes of receipts to update in block receipts cache.
+	/// Modified block receipts.
 	pub block_receipts: HashMap<H256, BlockReceipts>,
-	/// Hashes of transactions to update in transactions addresses cache.
+	/// Modified transaction addresses.
 	pub transactions_addresses: HashMap<H256, TransactionAddress>,
-	/// Changed blocks bloom location hashes.
+	/// Modified blocks blooms.
 	pub blocks_blooms: HashMap<H256, BlocksBlooms>,
 }

--- a/ethcore/src/blockchain/update.rs
+++ b/ethcore/src/blockchain/update.rs
@@ -1,23 +1,21 @@
-use std::collections::HashSet;
+use std::collections::HashMap;
 use util::hash::H256;
-use util::kvdb::DBTransaction;
 use header::BlockNumber;
 use blockchain::block_info::BlockInfo;
+use extras::{BlockDetails, BlockReceipts, TransactionAddress, BlocksBlooms};
 
 /// Block extras update info.
 pub struct ExtrasUpdate {
 	/// Block info.
 	pub info: BlockInfo,
-	/// DB update batch.
-	pub batch: DBTransaction,
 	/// Numbers of blocks to update in block hashes cache.
-	pub block_numbers: HashSet<BlockNumber>,
+	pub block_hashes: HashMap<BlockNumber, H256>,
 	/// Hashes of blocks to update in block details cache.
-	pub block_details_hashes: HashSet<H256>,
+	pub block_details: HashMap<H256, BlockDetails>,
 	/// Hashes of receipts to update in block receipts cache.
-	pub block_receipts_hashes: HashSet<H256>,
+	pub block_receipts: HashMap<H256, BlockReceipts>,
 	/// Hashes of transactions to update in transactions addresses cache.
-	pub transactions_addresses_hashes: HashSet<H256>,
+	pub transactions_addresses: HashMap<H256, TransactionAddress>,
 	/// Changed blocks bloom location hashes.
-	pub bloom_hashes: HashSet<H256>,
+	pub blocks_blooms: HashMap<H256, BlocksBlooms>,
 }

--- a/ethcore/src/blockchain/update.rs
+++ b/ethcore/src/blockchain/update.rs
@@ -1,0 +1,23 @@
+use std::collections::HashSet;
+use util::hash::H256;
+use util::kvdb::DBTransaction;
+use header::BlockNumber;
+use blockchain::block_info::BlockInfo;
+
+/// Block extras update info.
+pub struct ExtrasUpdate {
+	/// Block info.
+	pub info: BlockInfo,
+	/// DB update batch.
+	pub batch: DBTransaction,
+	/// Numbers of blocks to update in block hashes cache.
+	pub block_numbers: HashSet<BlockNumber>,
+	/// Hashes of blocks to update in block details cache.
+	pub block_details_hashes: HashSet<H256>,
+	/// Hashes of receipts to update in block receipts cache.
+	pub block_receipts_hashes: HashSet<H256>,
+	/// Hashes of transactions to update in transactions addresses cache.
+	pub transactions_addresses_hashes: HashSet<H256>,
+	/// Changed blocks bloom location hashes.
+	pub bloom_hashes: HashSet<H256>,
+}

--- a/ethcore/src/client.rs
+++ b/ethcore/src/client.rs
@@ -408,7 +408,11 @@ impl BlockChainClient for Client {
 	}
 
 	fn tree_route(&self, from: &H256, to: &H256) -> Option<TreeRoute> {
-		self.chain.read().unwrap().tree_route(from.clone(), to.clone())
+		let chain = self.chain.read().unwrap();
+		match chain.is_known(from) && chain.is_known(to) {
+			true => Some(chain.tree_route(from.clone(), to.clone())),
+			false => None
+		}
 	}
 
 	fn state_data(&self, _hash: &H256) -> Option<Bytes> {

--- a/ethcore/src/extras.rs
+++ b/ethcore/src/extras.rs
@@ -262,15 +262,6 @@ impl Encodable for BlocksBlooms {
 	}
 }
 
-/// Represents location of bloom in database.
-#[derive(Debug, PartialEq)]
-pub struct BlocksBloomLocation {
-	/// Unique hash of BlocksBloom
-	pub hash: H256,
-	/// Index within BlocksBloom
-	pub index: usize,
-}
-
 /// Represents address of certain transaction within block
 #[derive(Clone)]
 pub struct TransactionAddress {


### PR DESCRIPTION
changes:

- split `block_to_extras_update` function into 6 smaller functions. Code is cleaner, more maintainable and readable.
- fully separated preparing extas update from applying it to a batch. 
- split `blockchain.rs` into few separate files. This file was becoming a behemoth.
- fixed cleaning up blockchain caches.