### PR TITLE
updated jsonrpc-core and http-server libs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -228,8 +228,8 @@ dependencies = [
  "ethcore 0.9.99",
  "ethcore-util 0.9.99",
  "ethsync 0.9.99",
- "jsonrpc-core 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-http-server 2.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-http-server 3.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.18 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -400,7 +400,7 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-core"
-version = "1.2.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "serde 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -411,11 +411,11 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-http-server"
-version = "2.1.0"
+version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "hyper 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-core 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core 2.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/parity/main.rs
+++ b/parity/main.rs
@@ -193,7 +193,7 @@ fn setup_log(init: &Option<String>) {
 fn setup_rpc_server(client: Arc<Client>, sync: Arc<EthSync>, url: &str, cors_domain: &str, apis: Vec<&str>) -> Option<Arc<PanicHandler>> {
 	use rpc::v1::*;
 
-	let mut server = rpc::HttpServer::new(1);
+	let server = rpc::RpcServer::new();
 	for api in apis.into_iter() {
 		match api {
 			"web3" => server.add_delegate(Web3Client::new().to_delegate()),
@@ -207,7 +207,7 @@ fn setup_rpc_server(client: Arc<Client>, sync: Arc<EthSync>, url: &str, cors_dom
 			}
 		}
 	}
-	Some(server.start_async(url, cors_domain))
+	Some(server.start_http(url, cors_domain, 1))
 }
 
 #[cfg(not(feature = "rpc"))]

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -12,8 +12,8 @@ build = "build.rs"
 log = "0.3"
 serde = "0.7.0"
 serde_json = "0.7.0"
-jsonrpc-core = "1.2"
-jsonrpc-http-server = "2.1"
+jsonrpc-core = "2.0"
+jsonrpc-http-server = "3.0"
 ethcore-util = { path = "../util" }
 ethcore = { path = "../ethcore" }
 ethash = { path = "../ethash" }

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -37,35 +37,33 @@ use self::jsonrpc_core::{IoHandler, IoDelegate};
 pub mod v1;
 
 /// Http server.
-pub struct HttpServer {
-	handler: IoHandler,
-	threads: usize,
+pub struct RpcServer {
+	handler: Arc<IoHandler>,
 }
 
-impl HttpServer {
+impl RpcServer {
 	/// Construct new http server object with given number of threads.
-	pub fn new(threads: usize) -> HttpServer {
-		HttpServer {
-			handler: IoHandler::new(),
-			threads: threads,
+	pub fn new() -> RpcServer {
+		RpcServer {
+			handler: Arc::new(IoHandler::new()),
 		}
 	}
 
 	/// Add io delegate.
-	pub fn add_delegate<D>(&mut self, delegate: IoDelegate<D>) where D: Send + Sync + 'static {
+	pub fn add_delegate<D>(&self, delegate: IoDelegate<D>) where D: Send + Sync + 'static {
 		self.handler.add_delegate(delegate);
 	}
 
 	/// Start server asynchronously in new thread and returns panic handler.
-	pub fn start_async(self, addr: &str, cors_domain: &str) -> Arc<PanicHandler> {
+	pub fn start_http(&self, addr: &str, cors_domain: &str, threads: usize) -> Arc<PanicHandler> {
 		let addr = addr.to_owned();
 		let cors_domain = cors_domain.to_owned();
 		let panic_handler = PanicHandler::new_in_arc();
 		let ph = panic_handler.clone();
-		let server = jsonrpc_http_server::Server::new(self.handler, self.threads);
+		let server = jsonrpc_http_server::Server::new(self.handler.clone());
 		thread::Builder::new().name("jsonrpc_http".to_string()).spawn(move || {
 			ph.catch_panic(move || {
-				server.start(addr.as_ref(), jsonrpc_http_server::AccessControlAllowOrigin::Value(cors_domain));
+				server.start(addr.as_ref(), jsonrpc_http_server::AccessControlAllowOrigin::Value(cors_domain), threads);
 			}).unwrap()
 		}).expect("Error while creating jsonrpc http thread");
 		panic_handler


### PR DESCRIPTION
changes in jsonrpc-core:
- `IoHandler` provides interior threadsafety

changes in jsonrpc-http-server:
- `IoHandler` is not wrapped into mutex what improves performance if server is used on multiple threads
- server constructor takes `Arc<IoHandler>` instead of moving `IoHandler` what makes `IoHandler` reusable for multiple rpc servers

changes in pr:
- renamed `HttpServer` to `RpcServer`
- renamed `start_async` to `start_http`