### PR TITLE
Syntax helpers for IPC RPC (part 2)

### DIFF
--- a/ipc/codegen/src/codegen.rs
+++ b/ipc/codegen/src/codegen.rs
@@ -431,6 +431,18 @@ fn push_proxy_implementation(
 
 	let implement = quote_item!(cx,
 		impl<S> ServiceProxy<S> where S: ::ipc::IpcSocket {
+			pub fn new(socket: S) -> ServiceProxy<S> {
+				ServiceProxy {
+					socket: ::std::cell::RefCell::new(socket),
+					phantom: ::std::marker::PhantomData,
+				}
+			}
+
+			#[cfg(test)]
+			pub fn socket(&self) -> &::std::cell::RefCell<S> {
+				&self.socket
+			}
+
 			$items
 		}).unwrap();
 

--- a/ipc/codegen/src/codegen.rs
+++ b/ipc/codegen/src/codegen.rs
@@ -278,7 +278,6 @@ fn push_client(
 ///    ::ipc::invoke(0, &Some(serialized_payload), &mut socket);
 ///    while !socket.ready().load(::std::sync::atomic::Ordering::Relaxed) { }
 ///    ::bincode::serde::deserialize_from::<_, u32>(&mut socket, ::bincode::SizeLimit::Infinite).unwrap()
-
 fn implement_client_method_body(
 	cx: &ExtCtxt,
 	builder: &aster::AstBuilder,
@@ -386,8 +385,8 @@ fn implement_client_method_body(
 	}
 }
 
-///
-/// Generates signature and
+/// Generates signature and body (see `implement_client_method_body`)
+/// for the client (signature is identical to the original method)
 fn implement_client_method(
 	cx: &ExtCtxt,
 	builder: &aster::AstBuilder,
@@ -443,6 +442,7 @@ fn implement_client_method(
 	signature.unwrap()
 }
 
+/// pushes full client side code for the original class exposed via ipc
 fn push_client_implementation(
 	cx: &ExtCtxt,
 	builder: &aster::AstBuilder,
@@ -476,6 +476,7 @@ fn push_client_implementation(
 	push(Annotatable::Item(implement));
 }
 
+/// implements `IpcInterface<C>` for the given class `C`
 fn implement_interface(
 	cx: &ExtCtxt,
 	builder: &aster::AstBuilder,

--- a/ipc/codegen/src/codegen.rs
+++ b/ipc/codegen/src/codegen.rs
@@ -356,13 +356,6 @@ fn implement_proxy_method_body(
 			$wait_result_stmt
 		})
 	}
-
-	//let output_type_id = builder.id(dispatch.return_type_name.clone().unwrap().as_str());
-//	let invariant_serialization = quote_expr!(cx, {
-//
-//
-//	});
-
 }
 
 fn implement_proxy_method(

--- a/ipc/rpc/Cargo.toml
+++ b/ipc/rpc/Cargo.toml
@@ -7,3 +7,4 @@ license = "GPL-3.0"
 [features]
 
 [dependencies]
+ethcore-devtools = { path = "../../devtools" }

--- a/ipc/rpc/src/interface.rs
+++ b/ipc/rpc/src/interface.rs
@@ -24,8 +24,8 @@ pub trait IpcInterface<T> {
 pub fn invoke<W>(method_num: u16, params: &Option<Vec<u8>>, w: &mut W) where W: ::std::io::Write {
 	let buf_len = match *params { None => 2, Some(ref val) => val.len() + 2 };
 	let mut buf = vec![0u8; buf_len];
-	buf[0] = (method_num & (255<<8)) as u8;
-	buf[1] = (method_num >> 8) as u8;
+	buf[1] = (method_num & 255) as u8;
+	buf[0] = (method_num >> 8) as u8;
 	if params.is_some() {
 		buf[2..buf_len].clone_from_slice(params.as_ref().unwrap());
 	}

--- a/ipc/rpc/src/interface.rs
+++ b/ipc/rpc/src/interface.rs
@@ -16,31 +16,43 @@
 
 //! IPC RPC interface
 
+use std::io::{Read, Write};
+use std::marker::Sync;
+use std::sync::atomic::*;
+
 pub trait IpcInterface<T> {
 	/// reads the message from io, dispatches the call and returns result
-	fn dispatch<R>(&self, r: &mut R) -> Vec<u8> where R: ::std::io::Read;
+	fn dispatch<R>(&self, r: &mut R) -> Vec<u8> where R: Read;
 }
 
-pub fn invoke<W>(method_num: u16, params: &Option<Vec<u8>>, w: &mut W) where W: ::std::io::Write {
+/// serializes method invocation (method_num and parameters) to the stream specified by `w`
+pub fn invoke<W>(method_num: u16, params: &Option<Vec<u8>>, w: &mut W) where W: Write {
+	// creating buffer to contain all message
 	let buf_len = match *params { None => 2, Some(ref val) => val.len() + 2 };
 	let mut buf = vec![0u8; buf_len];
+
+	// writing method_num as u16
 	buf[1] = (method_num & 255) as u8;
 	buf[0] = (method_num >> 8) as u8;
+
+	// serializing parameters only if provided with any
 	if params.is_some() {
 		buf[2..buf_len].clone_from_slice(params.as_ref().unwrap());
 	}
 	if w.write(&buf).unwrap() != buf_len
 	{
+		// if write was inconsistent
 		panic!("failed to write to socket");
 	}
 }
 
-pub trait IpcSocket: ::std::io::Read + ::std::io::Write {
-	fn ready(&self) -> ::std::sync::atomic::AtomicBool;
+/// IpcSocket
+pub trait IpcSocket: Read + Write + Sync {
+	fn ready(&self) -> AtomicBool;
 }
 
 impl IpcSocket for ::devtools::TestSocket {
-	fn ready(&self) -> ::std::sync::atomic::AtomicBool {
-		::std::sync::atomic::AtomicBool::new(true)
+	fn ready(&self) -> AtomicBool {
+		AtomicBool::new(true)
 	}
 }

--- a/ipc/rpc/src/lib.rs
+++ b/ipc/rpc/src/lib.rs
@@ -16,5 +16,7 @@
 
 //! IPC RPC interface
 
+extern crate ethcore_devtools as devtools;
+
 pub mod interface;
-pub use interface::IpcInterface;
+pub use interface::{IpcInterface, IpcSocket, invoke};

--- a/ipc/tests/examples.rs
+++ b/ipc/tests/examples.rs
@@ -45,4 +45,16 @@ mod tests {
 		assert_eq!(vec![0, 0, 0, 0, 0, 5], service_proxy.socket().borrow().write_buffer.clone());
 		assert_eq!(10, result);
 	}
+
+	#[test]
+	fn call_service_proxy_optional() {
+		let mut socket = TestSocket::new();
+		socket.read_buffer = vec![0, 0, 0, 10];
+		let service_proxy = ServiceProxy::new(socket);
+
+		let result = service_proxy.rollback(Some(5), 10);
+
+		assert_eq!(vec![0, 1, 1, 0, 0, 0, 5, 0, 0, 0, 10], service_proxy.socket().borrow().write_buffer.clone());
+		assert_eq!(10, result);
+	}
 }

--- a/ipc/tests/examples.rs
+++ b/ipc/tests/examples.rs
@@ -38,11 +38,11 @@ mod tests {
 	fn call_service_proxy() {
 		let mut socket = TestSocket::new();
 		socket.read_buffer = vec![0, 0, 0, 10];
-		let service_proxy = ServiceProxy::new(socket);
+		let service_client = ServiceClient::new(socket);
 
-		let result = service_proxy.commit(5);
+		let result = service_client.commit(5);
 
-		assert_eq!(vec![0, 0, 0, 0, 0, 5], service_proxy.socket().borrow().write_buffer.clone());
+		assert_eq!(vec![0, 0, 0, 0, 0, 5], service_client.socket().borrow().write_buffer.clone());
 		assert_eq!(10, result);
 	}
 
@@ -50,11 +50,11 @@ mod tests {
 	fn call_service_proxy_optional() {
 		let mut socket = TestSocket::new();
 		socket.read_buffer = vec![0, 0, 0, 10];
-		let service_proxy = ServiceProxy::new(socket);
+		let service_client = ServiceClient::new(socket);
 
-		let result = service_proxy.rollback(Some(5), 10);
+		let result = service_client.rollback(Some(5), 10);
 
-		assert_eq!(vec![0, 1, 1, 0, 0, 0, 5, 0, 0, 0, 10], service_proxy.socket().borrow().write_buffer.clone());
+		assert_eq!(vec![0, 1, 1, 0, 0, 0, 5, 0, 0, 0, 10], service_client.socket().borrow().write_buffer.clone());
 		assert_eq!(10, result);
 	}
 }

--- a/ipc/tests/examples.rs
+++ b/ipc/tests/examples.rs
@@ -33,4 +33,16 @@ mod tests {
 
 		assert_eq!(10, *service.commits.read().unwrap());
 	}
+
+	#[test]
+	fn call_service_proxy() {
+		let mut socket = TestSocket::new();
+		socket.read_buffer = vec![0, 0, 0, 10];
+		let service_proxy = ServiceProxy::new(socket);
+
+		let result = service_proxy.commit(5);
+
+		assert_eq!(vec![0, 0, 0, 0, 0, 5], service_proxy.socket().borrow().write_buffer.clone());
+		assert_eq!(10, result);
+	}
 }

--- a/ipc/tests/service.rs.in
+++ b/ipc/tests/service.rs.in
@@ -29,10 +29,11 @@ impl Service {
 		*lock = *lock + f as usize;
 		f
 	}
-	pub fn rollback(&self, a: u32, b: u32) -> i32 {
+	pub fn rollback(&self, a: Option<u32>, b: u32) -> i32 {
+		let a_0 = a.unwrap_or_else(|| 0);
 		let mut lock = self.rollbacks.write().unwrap();
-		*lock = *lock + a as usize - b as usize;
-		(a - b) as i32
+		*lock = *lock + a_0 as usize - b as usize;
+		(a_0 - b) as i32
 	}
 }
 

--- a/ipc/tests/service.rs.in
+++ b/ipc/tests/service.rs.in
@@ -15,6 +15,7 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::sync::RwLock;
+use std::ops::*;
 
 pub struct Service {
 	pub commits: RwLock<usize>,
@@ -32,6 +33,37 @@ impl Service {
 		let mut lock = self.rollbacks.write().unwrap();
 		*lock = *lock + a as usize - b as usize;
 		(a - b) as i32
+	}
+}
+
+impl<S: ::ipc::IpcSocket> ServiceProxy<S> {
+	pub fn commit(&self, f: u32) -> u32 {
+		#[derive(Serialize)]
+		struct Request<'a> {
+			f: &'a u32,
+		}
+		let payload = Request{ f: &f, };
+
+		let mut socket_ref = self.socket.borrow_mut();
+		let mut socket = socket_ref.deref_mut();
+
+		let serialized_payload = ::bincode::serde::serialize(&payload, ::bincode::SizeLimit::Infinite).unwrap();
+		::ipc::invoke(0, &Some(serialized_payload), &mut socket);
+
+		while !socket.ready().load(::std::sync::atomic::Ordering::Relaxed) { }
+		::bincode::serde::deserialize_from::<_, u32>(&mut socket, ::bincode::SizeLimit::Infinite).unwrap()
+	}
+
+	pub fn new(socket: S) -> ServiceProxy<S> {
+		ServiceProxy {
+			socket: ::std::cell::RefCell::new(socket),
+			phantom: ::std::marker::PhantomData,
+		}
+	}
+
+	#[cfg(test)]
+	pub fn socket(&self) -> &::std::cell::RefCell<S> {
+		&self.socket
 	}
 }
 

--- a/ipc/tests/service.rs.in
+++ b/ipc/tests/service.rs.in
@@ -37,23 +37,6 @@ impl Service {
 }
 
 impl<S: ::ipc::IpcSocket> ServiceProxy<S> {
-	pub fn commit(&self, f: u32) -> u32 {
-		#[derive(Serialize)]
-		struct Request<'a> {
-			f: &'a u32,
-		}
-		let payload = Request{ f: &f, };
-
-		let mut socket_ref = self.socket.borrow_mut();
-		let mut socket = socket_ref.deref_mut();
-
-		let serialized_payload = ::bincode::serde::serialize(&payload, ::bincode::SizeLimit::Infinite).unwrap();
-		::ipc::invoke(0, &Some(serialized_payload), &mut socket);
-
-		while !socket.ready().load(::std::sync::atomic::Ordering::Relaxed) { }
-		::bincode::serde::deserialize_from::<_, u32>(&mut socket, ::bincode::SizeLimit::Infinite).unwrap()
-	}
-
 	pub fn new(socket: S) -> ServiceProxy<S> {
 		ServiceProxy {
 			socket: ::std::cell::RefCell::new(socket),

--- a/ipc/tests/service.rs.in
+++ b/ipc/tests/service.rs.in
@@ -36,21 +36,7 @@ impl Service {
 	}
 }
 
-impl<S: ::ipc::IpcSocket> ServiceProxy<S> {
-	pub fn new(socket: S) -> ServiceProxy<S> {
-		ServiceProxy {
-			socket: ::std::cell::RefCell::new(socket),
-			phantom: ::std::marker::PhantomData,
-		}
-	}
-
-	#[cfg(test)]
-	pub fn socket(&self) -> &::std::cell::RefCell<S> {
-		&self.socket
-	}
-}
-
-impl Service {
+	impl Service {
 	pub fn new() -> Service {
 		Service {
 			commits: RwLock::new(0usize),

--- a/ipc/tests/service.rs.in
+++ b/ipc/tests/service.rs.in
@@ -36,7 +36,7 @@ impl Service {
 	}
 }
 
-	impl Service {
+impl Service {
 	pub fn new() -> Service {
 		Service {
 			commits: RwLock::new(0usize),


### PR DESCRIPTION
- generates client code that has the same signature as server method

  so specifying
  ```
  #[derive(Ipc)]
  impl Service {
	  fn commit(&self, f: u32) -> u32 {
            ...
	  }
  }
  ```

  will generate client proxy ServiceClient with the `fn commit(&self, f: u32) -> u32` as well

- duplex socket draft for ipc (`IpcSocket`)
- small test