### PR TITLE
jsonrpc uses client and sync interfaces

### DIFF
--- a/parity/main.rs
+++ b/parity/main.rs
@@ -48,7 +48,7 @@ use ethcore::spec::*;
 use ethcore::client::*;
 use ethcore::service::{ClientService, NetSyncMessage};
 use ethcore::ethereum;
-use ethsync::{EthSync, SyncConfig};
+use ethsync::{EthSync, SyncConfig, SyncStatusProvider};
 use docopt::Docopt;
 use daemonize::Daemonize;
 use number_prefix::{binary_prefix, Standalone, Prefixed};

--- a/rpc/src/v1/impls/eth.rs
+++ b/rpc/src/v1/impls/eth.rs
@@ -17,7 +17,7 @@
 //! Eth rpc implementation.
 use std::collections::HashMap;
 use std::sync::{Arc, Weak, Mutex, RwLock};
-use ethsync::{EthSync, SyncState};
+use ethsync::{SyncStatusProvider, SyncState};
 use jsonrpc_core::*;
 use util::numbers::*;
 use util::sha3::*;
@@ -25,7 +25,6 @@ use util::rlp::encode;
 use ethcore::client::*;
 use ethcore::block::{IsBlock};
 use ethcore::views::*;
-//#[macro_use] extern crate log;
 use ethcore::ethereum::Ethash;
 use ethcore::ethereum::denominations::shannon;
 use v1::traits::{Eth, EthFilter};
@@ -33,15 +32,15 @@ use v1::types::{Block, BlockTransactions, BlockNumber, Bytes, SyncStatus, SyncIn
 use v1::helpers::{PollFilter, PollManager};
 
 /// Eth rpc implementation.
-pub struct EthClient {
-	client: Weak<Client>,
-	sync: Weak<EthSync>,
+pub struct EthClient<C, S> where C: BlockChainClient, S: SyncStatusProvider {
+	client: Weak<C>,
+	sync: Weak<S>,
 	hashrates: RwLock<HashMap<H256, u64>>,
 }
 
-impl EthClient {
+impl<C, S> EthClient<C, S> where C: BlockChainClient, S: SyncStatusProvider {
 	/// Creates new EthClient.
-	pub fn new(client: &Arc<Client>, sync: &Arc<EthSync>) -> Self {
+	pub fn new(client: &Arc<C>, sync: &Arc<S>) -> Self {
 		EthClient {
 			client: Arc::downgrade(client),
 			sync: Arc::downgrade(sync),
@@ -95,7 +94,7 @@ impl EthClient {
 	}
 }
 
-impl Eth for EthClient {
+impl<C, S> Eth for EthClient<C, S> where C: BlockChainClient + 'static, S: SyncStatusProvider + 'static {
 	fn protocol_version(&self, params: Params) -> Result<Value, Error> {
 		match params {
 			Params::None => to_value(&U256::from(take_weak!(self.sync).status().protocol_version)),
@@ -256,14 +255,14 @@ impl Eth for EthClient {
 }
 
 /// Eth filter rpc implementation.
-pub struct EthFilterClient {
-	client: Weak<Client>,
+pub struct EthFilterClient<C> where C: BlockChainClient {
+	client: Weak<C>,
 	polls: Mutex<PollManager<PollFilter>>,
 }
 
-impl EthFilterClient {
+impl<C> EthFilterClient<C> where C: BlockChainClient {
 	/// Creates new Eth filter client.
-	pub fn new(client: &Arc<Client>) -> Self {
+	pub fn new(client: &Arc<C>) -> Self {
 		EthFilterClient {
 			client: Arc::downgrade(client),
 			polls: Mutex::new(PollManager::new())
@@ -271,7 +270,7 @@ impl EthFilterClient {
 	}
 }
 
-impl EthFilter for EthFilterClient {
+impl<C> EthFilter for EthFilterClient<C> where C: BlockChainClient + 'static {
 	fn new_filter(&self, params: Params) -> Result<Value, Error> {
 		from_params::<(Filter,)>(params)
 			.and_then(|(filter,)| {

--- a/rpc/src/v1/impls/net.rs
+++ b/rpc/src/v1/impls/net.rs
@@ -17,24 +17,24 @@
 //! Net rpc implementation.
 use std::sync::{Arc, Weak};
 use jsonrpc_core::*;
-use ethsync::EthSync;
+use ethsync::SyncStatusProvider;
 use v1::traits::Net;
 
 /// Net rpc implementation.
-pub struct NetClient {
-	sync: Weak<EthSync>
+pub struct NetClient<S> where S: SyncStatusProvider {
+	sync: Weak<S>
 }
 
-impl NetClient {
+impl<S> NetClient<S> where S: SyncStatusProvider {
 	/// Creates new NetClient.
-	pub fn new(sync: &Arc<EthSync>) -> Self {
+	pub fn new(sync: &Arc<S>) -> Self {
 		NetClient {
 			sync: Arc::downgrade(sync)
 		}
 	}
 }
 
-impl Net for NetClient {
+impl<S> Net for NetClient<S> where S: SyncStatusProvider + 'static {
 	fn version(&self, _: Params) -> Result<Value, Error> {
 		Ok(Value::U64(take_weak!(self.sync).status().protocol_version as u64))
 	}

--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -93,6 +93,12 @@ impl Default for SyncConfig {
 	}
 }
 
+/// Current sync status
+pub trait SyncStatusProvider: Send + Sync {
+	/// Get sync status
+	fn status(&self) -> SyncStatus;
+}
+
 /// Ethereum network protocol handler
 pub struct EthSync {
 	/// Shared blockchain client. TODO: this should evetually become an IPC endpoint
@@ -114,11 +120,6 @@ impl EthSync {
 		sync
 	}
 
-	/// Get sync status
-	pub fn status(&self) -> SyncStatus {
-		self.sync.read().unwrap().status()
-	}
-
 	/// Stop sync
 	pub fn stop(&mut self, io: &mut NetworkContext<SyncMessage>) {
 		self.sync.write().unwrap().abort(&mut NetSyncIo::new(io, self.chain.deref()));
@@ -127,6 +128,13 @@ impl EthSync {
 	/// Restart sync
 	pub fn restart(&mut self, io: &mut NetworkContext<SyncMessage>) {
 		self.sync.write().unwrap().restart(&mut NetSyncIo::new(io, self.chain.deref()));
+	}
+}
+
+impl SyncStatusProvider for EthSync {
+	/// Get sync status
+	fn status(&self) -> SyncStatus {
+		self.sync.read().unwrap().status()
 	}
 }
 

--- a/sync/src/tests/helpers.rs
+++ b/sync/src/tests/helpers.rs
@@ -25,6 +25,7 @@ use ethcore::receipt::Receipt;
 use ethcore::transaction::LocalizedTransaction;
 use ethcore::filter::Filter;
 use ethcore::log_entry::LocalizedLogEntry;
+use ethcore::block::ClosedBlock;
 
 pub struct TestBlockChainClient {
 	pub blocks: RwLock<HashMap<H256, Bytes>>,
@@ -122,6 +123,14 @@ impl BlockChainClient for TestBlockChainClient {
 	}
 
 	fn logs(&self, _filter: Filter) -> Vec<LocalizedLogEntry> {
+		unimplemented!();
+	}
+
+	fn sealing_block(&self) -> &Mutex<Option<ClosedBlock>> {
+		unimplemented!();
+	}
+
+	fn submit_seal(&self, _pow_hash: H256, _seal: Vec<Bytes>) -> Result<(), Error> {
 		unimplemented!();
 	}
 


### PR DESCRIPTION
it's a preparation for jsonrpc tests

changes:
- `sealing_block` and `submit_seal` are now a part of `BlockChainClient` trait
- new trait `SyncStatusProvider` (implemented by `EthSync`)
- rpc server uses `BlockChainClient` and `SyncStatus Provider` instead of `Client` and `EthSync`.