### PR TITLE
ignore out directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@
 # jetbrains ide stuff
 .idea
 *.iml
+
+# Build artifacts
+out/


### PR DESCRIPTION
when building project with IntelliJ, build artifacts are saved into `out` directory so adding this to gitignore