### PR TITLE
complete getting started steps for OS X

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ curl -sf https://raw.githubusercontent.com/brson/multirust/master/quick-install.
 - OSX with Homebrew:
 ```bash
 brew update && brew install multirust
+multirust default stable
 ```
 
 Then, download and build Parity:


### PR DESCRIPTION
You get 
`multirust: no default toolchain configured` 
when 
`multirust default stable`
is not executed.