### PR TITLE
Reduce HISTORY size to 20.

### DIFF
--- a/ethcore/src/client.rs
+++ b/ethcore/src/client.rs
@@ -200,7 +200,7 @@ pub struct Client {
 	extra_data: RwLock<Bytes>,
 }
 
-const HISTORY: u64 = 1000;
+const HISTORY: u64 = 20;
 const CLIENT_DB_VER_STR: &'static str = "4.0";
 
 impl Client {


### PR DESCRIPTION
might be useful for anyone wanting to quickly test whether forks kill the history mechanism. saves having to wait 1000 blocks before they begin.