### PR TITLE
Find geth data store cross-platform.

### DIFF
--- a/util/src/keys/geth_import.rs
+++ b/util/src/keys/geth_import.rs
@@ -19,6 +19,7 @@
 use common::*;
 use keys::store::SecretStore;
 use keys::directory::KeyFileContent;
+use std::path::PathBuf;
 
 /// Enumerates all geth keys in the directory and returns collection of tuples `(accountId, filename)`
 pub fn enumerate_geth_keys(path: &Path) -> Result<Vec<(Address, String)>, io::Error> {
@@ -91,6 +92,37 @@ pub fn import_geth_keys(secret_store: &mut SecretStore, geth_keyfiles_directory:
 		}
 	}
 	Ok(())
+}
+
+
+/// Gets the default geth keystore directory.
+///
+/// Based on https://github.com/ethereum/go-ethereum/blob/e553215/common/path.go#L75
+pub fn keystore_dir() -> PathBuf {
+	#[cfg(target_os = "macos")]
+	fn data_dir(mut home: PathBuf) -> PathBuf {
+		home.push("Library");
+		home.push("Ethereum");
+		home
+	}
+	
+	#[cfg(windows)]
+	fn data_dir(mut home: PathBuf) -> PathBuf {
+		home.push("AppData");
+		home.push("Roaming");
+		home.push("Ethereum");
+		home	
+	}
+	
+	#[cfg(not(any(target_os = "macos", windows)))]
+	fn data_dir(mut home: PathBuf) -> PathBuf {
+		home.push(".ethereum");
+        home
+	}
+	
+	let mut data_dir = data_dir(::std::env::home_dir().expect("Failed to get home dir"));
+	data_dir.push("keystore");
+	data_dir
 }
 
 #[cfg(test)]

--- a/util/src/keys/store.rs
+++ b/util/src/keys/store.rs
@@ -150,7 +150,7 @@ impl AccountService {
 		self.secret_store.write().unwrap().collect_garbage();
 	}
 
-    /// Unlocks account for use (no expiration of unlock)
+	/// Unlocks account for use (no expiration of unlock)
 	pub fn unlock_account_no_expire(&self, account: &Address, pass: &str) -> Result<(), EncryptedHashMapError> {
 		self.secret_store.write().unwrap().unlock_account_with_expiration(account, pass, None)
 	}
@@ -183,13 +183,9 @@ impl SecretStore {
 
 	/// trys to import keys in the known locations
 	pub fn try_import_existing(&mut self) {
-		use std::path::PathBuf;
 		use keys::geth_import;
 
-		let mut import_path = PathBuf::new();
-		import_path.push(::std::env::home_dir().expect("Failed to get home dir"));
-		import_path.push(".ethereum");
-		import_path.push("keystore");
+		let import_path = geth_import::keystore_dir();
 		if let Err(e) = geth_import::import_geth_keys(self, &import_path) {
 			trace!(target: "sstore", "Geth key not imported: {:?}", e);
 		}


### PR DESCRIPTION
Fixes #869 

cc @jacogr (Please try this branch to see if everything works as it should)

I have based this off of https://github.com/ethereum/go-ethereum/blob/e553215/common/path.go#L75
This should probably be tested somehow -- but both I and Travis run linux.