### PR TITLE
another batch of rpc improvements

### DIFF
--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -21,7 +21,7 @@ use util::*;
 use util::panics::*;
 use views::BlockView;
 use error::*;
-use header::{BlockNumber};
+use header::{BlockNumber, Header};
 use state::State;
 use spec::Spec;
 use engine::Engine;
@@ -36,7 +36,7 @@ use filter::Filter;
 use log_entry::LocalizedLogEntry;
 use block_queue::{BlockQueue, BlockQueueInfo};
 use blockchain::{BlockChain, BlockProvider, TreeRoute, ImportRoute};
-use client::{BlockId, TransactionId, ClientConfig, BlockChainClient};
+use client::{BlockId, TransactionId, UncleId, ClientConfig, BlockChainClient};
 use env_info::EnvInfo;
 use executive::{Executive, Executed};
 use receipt::LocalizedReceipt;
@@ -547,6 +547,11 @@ impl<V> BlockChainClient for Client<V> where V: Verifier {
 
 	fn transaction(&self, id: TransactionId) -> Option<LocalizedTransaction> {
 		self.transaction_address(id).and_then(|address| self.chain.transaction(&address))
+	}
+
+	fn uncle(&self, id: UncleId) -> Option<Header> {
+		let index = id.1;
+		self.block(id.0).and_then(|block| BlockView::new(&block).uncle_at(index))
 	}
 
 	fn transaction_receipt(&self, id: TransactionId) -> Option<LocalizedReceipt> {

--- a/ethcore/src/client/ids.rs
+++ b/ethcore/src/client/ids.rs
@@ -20,7 +20,7 @@ use util::hash::H256;
 use header::BlockNumber;
 
 /// Uniquely identifies block.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Hash, Eq)]
 pub enum BlockId {
 	/// Block's sha3.
 	/// Querying by hash is always faster.
@@ -34,7 +34,7 @@ pub enum BlockId {
 }
 
 /// Uniquely identifies transaction.
-#[derive(Debug, PartialEq, Clone)]
+#[derive(Debug, PartialEq, Clone, Hash, Eq)]
 pub enum TransactionId {
 	/// Transaction's sha3.
 	Hash(H256),

--- a/ethcore/src/client/ids.rs
+++ b/ethcore/src/client/ids.rs
@@ -42,3 +42,11 @@ pub enum TransactionId {
 	/// Querying by block position is always faster.
 	Location(BlockId, usize)
 }
+
+/// Uniquely identifies Uncle.
+pub struct UncleId (
+	/// Block id.
+	pub BlockId,
+	/// Position in block.
+	pub usize
+);

--- a/ethcore/src/client/mod.rs
+++ b/ethcore/src/client/mod.rs
@@ -23,7 +23,7 @@ mod test_client;
 
 pub use self::client::*;
 pub use self::config::{ClientConfig, BlockQueueConfig, BlockChainConfig};
-pub use self::ids::{BlockId, TransactionId};
+pub use self::ids::{BlockId, TransactionId, UncleId};
 pub use self::test_client::{TestBlockChainClient, EachBlockWith};
 pub use executive::Executed;
 
@@ -34,7 +34,7 @@ use util::numbers::U256;
 use blockchain::TreeRoute;
 use block_queue::BlockQueueInfo;
 use block::{ClosedBlock, SealedBlock};
-use header::BlockNumber;
+use header::{BlockNumber, Header};
 use transaction::{LocalizedTransaction, SignedTransaction};
 use log_entry::LocalizedLogEntry;
 use filter::Filter;
@@ -76,6 +76,9 @@ pub trait BlockChainClient : Sync + Send {
 
 	/// Get transaction with given hash.
 	fn transaction(&self, id: TransactionId) -> Option<LocalizedTransaction>;
+
+	/// Get uncle with given id.
+	fn uncle(&self, id: UncleId) -> Option<Header>;
 
 	/// Get transaction receipt with given hash.
 	fn transaction_receipt(&self, id: TransactionId) -> Option<LocalizedReceipt>;

--- a/ethcore/src/client/test_client.rs
+++ b/ethcore/src/client/test_client.rs
@@ -19,7 +19,7 @@
 use util::*;
 use transaction::{Transaction, LocalizedTransaction, SignedTransaction, Action};
 use blockchain::TreeRoute;
-use client::{BlockChainClient, BlockChainInfo, BlockStatus, BlockId, TransactionId};
+use client::{BlockChainClient, BlockChainInfo, BlockStatus, BlockId, TransactionId, UncleId};
 use header::{Header as BlockHeader, BlockNumber};
 use filter::Filter;
 use log_entry::LocalizedLogEntry;
@@ -229,6 +229,10 @@ impl BlockChainClient for TestBlockChainClient {
 	}
 
 	fn transaction(&self, _id: TransactionId) -> Option<LocalizedTransaction> {
+		unimplemented!();
+	}
+
+	fn uncle(&self, _id: UncleId) -> Option<BlockHeader> {
 		unimplemented!();
 	}
 

--- a/ethcore/src/client/test_client.rs
+++ b/ethcore/src/client/test_client.rs
@@ -52,6 +52,8 @@ pub struct TestBlockChainClient {
 	pub code: RwLock<HashMap<Address, Bytes>>,
 	/// Execution result.
 	pub execution_result: RwLock<Option<Executed>>,
+	/// Transaction receipts.
+	pub receipts: RwLock<HashMap<TransactionId, LocalizedReceipt>>,
 }
 
 #[derive(Clone)]
@@ -87,10 +89,16 @@ impl TestBlockChainClient {
 			storage: RwLock::new(HashMap::new()),
 			code: RwLock::new(HashMap::new()),
 			execution_result: RwLock::new(None),
+			receipts: RwLock::new(HashMap::new()),
 		};
 		client.add_blocks(1, EachBlockWith::Nothing); // add genesis block
 		client.genesis_hash = client.last_hash.read().unwrap().clone();
 		client
+	}
+
+	/// Set the transaction receipt result
+	pub fn set_transaction_receipt(&self, id: TransactionId, receipt: LocalizedReceipt) {
+		self.receipts.write().unwrap().insert(id, receipt);
 	}
 
 	/// Set the execution result.
@@ -224,8 +232,8 @@ impl BlockChainClient for TestBlockChainClient {
 		unimplemented!();
 	}
 
-	fn transaction_receipt(&self, _id: TransactionId) -> Option<LocalizedReceipt> {
-		unimplemented!();
+	fn transaction_receipt(&self, id: TransactionId) -> Option<LocalizedReceipt> {
+		self.receipts.read().unwrap().get(&id).cloned()
 	}
 
 	fn blocks_with_bloom(&self, _bloom: &H2048, _from_block: BlockId, _to_block: BlockId) -> Option<Vec<BlockNumber>> {

--- a/ethcore/src/log_entry.rs
+++ b/ethcore/src/log_entry.rs
@@ -78,7 +78,7 @@ impl FromJson for LogEntry {
 }
 
 /// Log localized in a blockchain.
-#[derive(Default, Debug, PartialEq)]
+#[derive(Default, Debug, PartialEq, Clone)]
 pub struct LocalizedLogEntry {
 	/// Plain log entry.
 	pub entry: LogEntry,

--- a/ethcore/src/receipt.rs
+++ b/ethcore/src/receipt.rs
@@ -76,6 +76,7 @@ impl HeapSizeOf for Receipt {
 }
 
 /// Receipt with additional info.
+#[derive(Debug, Clone, PartialEq)]
 pub struct LocalizedReceipt {
 	/// Transaction hash.
 	pub transaction_hash: H256,

--- a/rpc/src/v1/impls/eth.rs
+++ b/rpc/src/v1/impls/eth.rs
@@ -61,7 +61,6 @@ impl<C, S, A, M> EthClient<C, S, A, M, ExternalMiner>
 	}
 }
 
-
 impl<C, S, A, M, EM> EthClient<C, S, A, M, EM>
 	where C: BlockChainClient,
 		  S: SyncProvider,
@@ -371,7 +370,6 @@ impl<C, S, A, M, EM> Eth for EthClient<C, S, A, M, EM>
 	}
 
 	fn submit_hashrate(&self, params: Params) -> Result<Value, Error> {
-		// TODO: Index should be U256.
 		from_params::<(U256, H256)>(params).and_then(|(rate, id)| {
 			self.external_miner.submit_hashrate(rate, id);
 			to_value(&true)

--- a/rpc/src/v1/types/call_request.rs
+++ b/rpc/src/v1/types/call_request.rs
@@ -19,8 +19,8 @@ use util::numbers::U256;
 use v1::types::Bytes;
 
 #[derive(Debug, Default, PartialEq, Deserialize)]
-pub struct TransactionRequest {
-	pub from: Address,
+pub struct CallRequest {
+	pub from: Option<Address>,
 	pub to: Option<Address>,
 	#[serde(rename="gasPrice")]
 	pub gas_price: Option<U256>,
@@ -52,10 +52,10 @@ mod tests {
 			"data":"0x123456",
 			"nonce":"0x4"
 		}"#;
-		let deserialized: TransactionRequest = serde_json::from_str(s).unwrap();
+		let deserialized: CallRequest = serde_json::from_str(s).unwrap();
 
-		assert_eq!(deserialized, TransactionRequest {
-			from: Address::from(1),
+		assert_eq!(deserialized, CallRequest {
+			from: Some(Address::from(1)),
 			to: Some(Address::from(2)),
 			gas_price: Some(U256::from(1)),
 			gas: Some(U256::from(2)),
@@ -75,10 +75,10 @@ mod tests {
 			"value": "0x9184e72a",
 			"data": "0xd46e8dd67c5d32be8d46e8dd67c5d32be8058bb8eb970870f072445675058bb8eb970870f072445675"
 		}"#;
-		let deserialized: TransactionRequest = serde_json::from_str(s).unwrap();
+		let deserialized: CallRequest = serde_json::from_str(s).unwrap();
 
-		assert_eq!(deserialized, TransactionRequest {
-			from: Address::from_str("b60e8dd61c5d32be8058bb8eb970870f07233155").unwrap(),
+		assert_eq!(deserialized, CallRequest {
+			from: Some(Address::from_str("b60e8dd61c5d32be8058bb8eb970870f07233155").unwrap()),
 			to: Some(Address::from_str("d46e8dd67c5d32be8058bb8eb970870f07244567").unwrap()),
 			gas_price: Some(U256::from_str("9184e72a000").unwrap()),
 			gas: Some(U256::from_str("76c0").unwrap()),
@@ -91,10 +91,10 @@ mod tests {
 	#[test]
 	fn transaction_request_deserialize_empty() {
 		let s = r#"{"from":"0x0000000000000000000000000000000000000001"}"#;
-		let deserialized: TransactionRequest = serde_json::from_str(s).unwrap();
+		let deserialized: CallRequest = serde_json::from_str(s).unwrap();
 
-		assert_eq!(deserialized, TransactionRequest {
-			from: Address::from(1),
+		assert_eq!(deserialized, CallRequest {
+			from: Some(Address::from(1)),
 			to: None,
 			gas_price: None,
 			gas: None,

--- a/rpc/src/v1/types/log.rs
+++ b/rpc/src/v1/types/log.rs
@@ -20,19 +20,19 @@ use v1::types::Bytes;
 
 #[derive(Debug, Serialize)]
 pub struct Log {
-	address: Address,
-	topics: Vec<H256>,
-	data: Bytes,
+	pub address: Address,
+	pub topics: Vec<H256>,
+	pub data: Bytes,
 	#[serde(rename="blockHash")]
-	block_hash: H256,
+	pub block_hash: H256,
 	#[serde(rename="blockNumber")]
-	block_number: U256,
+	pub block_number: U256,
 	#[serde(rename="transactionHash")]
-	transaction_hash: H256,
+	pub transaction_hash: H256,
 	#[serde(rename="transactionIndex")]
-	transaction_index: U256,
+	pub transaction_index: U256,
 	#[serde(rename="logIndex")]
-	log_index: U256,
+	pub log_index: U256,
 }
 
 impl From<LocalizedLogEntry> for Log {

--- a/rpc/src/v1/types/mod.rs.in
+++ b/rpc/src/v1/types/mod.rs.in
@@ -24,6 +24,7 @@ mod optionals;
 mod sync;
 mod transaction;
 mod transaction_request;
+mod call_request;
 mod receipt;
 
 pub use self::block::{Block, BlockTransactions};
@@ -36,5 +37,6 @@ pub use self::optionals::OptionalValue;
 pub use self::sync::{SyncStatus, SyncInfo};
 pub use self::transaction::Transaction;
 pub use self::transaction_request::TransactionRequest;
+pub use self::call_request::CallRequest;
 pub use self::receipt::Receipt;
 

--- a/rpc/src/v1/types/receipt.rs
+++ b/rpc/src/v1/types/receipt.rs
@@ -53,4 +53,42 @@ impl From<LocalizedReceipt> for Receipt {
 	}
 }
 
+#[cfg(test)]
+mod tests {
+	use serde_json;
+	use std::str::FromStr;
+	use util::numbers::*;
+	use v1::types::{Bytes, Log, Receipt};
+
+	#[test]
+	fn receipt_serialization() {
+		let s = r#"{"transactionHash":"0x0000000000000000000000000000000000000000000000000000000000000000","transactionIndex":"0x00","blockHash":"0xed76641c68a1c641aee09a94b3b471f4dc0316efe5ac19cf488e2674cf8d05b5","blockNumber":"0x04510c","cumulativeGasUsed":"0x20","gasUsed":"0x10","contractAddress":null,"logs":[{"address":"0x33990122638b9132ca29c723bdf037f1a891a70c","topics":["0xa6697e974e6a320f454390be03f74955e8978f1a6971ea6730542e37b66179bc","0x4861736852656700000000000000000000000000000000000000000000000000"],"data":"0x","blockHash":"0xed76641c68a1c641aee09a94b3b471f4dc0316efe5ac19cf488e2674cf8d05b5","blockNumber":"0x04510c","transactionHash":"0x0000000000000000000000000000000000000000000000000000000000000000","transactionIndex":"0x00","logIndex":"0x01"}]}"#;
+
+		let receipt = Receipt {
+			transaction_hash: H256::zero(),
+			transaction_index: U256::zero(),
+			block_hash: H256::from_str("ed76641c68a1c641aee09a94b3b471f4dc0316efe5ac19cf488e2674cf8d05b5").unwrap(),
+			block_number: U256::from(0x4510c),
+			cumulative_gas_used: U256::from(0x20),
+			gas_used: U256::from(0x10),
+			contract_address: None,
+			logs: vec![Log {
+				address: Address::from_str("33990122638b9132ca29c723bdf037f1a891a70c").unwrap(),
+				topics: vec![
+					H256::from_str("a6697e974e6a320f454390be03f74955e8978f1a6971ea6730542e37b66179bc").unwrap(),
+					H256::from_str("4861736852656700000000000000000000000000000000000000000000000000").unwrap()
+				],
+				data: Bytes::new(vec![]),
+				block_hash: H256::from_str("ed76641c68a1c641aee09a94b3b471f4dc0316efe5ac19cf488e2674cf8d05b5").unwrap(),
+				block_number: U256::from(0x4510c),
+				transaction_hash: H256::new(),
+				transaction_index: U256::zero(),
+				log_index: U256::one()
+			}]
+		};
+
+		let serialized = serde_json::to_string(&receipt).unwrap();
+		assert_eq!(serialized, s);
+	}
+}
 

--- a/util/src/crypto.rs
+++ b/util/src/crypto.rs
@@ -20,6 +20,7 @@ use numbers::*;
 use bytes::*;
 use secp256k1::{key, Secp256k1};
 use rand::os::OsRng;
+use sha3::Hashable;
 
 /// Secret key for secp256k1 EC operations. 256 bit generic "hash" data.
 pub type Secret = H256;
@@ -135,13 +136,20 @@ impl KeyPair {
 			public: p,
 		})
 	}
+
 	/// Returns public key
 	pub fn public(&self) -> &Public {
 		&self.public
 	}
+
 	/// Returns private key
 	pub fn secret(&self) -> &Secret {
 		&self.secret
+	}
+
+	/// Returns address.
+	pub fn address(&self) -> Address {
+		Address::from(self.public.sha3())
 	}
 
 	/// Sign a message with our secret key.


### PR DESCRIPTION
changes:
- implemented `eth_sendRawTransaction`
- fixed default `nonce`, `gasPrice` and `gas` in `eth_sendTransaction`
- fixed default `address` in `eth_call` and `eth_estimateGas`
- added `address()` function to `util::crypto::KeyPair`
- added tests for `eth_getTransactionReceipt`

todo:

`eth_call` and few other rpc methods do not take into block param:

https://github.com/ethereum/wiki/wiki/JSON-RPC#the-default-block-parameter