### PR TITLE
eth_getTransactionReceipt

### DIFF
--- a/ethcore/src/blockchain/blockchain.rs
+++ b/ethcore/src/blockchain/blockchain.rs
@@ -103,6 +103,11 @@ pub trait BlockProvider {
 		self.block(&address.block_hash).and_then(|bytes| BlockView::new(&bytes).localized_transaction_at(address.index))
 	}
 
+	/// Get transaction receipt.
+	fn transaction_receipt(&self, address: &TransactionAddress) -> Option<Receipt> {
+		self.block_receipts(&address.block_hash).and_then(|br| br.receipts.into_iter().nth(address.index))
+	}
+
 	/// Get a list of transactions for a given block.
 	/// Returns None if block does not exist.
 	fn transactions(&self, hash: &H256) -> Option<Vec<LocalizedTransaction>> {

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -39,7 +39,7 @@ use blockchain::{BlockChain, BlockProvider, TreeRoute, ImportRoute};
 use client::{BlockId, TransactionId, ClientConfig, BlockChainClient};
 use env_info::EnvInfo;
 use executive::{Executive, Executed};
-use receipt::Receipt;
+use receipt::LocalizedReceipt;
 pub use blockchain::CacheSize as BlockChainCacheSize;
 
 /// General block status
@@ -549,8 +549,40 @@ impl<V> BlockChainClient for Client<V> where V: Verifier {
 		self.transaction_address(id).and_then(|address| self.chain.transaction(&address))
 	}
 
-	fn transaction_receipt(&self, id: TransactionId) -> Option<Receipt> {
-		self.transaction_address(id).and_then(|address| self.chain.transaction_receipt(&address))
+	fn transaction_receipt(&self, id: TransactionId) -> Option<LocalizedReceipt> {
+		self.transaction_address(id).and_then(|address| {
+			let t = self.chain.block(&address.block_hash)
+				.and_then(|block| BlockView::new(&block).localized_transaction_at(address.index));
+
+			match (t, self.chain.transaction_receipt(&address)) {
+				(Some(tx), Some(receipt)) => {
+					let block_hash = tx.block_hash.clone();
+					let block_number = tx.block_number.clone();
+					let transaction_hash = tx.hash();
+					let transaction_index = tx.transaction_index;
+					Some(LocalizedReceipt {
+						transaction_hash: tx.hash(),
+						transaction_index: tx.transaction_index,
+						block_hash: tx.block_hash,
+						block_number: tx.block_number,
+						// TODO: to fix this, query all previous transaction receipts and retrieve their gas usage
+						cumulative_gas_used: receipt.gas_used,
+						gas_used: receipt.gas_used,
+						// TODO: to fix this, store created contract address in db
+						contract_address: None,
+						logs: receipt.logs.into_iter().enumerate().map(|(i, log)| LocalizedLogEntry {
+							entry: log,
+							block_hash: block_hash.clone(),
+							block_number: block_number,
+							transaction_hash: transaction_hash.clone(),
+							transaction_index: transaction_index,
+							log_index: i
+						}).collect()
+					})
+				},
+				_ => None
+			}
+		})
 	}
 
 	fn tree_route(&self, from: &H256, to: &H256) -> Option<TreeRoute> {
@@ -635,7 +667,7 @@ impl<V> BlockChainClient for Client<V> where V: Verifier {
 						 	.map(|(i, log)| LocalizedLogEntry {
 							 	entry: log,
 								block_hash: hash.clone(),
-								block_number: number as usize,
+								block_number: number,
 								transaction_hash: hashes.get(index).cloned().unwrap_or_else(H256::new),
 								transaction_index: index,
 								log_index: log_index + i

--- a/ethcore/src/client/mod.rs
+++ b/ethcore/src/client/mod.rs
@@ -39,7 +39,7 @@ use transaction::{LocalizedTransaction, SignedTransaction};
 use log_entry::LocalizedLogEntry;
 use filter::Filter;
 use error::{ImportResult, Error};
-use receipt::Receipt;
+use receipt::LocalizedReceipt;
 
 /// Blockchain database client. Owns and manages a blockchain and a block queue.
 pub trait BlockChainClient : Sync + Send {
@@ -78,7 +78,7 @@ pub trait BlockChainClient : Sync + Send {
 	fn transaction(&self, id: TransactionId) -> Option<LocalizedTransaction>;
 
 	/// Get transaction receipt with given hash.
-	fn transaction_receipt(&self, id: TransactionId) -> Option<Receipt>;
+	fn transaction_receipt(&self, id: TransactionId) -> Option<LocalizedReceipt>;
 
 	/// Get a tree route between `from` and `to`.
 	/// See `BlockChain::tree_route`.

--- a/ethcore/src/client/mod.rs
+++ b/ethcore/src/client/mod.rs
@@ -39,6 +39,7 @@ use transaction::{LocalizedTransaction, SignedTransaction};
 use log_entry::LocalizedLogEntry;
 use filter::Filter;
 use error::{ImportResult, Error};
+use receipt::Receipt;
 
 /// Blockchain database client. Owns and manages a blockchain and a block queue.
 pub trait BlockChainClient : Sync + Send {
@@ -75,6 +76,9 @@ pub trait BlockChainClient : Sync + Send {
 
 	/// Get transaction with given hash.
 	fn transaction(&self, id: TransactionId) -> Option<LocalizedTransaction>;
+
+	/// Get transaction receipt with given hash.
+	fn transaction_receipt(&self, id: TransactionId) -> Option<Receipt>;
 
 	/// Get a tree route between `from` and `to`.
 	/// See `BlockChain::tree_route`.

--- a/ethcore/src/client/test_client.rs
+++ b/ethcore/src/client/test_client.rs
@@ -23,7 +23,7 @@ use client::{BlockChainClient, BlockChainInfo, BlockStatus, BlockId, Transaction
 use header::{Header as BlockHeader, BlockNumber};
 use filter::Filter;
 use log_entry::LocalizedLogEntry;
-use receipt::Receipt;
+use receipt::{Receipt, LocalizedReceipt};
 use extras::BlockReceipts;
 use error::{ImportResult};
 
@@ -224,7 +224,7 @@ impl BlockChainClient for TestBlockChainClient {
 		unimplemented!();
 	}
 
-	fn transaction_receipt(&self, _id: TransactionId) -> Option<Receipt> {
+	fn transaction_receipt(&self, _id: TransactionId) -> Option<LocalizedReceipt> {
 		unimplemented!();
 	}
 

--- a/ethcore/src/client/test_client.rs
+++ b/ethcore/src/client/test_client.rs
@@ -224,6 +224,10 @@ impl BlockChainClient for TestBlockChainClient {
 		unimplemented!();
 	}
 
+	fn transaction_receipt(&self, _id: TransactionId) -> Option<Receipt> {
+		unimplemented!();
+	}
+
 	fn blocks_with_bloom(&self, _bloom: &H2048, _from_block: BlockId, _to_block: BlockId) -> Option<Vec<BlockNumber>> {
 		unimplemented!();
 	}

--- a/ethcore/src/log_entry.rs
+++ b/ethcore/src/log_entry.rs
@@ -18,6 +18,7 @@
 
 use util::*;
 use basic_types::LogBloom;
+use header::BlockNumber;
 
 /// A record of execution for a `LOG` operation.
 #[derive(Default, Debug, Clone, PartialEq, Eq)]
@@ -84,7 +85,7 @@ pub struct LocalizedLogEntry {
 	/// Block in which this log was created.
 	pub block_hash: H256,
 	/// Block number.
-	pub block_number: usize,
+	pub block_number: BlockNumber,
 	/// Hash of transaction in which this log was created.
 	pub transaction_hash: H256,
 	/// Index of transaction within block.

--- a/ethcore/src/receipt.rs
+++ b/ethcore/src/receipt.rs
@@ -18,7 +18,8 @@
 
 use util::*;
 use basic_types::LogBloom;
-use log_entry::LogEntry;
+use header::BlockNumber;
+use log_entry::{LogEntry, LocalizedLogEntry};
 
 /// Information describing execution of a transaction.
 #[derive(Default, Debug, Clone)]
@@ -72,6 +73,26 @@ impl HeapSizeOf for Receipt {
 	fn heap_size_of_children(&self) -> usize {
 		self.logs.heap_size_of_children()
 	}
+}
+
+/// Receipt with additional info.
+pub struct LocalizedReceipt {
+	/// Transaction hash.
+	pub transaction_hash: H256,
+	/// Transaction index.
+	pub transaction_index: usize,
+	/// Block hash.
+	pub block_hash: H256,
+	/// Block number.
+	pub block_number: BlockNumber,
+	/// Cumulative gas used.
+	pub cumulative_gas_used: U256,
+	/// Gas used.
+	pub gas_used: U256,
+	/// Contract address.
+	pub contract_address: Option<Address>,
+	/// Logs
+	pub logs: Vec<LocalizedLogEntry>,
 }
 
 #[test]

--- a/rpc/src/v1/impls/eth.rs
+++ b/rpc/src/v1/impls/eth.rs
@@ -293,6 +293,12 @@ impl<C, S, A, M, EM> Eth for EthClient<C, S, A, M, EM>
 			.and_then(|(number, index)| self.transaction(TransactionId::Location(number.into(), index.value())))
 	}
 
+	fn transaction_receipt(&self, params: Params) -> Result<Value, Error> {
+		unimplemented!();
+		//from_params::<(H256,)>(params)
+			//.and_then(|(hash,)| self.transaction_receipt(TransactionId::Hash(hash)))
+	}
+
 	fn uncle_by_block_hash_and_index(&self, params: Params) -> Result<Value, Error> {
 		from_params::<(H256, Index)>(params)
 			.and_then(|(hash, index)| self.uncle(BlockId::Hash(hash), index.value()))

--- a/rpc/src/v1/impls/eth.rs
+++ b/rpc/src/v1/impls/eth.rs
@@ -31,7 +31,7 @@ use ethcore::ethereum::Ethash;
 use ethcore::ethereum::denominations::shannon;
 use ethcore::transaction::Transaction as EthTransaction;
 use v1::traits::{Eth, EthFilter};
-use v1::types::{Block, BlockTransactions, BlockNumber, Bytes, SyncStatus, SyncInfo, Transaction, TransactionRequest, OptionalValue, Index, Filter, Log};
+use v1::types::{Block, BlockTransactions, BlockNumber, Bytes, SyncStatus, SyncInfo, Transaction, TransactionRequest, OptionalValue, Index, Filter, Log, Receipt};
 use v1::helpers::{PollFilter, PollManager, ExternalMinerService, ExternalMiner};
 use util::keys::store::AccountProvider;
 
@@ -294,9 +294,12 @@ impl<C, S, A, M, EM> Eth for EthClient<C, S, A, M, EM>
 	}
 
 	fn transaction_receipt(&self, params: Params) -> Result<Value, Error> {
-		unimplemented!();
-		//from_params::<(H256,)>(params)
-			//.and_then(|(hash,)| self.transaction_receipt(TransactionId::Hash(hash)))
+		from_params::<(H256,)>(params)
+			.and_then(|(hash,)| {
+				let client = take_weak!(self.client);
+				let receipt = client.transaction_receipt(TransactionId::Hash(hash));
+				to_value(&receipt.map(Receipt::from))
+			})
 	}
 
 	fn uncle_by_block_hash_and_index(&self, params: Params) -> Result<Value, Error> {

--- a/rpc/src/v1/types/mod.rs.in
+++ b/rpc/src/v1/types/mod.rs.in
@@ -24,6 +24,7 @@ mod optionals;
 mod sync;
 mod transaction;
 mod transaction_request;
+mod receipt;
 
 pub use self::block::{Block, BlockTransactions};
 pub use self::block_number::BlockNumber;
@@ -35,4 +36,5 @@ pub use self::optionals::OptionalValue;
 pub use self::sync::{SyncStatus, SyncInfo};
 pub use self::transaction::Transaction;
 pub use self::transaction_request::TransactionRequest;
+pub use self::receipt::Receipt;
 

--- a/rpc/src/v1/types/receipt.rs
+++ b/rpc/src/v1/types/receipt.rs
@@ -1,0 +1,56 @@
+// Copyright 2015, 2016 Ethcore (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+use util::numbers::U256;
+use util::hash::{Address, H256};
+use v1::types::Log;
+use ethcore::receipt::LocalizedReceipt;
+
+#[derive(Debug, Serialize)]
+pub struct Receipt {
+	#[serde(rename="transactionHash")]
+	pub transaction_hash: H256,
+	#[serde(rename="transactionIndex")]
+	pub transaction_index: U256,
+	#[serde(rename="blockHash")]
+	pub block_hash: H256,
+	#[serde(rename="blockNumber")]
+	pub block_number: U256,
+	#[serde(rename="cumulativeGasUsed")]
+	pub cumulative_gas_used: U256,
+	#[serde(rename="gasUsed")]
+	pub gas_used: U256,
+	#[serde(rename="contractAddress")]
+	pub contract_address: Option<Address>,
+	pub logs: Vec<Log>,
+}
+
+impl From<LocalizedReceipt> for Receipt {
+	fn from(r: LocalizedReceipt) -> Self {
+		Receipt {
+			transaction_hash: r.transaction_hash,
+			transaction_index: U256::from(r.transaction_index),
+			block_hash: r.block_hash,
+			block_number: U256::from(r.block_number),
+			cumulative_gas_used: r.cumulative_gas_used,
+			gas_used: r.gas_used,
+			contract_address: r.contract_address,
+			logs: r.logs.into_iter().map(From::from).collect(),
+		}
+	}
+}
+
+


### PR DESCRIPTION
all jsonrpc test for `eth_getTransactionReceipt` method passes.

changes:
- implemented `eth_getTransactionReceipt`

todo:

two fields of transaction receipt are not returning proper values
- `cumulative_gas_used`
- `contract_address`

Will fix them in next prs, cause they require more changes.