### PR TITLE
Fixed eth_call nonce and gas handling

### DIFF
--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -38,7 +38,7 @@ use block_queue::{BlockQueue, BlockQueueInfo};
 use blockchain::{BlockChain, BlockProvider, TreeRoute, ImportRoute};
 use client::{BlockId, TransactionId, UncleId, ClientConfig, BlockChainClient};
 use env_info::EnvInfo;
-use executive::{Executive, Executed, contract_address};
+use executive::{Executive, Executed, TransactOptions, contract_address};
 use receipt::LocalizedReceipt;
 pub use blockchain::CacheSize as BlockChainCacheSize;
 
@@ -418,7 +418,8 @@ impl<V> BlockChainClient for Client<V> where V: Verifier {
 		// give the sender max balance
 		state.sub_balance(&sender, &balance);
 		state.add_balance(&sender, &U256::max_value());
-		Executive::new(&mut state, &env_info, self.engine.deref().deref()).transact(t, false)
+		let options = TransactOptions { tracing: false, check_nonce: false };
+		Executive::new(&mut state, &env_info, self.engine.deref().deref()).transact(t, options)
 	}
 
 	// TODO [todr] Should be moved to miner crate eventually.

--- a/ethcore/src/state.rs
+++ b/ethcore/src/state.rs
@@ -16,7 +16,7 @@
 
 use common::*;
 use engine::Engine;
-use executive::Executive;
+use executive::{Executive, TransactOptions};
 use account_db::*;
 #[cfg(test)]
 #[cfg(feature = "json-tests")]
@@ -220,7 +220,8 @@ impl State {
 	pub fn apply(&mut self, env_info: &EnvInfo, engine: &Engine, t: &SignedTransaction, tracing: bool) -> ApplyResult {
 //		let old = self.to_pod();
 
-		let e = try!(Executive::new(self, env_info, engine).transact(t, tracing));
+		let options = TransactOptions { tracing: tracing, check_nonce: true };
+		let e = try!(Executive::new(self, env_info, engine).transact(t, options));
 
 		// TODO uncomment once to_pod() works correctly.
 //		trace!("Applied transaction. Diff:\n{}\n", StateDiff::diff_pod(&old, &self.to_pod()));

--- a/rpc/src/v1/impls/eth.rs
+++ b/rpc/src/v1/impls/eth.rs
@@ -43,6 +43,10 @@ fn default_gas() -> U256 {
 	U256::from(21_000)
 }
 
+fn default_call_gas() -> U256 {
+	U256::from(50_000_000)
+}
+
 /// Eth rpc implementation.
 pub struct EthClient<C, S, A, M, EM = ExternalMiner>
 	where C: BlockChainClient,
@@ -175,7 +179,7 @@ impl<C, S, A, M, EM> EthClient<C, S, A, M, EM>
 		Ok(EthTransaction {
 			nonce: request.nonce.unwrap_or_else(|| client.nonce(&from)),
 			action: request.to.map_or(Action::Create, Action::Call),
-			gas: request.gas.unwrap_or_else(default_gas),
+			gas: request.gas.unwrap_or_else(default_call_gas),
 			gas_price: request.gas_price.unwrap_or_else(|| miner.sensible_gas_price()),
 			value: request.value.unwrap_or_else(U256::zero),
 			data: request.data.map_or_else(Vec::new, |d| d.to_vec())


### PR DESCRIPTION
Fixes #885 and #887 
Two issues fixed here:
1. eth_call always executed with nonce == 0, Nonce check was preventing call from executing if sender hash non-zero nonce
2. Default gas setting for a call was incorrect.