### PR TITLE
ipc rpc with nano transport (simple duplex)

### DIFF
--- a/ipc/codegen/src/codegen.rs
+++ b/ipc/codegen/src/codegen.rs
@@ -531,6 +531,15 @@ fn implement_interface(
 					_ => vec![]
 				}
 			}
+
+			fn dispatch_buf<R>(&self, method_num: u16, r: &mut R) -> Vec<u8>
+				where R: ::std::io::Read
+			{
+				match method_num {
+					$dispatch_arms
+					_ => vec![]
+				}
+			}
 		}
 	).unwrap(), dispatch_table))
 }

--- a/ipc/nano/Cargo.toml
+++ b/ipc/nano/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "ethcore-ipc-nano"
+version = "1.1.0"
+authors = ["Nikolay Volf <nikolay@ethcore.io>"]
+license = "GPL-3.0"
+
+[features]
+
+[dependencies]
+"ethcore-ipc" = { path = "../rpc" }
+nanomsg = "0.5.0"

--- a/ipc/nano/Cargo.toml
+++ b/ipc/nano/Cargo.toml
@@ -9,3 +9,4 @@ license = "GPL-3.0"
 [dependencies]
 "ethcore-ipc" = { path = "../rpc" }
 nanomsg = "0.5.0"
+log = "0.3"

--- a/ipc/nano/src/lib.rs
+++ b/ipc/nano/src/lib.rs
@@ -178,7 +178,7 @@ mod tests {
 
 	#[test]
 	fn worker_can_poll_long() {
-		let url = "ipc:///tmp/parity-test30.ipc";
+		let url = "ipc:///tmp/parity-test40.ipc";
 
 		let mut worker = Worker::<DummyService>::new(Arc::new(DummyService::new()));
 		worker.add_duplex(url).unwrap();

--- a/ipc/nano/src/lib.rs
+++ b/ipc/nano/src/lib.rs
@@ -18,6 +18,7 @@
 
 extern crate ethcore_ipc as ipc;
 extern crate nanomsg;
+#[macro_use] extern crate log;
 
 pub use ipc::*;
 
@@ -47,7 +48,9 @@ impl<S> Worker<S> where S: IpcInterface<S> {
 					let result = self.service.dispatch_buf(
 						self.method_buf[1] as u16 * 256 + self.method_buf[0] as u16,
 						socket);
-					socket.write(&result);
+					if let Err(e) = socket.write(&result) {
+						warn!(target: "ipc", "Failed to write response: {:?}", e);
+					}
 				}
 			}
 		}

--- a/ipc/nano/src/lib.rs
+++ b/ipc/nano/src/lib.rs
@@ -99,6 +99,7 @@ mod tests {
 		}
 	}
 
+	#[test]
 	fn can_create_worker() {
 		let worker = Worker::<DummyService>::new(Arc::new(DummyService));
 		assert_eq!(0, worker.sockets.len());

--- a/ipc/nano/src/lib.rs
+++ b/ipc/nano/src/lib.rs
@@ -14,7 +14,29 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-//! Ethcore implementation of IPC over nanomsg transport
+//! IPC over nanomsg transport
 
 extern crate ethcore_ipc as ipc;
 extern crate nanomsg;
+
+pub use ipc::*;
+
+use std::sync::*;
+use nanomsg::{Socket, Protocol};
+
+pub struct Worker<S> where S: IpcInterface<S> {
+	service: Arc<S>,
+	sockets: Vec<Socket>,
+}
+
+impl<S> Worker<S> where S: IpcInterface<S> {
+	pub fn new(service: Arc<S>, socket_addr: &str) -> Worker<S> {
+		Worker::<S> {
+			service: service.clone(),
+			sockets: Vec::new(),
+		}
+	}
+
+	pub fn work_loop(&mut self) {
+	}
+}

--- a/ipc/nano/src/lib.rs
+++ b/ipc/nano/src/lib.rs
@@ -1,0 +1,20 @@
+// Copyright 2015, 2016 Ethcore (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Ethcore implementation of IPC over nanomsg transport
+
+extern crate ethcore_ipc as ipc;
+extern crate nanomsg;

--- a/ipc/nano/src/lib.rs
+++ b/ipc/nano/src/lib.rs
@@ -148,7 +148,7 @@ mod tests {
 	#[test]
 	fn can_add_duplex_socket_to_worker() {
 		let mut worker = Worker::<DummyService>::new(Arc::new(DummyService::new()));
-		worker.add_duplex("ipc://tmp/parity-test10.ipc").unwrap();
+		worker.add_duplex("ipc:///tmp/parity-test10.ipc").unwrap();
 		assert_eq!(1, worker.sockets.len());
 	}
 
@@ -156,7 +156,7 @@ mod tests {
 	fn worker_can_poll_empty() {
 		let service = Arc::new(DummyService::new());
 		let mut worker = Worker::<DummyService>::new(service.clone());
-		worker.add_duplex("ipc://tmp/parity-test20.ipc").unwrap();
+		worker.add_duplex("ipc:///tmp/parity-test20.ipc").unwrap();
 		worker.poll();
 		assert_eq!(0, service.methods_stack.read().unwrap().len());
 	}

--- a/ipc/nano/src/lib.rs
+++ b/ipc/nano/src/lib.rs
@@ -169,7 +169,7 @@ mod tests {
 		worker.add_duplex(url).unwrap();
 
 		let (_socket, _endpoint) = dummy_write(url, &vec![0, 0, 7, 7, 6, 6]);
-		for _ in 0..1000 { worker.poll(); }
+		for _ in 0..100 { worker.poll(); }
 
 		assert_eq!(1, worker.service.methods_stack.read().unwrap().len());
 		assert_eq!(0, worker.service.methods_stack.read().unwrap()[0].method_num);
@@ -186,7 +186,7 @@ mod tests {
 		let message = [0u8; 1024*1024];
 
 		let (_socket, _endpoint) = dummy_write(url, &message);
-		for _ in 0..10000 { worker.poll(); }
+		for _ in 0..1000 { worker.poll(); }
 
 		assert_eq!(1, worker.service.methods_stack.read().unwrap().len());
 		assert_eq!(0, worker.service.methods_stack.read().unwrap()[0].method_num);

--- a/ipc/rpc/src/interface.rs
+++ b/ipc/rpc/src/interface.rs
@@ -23,6 +23,10 @@ use std::sync::atomic::*;
 pub trait IpcInterface<T> {
 	/// reads the message from io, dispatches the call and returns result
 	fn dispatch<R>(&self, r: &mut R) -> Vec<u8> where R: Read;
+
+	/// deserialize the payload from the io `r` and invokes method specified by `method_num`
+	/// (for non-blocking io)
+	fn dispatch_buf<R>(&self, method_num: u16, r: &mut R) -> Vec<u8> where R: Read;
 }
 
 /// serializes method invocation (method_num and parameters) to the stream specified by `w`

--- a/ipc/rpc/src/interface.rs
+++ b/ipc/rpc/src/interface.rs
@@ -26,7 +26,7 @@ pub trait IpcInterface<T> {
 
 	/// deserialize the payload from the io `r` and invokes method specified by `method_num`
 	/// (for non-blocking io)
-	fn dispatch_buf<R>(&self, method_num: u16, r: &mut R) -> Vec<u8> where R: Read;
+	fn dispatch_buf(&self, method_num: u16, buf: &[u8]) -> Vec<u8>;
 }
 
 /// serializes method invocation (method_num and parameters) to the stream specified by `w`

--- a/ipc/rpc/src/interface.rs
+++ b/ipc/rpc/src/interface.rs
@@ -21,10 +21,10 @@ use std::marker::Sync;
 use std::sync::atomic::*;
 
 pub trait IpcInterface<T> {
-	/// reads the message from io, dispatches the call and returns result
+	/// reads the message from io, dispatches the call and returns serialized result
 	fn dispatch<R>(&self, r: &mut R) -> Vec<u8> where R: Read;
 
-	/// deserialize the payload from the io `r` and invokes method specified by `method_num`
+	/// deserialize the payload from buffer, dispatches invoke and returns serialized result
 	/// (for non-blocking io)
 	fn dispatch_buf(&self, method_num: u16, buf: &[u8]) -> Vec<u8>;
 }


### PR DESCRIPTION
- using non-blocking methods of nanomsg library
- worker with (currently) persistent two-way sockets
- some extensions for `codegen` to allow deserialize from predefined buffer

really would like some suggestions and advices on this