### PR TITLE
passing key path to all invocations

### DIFF
--- a/parity/main.rs
+++ b/parity/main.rs
@@ -82,7 +82,7 @@ Parity. Ethereum Client.
 
 Usage:
   parity daemon <pid-file> [options]
-  parity account (new | list)
+  parity account (new | list) [options]
   parity [options]
 
 Protocol Options:
@@ -93,7 +93,7 @@ Protocol Options:
   -d --db-path PATH        Specify the database & configuration directory path
                            [default: $HOME/.parity].
   --keys-path PATH         Specify the path for JSON key files to be found
-                           [default: $HOME/.web3/keys].
+                           [default: $HOME/.parity/keys].
   --identity NAME          Specify your node's name.
 
 Account Options:
@@ -505,7 +505,7 @@ impl Configuration {
 	fn execute_account_cli(&self) {
 		use util::keys::store::SecretStore;
 		use rpassword::read_password;
-		let mut secret_store = SecretStore::new();
+		let mut secret_store = SecretStore::new_in(Path::new(&self.args.flag_keys_path));
 		if self.args.cmd_new {
 			println!("Please note that password is NOT RECOVERABLE.");
 			println!("Type password: ");
@@ -539,7 +539,7 @@ impl Configuration {
 				.into_iter()
 		}).collect::<Vec<_>>();
 
-		let account_service = AccountService::new();
+		let account_service = AccountService::new_in(Path::new(&self.args.flag_keys_path));
 		for d in &self.args.flag_unlock {
 			let a = Address::from_str(clean_0x(&d)).unwrap_or_else(|_| {
 				die!("{}: Invalid address for --unlock. Must be 40 hex characters, without the 0x at the beginning.", d)

--- a/parity/main.rs
+++ b/parity/main.rs
@@ -383,7 +383,7 @@ impl Configuration {
 		}
 	}
 
-	fn _keys_path(&self) -> String {
+	fn keys_path(&self) -> String {
 		self.args.flag_keys_path.replace("$HOME", env::home_dir().unwrap().to_str().unwrap())
 	}
 
@@ -505,7 +505,7 @@ impl Configuration {
 	fn execute_account_cli(&self) {
 		use util::keys::store::SecretStore;
 		use rpassword::read_password;
-		let mut secret_store = SecretStore::new_in(Path::new(&self.args.flag_keys_path));
+		let mut secret_store = SecretStore::new_in(Path::new(&self.keys_path()));
 		if self.args.cmd_new {
 			println!("Please note that password is NOT RECOVERABLE.");
 			println!("Type password: ");
@@ -539,7 +539,7 @@ impl Configuration {
 				.into_iter()
 		}).collect::<Vec<_>>();
 
-		let account_service = AccountService::new_in(Path::new(&self.args.flag_keys_path));
+		let account_service = AccountService::new_in(Path::new(&self.keys_path()));
 		for d in &self.args.flag_unlock {
 			let a = Address::from_str(clean_0x(&d)).unwrap_or_else(|_| {
 				die!("{}: Invalid address for --unlock. Must be 40 hex characters, without the 0x at the beginning.", d)

--- a/util/src/keys/store.rs
+++ b/util/src/keys/store.rs
@@ -128,9 +128,18 @@ impl Default for AccountService {
 }
 
 impl AccountService {
-	/// New account service with the default location
+	/// New account service with the keys store in default location
 	pub fn new() -> Self {
 		let secret_store = RwLock::new(SecretStore::new());
+		secret_store.write().unwrap().try_import_existing();
+		AccountService {
+			secret_store: secret_store
+		}
+	}
+
+	/// New account service with the keys store in specific location
+	pub fn new_in(path: &Path) -> Self {
+		let secret_store = RwLock::new(SecretStore::new_in(path));
 		secret_store.write().unwrap().try_import_existing();
 		AccountService {
 			secret_store: secret_store


### PR DESCRIPTION
#882 

bug existed because no code in `parity.rs` actually passed `args.flag_keys_path` to any constructor of `SecretStore`/`AccountService`

was fixed by adding this pass