### PR TITLE
rpc net submodule tests

### DIFF
--- a/rpc/src/v1/impls/net.rs
+++ b/rpc/src/v1/impls/net.rs
@@ -36,10 +36,10 @@ impl<S> NetClient<S> where S: SyncProvider {
 
 impl<S> Net for NetClient<S> where S: SyncProvider + 'static {
 	fn version(&self, _: Params) -> Result<Value, Error> {
-		Ok(Value::U64(take_weak!(self.sync).status().protocol_version as u64))
+		Ok(Value::String(format!("{}", take_weak!(self.sync).status().protocol_version).to_owned()))
 	}
 
 	fn peer_count(&self, _params: Params) -> Result<Value, Error> {
-		Ok(Value::U64(take_weak!(self.sync).status().num_peers as u64))
+		Ok(Value::String(format!("0x{:x}", take_weak!(self.sync).status().num_peers as u64).to_owned()))
 	}
 }

--- a/rpc/src/v1/impls/net.rs
+++ b/rpc/src/v1/impls/net.rs
@@ -42,4 +42,9 @@ impl<S> Net for NetClient<S> where S: SyncProvider + 'static {
 	fn peer_count(&self, _params: Params) -> Result<Value, Error> {
 		Ok(Value::String(format!("0x{:x}", take_weak!(self.sync).status().num_peers as u64).to_owned()))
 	}
+
+	fn is_listening(&self, _: Params) -> Result<Value, Error> {
+		// right now (11 march 2016), we are always listening for incoming connections
+		Ok(Value::Bool(true))
+	}
 }

--- a/rpc/src/v1/mod.rs
+++ b/rpc/src/v1/mod.rs
@@ -21,9 +21,10 @@
 pub mod traits;
 mod impls;
 mod types;
+mod helpers;
+
 #[cfg(test)]
 mod tests;
-mod helpers;
 
 pub use self::traits::{Web3, Eth, EthFilter, Personal, Net};
 pub use self::impls::*;

--- a/rpc/src/v1/tests/helpers/mod.rs
+++ b/rpc/src/v1/tests/helpers/mod.rs
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-//!TODO: load custom blockchain state and test
+mod sync_provider;
 
-mod net;
-mod helpers;
+pub use self::sync_provider::{Config, TestSyncProvider};

--- a/rpc/src/v1/tests/helpers/sync_provider.rs
+++ b/rpc/src/v1/tests/helpers/sync_provider.rs
@@ -40,6 +40,7 @@ impl TestSyncProvider {
 				num_peers: config.num_peers,
 				num_active_peers: 0,
 				mem_used: 0,
+				transaction_queue_pending: 0,
 			},
 		}
 	}

--- a/rpc/src/v1/tests/helpers/sync_provider.rs
+++ b/rpc/src/v1/tests/helpers/sync_provider.rs
@@ -1,0 +1,57 @@
+// Copyright 2015, 2016 Ethcore (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+use ethcore::transaction::SignedTransaction;
+use ethsync::{SyncProvider, SyncStatus, SyncState};
+
+pub struct Config {
+	pub protocol_version: u8,
+	pub num_peers: usize,
+}
+
+pub struct TestSyncProvider {
+	status: SyncStatus,
+}
+
+impl TestSyncProvider {
+	pub fn new(config: Config) -> Self {
+		TestSyncProvider {
+			status: SyncStatus {
+				state: SyncState::NotSynced,
+				protocol_version: config.protocol_version,
+				start_block_number: 0,
+				last_imported_block_number: None,
+				highest_block_number: None,
+				blocks_total: 0,
+				blocks_received: 0,
+				num_peers: config.num_peers,
+				num_active_peers: 0,
+				mem_used: 0,
+			},
+		}
+	}
+}
+
+impl SyncProvider for TestSyncProvider {
+	fn status(&self) -> SyncStatus {
+		self.status.clone()
+	}
+
+	fn insert_transaction(&self, _transaction: SignedTransaction) {
+		unimplemented!()
+	}
+}
+

--- a/rpc/src/v1/tests/net.rs
+++ b/rpc/src/v1/tests/net.rs
@@ -19,12 +19,16 @@ use jsonrpc_core::IoHandler;
 use v1::{Net, NetClient};
 use v1::tests::helpers::{Config, TestSyncProvider};
 
-#[test]
-fn rpc_net_version() {
-	let sync = Arc::new(TestSyncProvider::new(Config {
+fn sync_provider() -> Arc<TestSyncProvider> {
+	Arc::new(TestSyncProvider::new(Config {
 		protocol_version: 65,
 		num_peers: 120,
-	}));
+	}))
+}
+
+#[test]
+fn rpc_net_version() {
+	let sync = sync_provider();
 	let net = NetClient::new(&sync).to_delegate();
 	let io = IoHandler::new();
 	io.add_delegate(net);
@@ -37,10 +41,7 @@ fn rpc_net_version() {
 
 #[test]
 fn rpc_net_peer_count() {
-	let sync = Arc::new(TestSyncProvider::new(Config {
-		protocol_version: 65,
-		num_peers: 120,
-	}));
+	let sync = sync_provider();
 	let net = NetClient::new(&sync).to_delegate();
 	let io = IoHandler::new();
 	io.add_delegate(net);
@@ -53,10 +54,7 @@ fn rpc_net_peer_count() {
 
 #[test]
 fn rpc_net_listening() {
-	let sync = Arc::new(TestSyncProvider::new(Config {
-		protocol_version: 65,
-		num_peers: 120,
-	}));
+	let sync = sync_provider();
 	let net = NetClient::new(&sync).to_delegate();
 	let io = IoHandler::new();
 	io.add_delegate(net);

--- a/rpc/src/v1/tests/net.rs
+++ b/rpc/src/v1/tests/net.rs
@@ -1,0 +1,52 @@
+// Copyright 2015, 2016 Ethcore (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::sync::Arc;
+use jsonrpc_core::IoHandler;
+use v1::{Net, NetClient};
+use v1::tests::helpers::{Config, TestSyncProvider};
+
+#[test]
+fn rpc_net_version() {
+	let sync = Arc::new(TestSyncProvider::new(Config {
+		protocol_version: 65,
+		num_peers: 120,
+	}));
+	let net = NetClient::new(&sync).to_delegate();
+	let io = IoHandler::new();
+	io.add_delegate(net);
+
+	let request = r#"{"jsonrpc": "2.0", "method": "net_version", "params": [], "id": 1}"#;
+	let response = r#"{"jsonrpc":"2.0","result":"65","id":1}"#;
+
+	assert_eq!(io.handle_request(request), Some(response.to_string()));
+}
+
+#[test]
+fn rpc_net_peer_count() {
+	let sync = Arc::new(TestSyncProvider::new(Config {
+		protocol_version: 65,
+		num_peers: 120,
+	}));
+	let net = NetClient::new(&sync).to_delegate();
+	let io = IoHandler::new();
+	io.add_delegate(net);
+
+	let request = r#"{"jsonrpc": "2.0", "method": "net_peerCount", "params": [], "id": 1}"#;
+	let response = r#"{"jsonrpc":"2.0","result":"0x78","id":1}"#;
+
+	assert_eq!(io.handle_request(request), Some(response.to_string()));
+}

--- a/rpc/src/v1/tests/net.rs
+++ b/rpc/src/v1/tests/net.rs
@@ -50,3 +50,19 @@ fn rpc_net_peer_count() {
 
 	assert_eq!(io.handle_request(request), Some(response.to_string()));
 }
+
+#[test]
+fn rpc_net_listening() {
+	let sync = Arc::new(TestSyncProvider::new(Config {
+		protocol_version: 65,
+		num_peers: 120,
+	}));
+	let net = NetClient::new(&sync).to_delegate();
+	let io = IoHandler::new();
+	io.add_delegate(net);
+
+	let request = r#"{"jsonrpc": "2.0", "method": "net_listening", "params": [], "id": 1}"#;
+	let response = r#"{"jsonrpc":"2.0","result":true,"id":1}"#;
+
+	assert_eq!(io.handle_request(request), Some(response.to_string()));
+}

--- a/sync/src/chain.rs
+++ b/sync/src/chain.rs
@@ -120,6 +120,7 @@ pub enum SyncState {
 }
 
 /// Syncing status and statistics
+#[derive(Clone)]
 pub struct SyncStatus {
 	/// State
 	pub state: SyncState,


### PR DESCRIPTION
based on #665

changes:
- implementation of `net_listening` method
- tests for `net_listening`, `net_peersCount` and `net_version` rpc methods