### PR TITLE
Don't call mark_as_bad needlessly

### DIFF
--- a/ethcore/src/block_queue.rs
+++ b/ethcore/src/block_queue.rs
@@ -320,6 +320,9 @@ impl BlockQueue {
 
 	/// Mark given block and all its children as bad. Stops verification.
 	pub fn mark_as_bad(&mut self, block_hashes: &[H256]) {
+		if block_hashes.is_empty() {
+			return;
+		}
 		let mut verification_lock = self.verification.lock().unwrap();
 		let mut processing = self.processing.write().unwrap();
 
@@ -345,6 +348,9 @@ impl BlockQueue {
 
 	/// Mark given block as processed
 	pub fn mark_as_good(&mut self, block_hashes: &[H256]) {
+		if block_hashes.is_empty() {
+			return;
+		}
 		let mut processing = self.processing.write().unwrap();
 		for hash in block_hashes {
 			processing.remove(&hash);

--- a/ethcore/src/client.rs
+++ b/ethcore/src/client.rs
@@ -404,8 +404,12 @@ impl<V> Client<V> where V: Verifier {
 
 		{
 			let mut block_queue = self.block_queue.write().unwrap();
-			block_queue.mark_as_bad(&bad_blocks);
-			block_queue.mark_as_good(&good_blocks);
+			if !bad_blocks.is_empty() {
+				block_queue.mark_as_bad(&bad_blocks);
+			}
+			if !good_blocks.is_empty() {
+				block_queue.mark_as_good(&good_blocks);
+			}
 		}
 
 		{


### PR DESCRIPTION
Profiling shows calls to `mark_as_bad` take significant time because inside there is a rearrangement of the verification queue even if the list of bad blocks is empty.