### PR TITLE
u256 full multiplication

### DIFF
--- a/util/benches/bigint.rs
+++ b/util/benches/bigint.rs
@@ -75,6 +75,19 @@ fn u256_mul(b: &mut Bencher) {
 
 
 #[bench]
+fn u256_full_mul(b: &mut Bencher) {
+	b.iter(|| {
+		let n = black_box(10000);
+		(0..n).fold(U256([rand::random::<u64>(), rand::random::<u64>(), rand::random::<u64>(), rand::random::<u64>()]),
+			|old, new| {
+				let U512(ref u512words) = old.full_mul(U256([rand::random::<u64>(), rand::random::<u64>(), rand::random::<u64>(), rand::random::<u64>()]));
+				U256([u512words[0], u512words[2], u512words[2], u512words[3]])
+			})
+	});
+}
+
+
+#[bench]
 fn u128_mul(b: &mut Bencher) {
 	b.iter(|| {
 		let n = black_box(10000);

--- a/util/src/uint.rs
+++ b/util/src/uint.rs
@@ -1105,8 +1105,8 @@ impl U256 {
 		let self_t: &[u64; 4] = unsafe { &mem::transmute(self) };
 		let other_t: &[u64; 4] = unsafe { &mem::transmute(other) };
 		let mut result: [u64; 8] = unsafe { mem::uninitialized() };
-        unsafe {
-            asm!("
+		unsafe {
+			asm!("
 				mov $8, %rax
 				mulq $12
 				mov %rax, $0
@@ -1230,11 +1230,11 @@ impl U256 {
             : /* $8 */ "m"(self_t[0]), /* $9 */ "m"(self_t[1]), /* $10 */  "m"(self_t[2]),
 			  /* $11 */ "m"(self_t[3]), /* $12 */ "m"(other_t[0]), /* $13 */ "m"(other_t[1]),
 			  /* $14 */ "m"(other_t[2]), /* $15 */ "m"(other_t[3])
-            : "rax", "rdx"
-            :
-            );
-        }
-        U512(result)
+			: "rax", "rdx"
+			:
+			);
+		}
+		U512(result)
 	}
 
 	/// Multiplies two 256-bit integers to produce full 512-bit integer


### PR DESCRIPTION
this will introduce method `full_mul` for `U256`, which returns full 512-bit product (of two 256-bit inputs)
this exact operation is used in plenty of places involving gas calculation

will add benches tonight (not running reference machine right now)
should be about x10 increase