### PR TITLE
Removing match on constant

### DIFF
--- a/ethcore/src/account.rs
+++ b/ethcore/src/account.rs
@@ -138,7 +138,7 @@ impl Account {
 	/// get someone who knows to call `note_code`.
 	pub fn code(&self) -> Option<&[u8]> {
 		match self.code_hash {
-			Some(c) if c == SHA3_EMPTY  && self.code_cache.is_empty() => Some(&self.code_cache),
+			Some(c) if c == SHA3_EMPTY && self.code_cache.is_empty() => Some(&self.code_cache),
 			Some(_) if !self.code_cache.is_empty() => Some(&self.code_cache),
 			None => Some(&self.code_cache),
 			_ => None,

--- a/ethcore/src/account.rs
+++ b/ethcore/src/account.rs
@@ -138,7 +138,7 @@ impl Account {
 	/// get someone who knows to call `note_code`.
 	pub fn code(&self) -> Option<&[u8]> {
 		match self.code_hash {
-			Some(SHA3_EMPTY) | None if self.code_cache.is_empty() => Some(&self.code_cache),
+			Some(c) if c == SHA3_EMPTY  && self.code_cache.is_empty() => Some(&self.code_cache),
 			Some(_) if !self.code_cache.is_empty() => Some(&self.code_cache),
 			None => Some(&self.code_cache),
 			_ => None,


### PR DESCRIPTION
Pattern matching on complex type constants without `#[derive(PartialEq)]` is being phased-out.

Details:
https://github.com/rust-lang/rfcs/pull/1445

We cannot derive `PartialEq` because arrays does not implement any traits.