### PR TITLE
executive tracing cleanup

### DIFF
--- a/ethcore/src/executive.rs
+++ b/ethcore/src/executive.rs
@@ -305,7 +305,7 @@ impl<'a> Executive<'a> {
 				// otherwise it's just a basic transaction, only do tracing, if necessary.
 				self.state.clear_snapshot();
 
-				tracer.trace_call(trace_info, U256::zero(), Some(vec![]), self.depth, vec![], delegate_call);
+				tracer.trace_call(trace_info, U256::zero(), trace_output, self.depth, vec![], delegate_call);
 				Ok(params.gas)
 			}
 		}

--- a/ethcore/src/executive.rs
+++ b/ethcore/src/executive.rs
@@ -113,12 +113,20 @@ impl<'a> Executive<'a> {
 	}
 
 	/// Creates `Externalities` from `Executive`.
-	pub fn as_externalities<'_>(&'_ mut self, origin_info: OriginInfo, substate: &'_ mut Substate, output: OutputPolicy<'_, '_>) -> Externalities {
-		Externalities::new(self.state, self.info, self.engine, self.depth, origin_info, substate, output)
+	pub fn as_externalities<'_, T>(&'_ mut self, origin_info: OriginInfo, substate: &'_ mut Substate, output: OutputPolicy<'_, '_>, tracer: &'_ mut T) -> Externalities<'_, T> where T: Tracer {
+		Externalities::new(self.state, self.info, self.engine, self.depth, origin_info, substate, output, tracer)
 	}
 
 	/// This funtion should be used to execute transaction.
 	pub fn transact(&'a mut self, t: &SignedTransaction, options: TransactOptions) -> Result<Executed, Error> {
+		let check = options.check_nonce;
+		match options.tracing {
+			true => self.transact_with_tracer(t, check, ExecutiveTracer::default()),
+			false => self.transact_with_tracer(t, check, NoopTracer),
+		}
+	}
+
+	pub fn transact_with_tracer<T>(&'a mut self, t: &SignedTransaction, check_nonce: bool, mut tracer: T) -> Result<Executed, Error> where T: Tracer {
 		let sender = try!(t.sender());
 		let nonce = self.state.nonce(&sender);
 
@@ -132,7 +140,7 @@ impl<'a> Executive<'a> {
 		let init_gas = t.gas - base_gas_required;
 
 		// validate transaction nonce
-		if options.check_nonce {
+		if check_nonce {
 			if t.nonce != nonce {
 				return Err(From::from(ExecutionError::InvalidNonce { expected: nonce, got: t.nonce }));
 			}
@@ -161,7 +169,7 @@ impl<'a> Executive<'a> {
 		self.state.inc_nonce(&sender);
 		self.state.sub_balance(&sender, &U256::from(gas_cost));
 
-		let mut substate = Substate::new(options.tracing);
+		let mut substate = Substate::new();
 
 		let (gas_left, output) = match t.action {
 			Action::Create => {
@@ -177,7 +185,7 @@ impl<'a> Executive<'a> {
 					code: Some(t.data.clone()),
 					data: None,
 				};
-				(self.create(params, &mut substate), vec![])
+				(self.create(params, &mut substate, &mut tracer), vec![])
 			},
 			Action::Call(ref address) => {
 				let params = ActionParams {
@@ -193,18 +201,19 @@ impl<'a> Executive<'a> {
 				};
 				// TODO: move output upstream
 				let mut out = vec![];
-				(self.call(params, &mut substate, BytesRef::Flexible(&mut out)), out)
+				(self.call(params, &mut substate, BytesRef::Flexible(&mut out), &mut tracer), out)
 			}
 		};
 
 		// finalize here!
-		Ok(try!(self.finalize(t, substate, gas_left, output)))
+		Ok(try!(self.finalize(t, substate, gas_left, output, tracer.traces().pop())))
 	}
 
-	fn exec_vm(&mut self, params: ActionParams, unconfirmed_substate: &mut Substate, output_policy: OutputPolicy) -> evm::Result {
+	fn exec_vm<T>(&mut self, params: ActionParams, unconfirmed_substate: &mut Substate, output_policy: OutputPolicy, tracer: &mut T)
+		-> evm::Result where T: Tracer {
 		// Ordinary execution - keep VM in same thread
 		if (self.depth + 1) % MAX_VM_DEPTH_FOR_THREAD != 0 {
-			let mut ext = self.as_externalities(OriginInfo::from(&params), unconfirmed_substate, output_policy);
+			let mut ext = self.as_externalities(OriginInfo::from(&params), unconfirmed_substate, output_policy, tracer);
 			let vm_factory = self.engine.vm_factory();
 			trace!(target: "executive", "ext.schedule.have_delegate_call: {}", ext.schedule().have_delegate_call);
 			return vm_factory.create().exec(params, &mut ext);
@@ -214,7 +223,7 @@ impl<'a> Executive<'a> {
 		// TODO [todr] No thread builder yet, so we need to reset once for a while
 		// https://github.com/aturon/crossbeam/issues/16
 		crossbeam::scope(|scope| {
-			let mut ext = self.as_externalities(OriginInfo::from(&params), unconfirmed_substate, output_policy);
+			let mut ext = self.as_externalities(OriginInfo::from(&params), unconfirmed_substate, output_policy, tracer);
 			let vm_factory = self.engine.vm_factory();
 
 			scope.spawn(move || {
@@ -227,7 +236,8 @@ impl<'a> Executive<'a> {
 	/// NOTE. It does not finalize the transaction (doesn't do refunds, nor suicides).
 	/// Modifies the substate and the output.
 	/// Returns either gas_left or `evm::Error`.
-	pub fn call(&mut self, params: ActionParams, substate: &mut Substate, mut output: BytesRef) -> evm::Result {
+	pub fn call<T>(&mut self, params: ActionParams, substate: &mut Substate, mut output: BytesRef, tracer: &mut T)
+		-> evm::Result where T: Tracer {
 		// backup used in case of running out of gas
 		self.state.snapshot();
 
@@ -257,49 +267,45 @@ impl<'a> Executive<'a> {
 				}
 			}
 		} else {
-			// if destination is a contract, do normal message call
-
-			// don't trace if it's DELEGATECALL or CALLCODE.
-			let should_trace = if let ActionValue::Transfer(_) = params.value {
-				params.code_address == params.address && substate.subtraces.is_some()
-			} else { false };
-
-			// transaction tracing stuff. None if there's no tracing.
-			let (mut trace_info, mut trace_output) = if should_trace {
-				(Some((TraceAction::from_call(&params), self.depth)), Some(vec![]))
-			} else { (None, None) };
+			let trace_info = tracer.prepare_trace_call(&params);
+			let mut trace_output = tracer.prepare_trace_output();
+			let mut subtracer = tracer.subtracer();
+			let delegate_call = params.code_address != params.address;
+			let gas = params.gas;
 
 			if params.code.is_some() {
 				// part of substate that may be reverted
-				let mut unconfirmed_substate = Substate::new(should_trace);
+				let mut unconfirmed_substate = Substate::new();
 
 				let res = {
-					self.exec_vm(params, &mut unconfirmed_substate, OutputPolicy::Return(output, trace_output.as_mut()))
+					self.exec_vm(params, &mut unconfirmed_substate, OutputPolicy::Return(output, trace_output.as_mut()), &mut subtracer)
 				};
 
 				trace!(target: "executive", "res={:?}", res);
 
-				// if there's tracing, make up trace_info's result with trace_output and some arithmetic.
-				if let Some((TraceAction::Call(ref mut c), _)) = trace_info {
-					c.result = res.as_ref().ok().map(|gas_left| TraceCallResult {
-						gas_used: c.gas - *gas_left,
-						output: trace_output.expect("trace_info is Some: qed")
-					});
-				}
+				let traces = subtracer.traces();
+				match res {
+					Ok(gas_left) => tracer.trace_call(
+						trace_info,
+						gas - gas_left,
+						trace_output,
+						self.depth,
+						traces,
+						delegate_call
+					),
+					_ => tracer.trace_failed_call(trace_info, self.depth, traces, delegate_call),
+				};
 
 				trace!(target: "executive", "substate={:?}; unconfirmed_substate={:?}\n", substate, unconfirmed_substate);
 
-				self.enact_result(&res, substate, unconfirmed_substate, trace_info);
+				self.enact_result(&res, substate, unconfirmed_substate);
 				trace!(target: "executive", "enacted: substate={:?}\n", substate);
 				res
 			} else {
 				// otherwise it's just a basic transaction, only do tracing, if necessary.
-				trace!(target: "executive", "Basic message (send funds) should_trace={}", should_trace);
 				self.state.clear_snapshot();
-				if let Some((TraceAction::Call(ref mut c), _)) = trace_info {
-					c.result = Some(TraceCallResult::default());// Some((x!(0), vec![]));
-				}
-				substate.accrue_trace(if should_trace {Some(vec![])} else {None}, trace_info);
+
+				tracer.trace_call(trace_info, U256::zero(), Some(vec![]), self.depth, vec![], delegate_call);
 				Ok(params.gas)
 			}
 		}
@@ -308,12 +314,13 @@ impl<'a> Executive<'a> {
 	/// Creates contract with given contract params.
 	/// NOTE. It does not finalize the transaction (doesn't do refunds, nor suicides).
 	/// Modifies the substate.
-	pub fn create(&mut self, params: ActionParams, substate: &mut Substate) -> evm::Result {
+	pub fn create<T>(&mut self, params: ActionParams, substate: &mut Substate, tracer: &mut T) -> evm::Result where T:
+		Tracer {
 		// backup used in case of running out of gas
 		self.state.snapshot();
 
 		// part of substate that may be reverted
-		let mut unconfirmed_substate = Substate::new(substate.subtraces.is_some());
+		let mut unconfirmed_substate = Substate::new();
 
 		// create contract and transfer value to it if necessary
 		let prev_bal = self.state.balance(&params.address);
@@ -324,30 +331,34 @@ impl<'a> Executive<'a> {
 			self.state.new_contract(&params.address, prev_bal);
 		}
 
-		let mut trace_info = substate.subtraces.as_ref().map(|_| (TraceAction::from_create(&params), self.depth));
-		let mut trace_output = trace_info.as_ref().map(|_| vec![]);
+		let trace_info = tracer.prepare_trace_create(&params);
+		let mut trace_output = tracer.prepare_trace_output();
+		let mut subtracer = tracer.subtracer();
+		let gas = params.gas;
 		let created = params.address.clone();
 
 		let res = {
-			self.exec_vm(params, &mut unconfirmed_substate, OutputPolicy::InitContract(trace_output.as_mut()))
+			self.exec_vm(params, &mut unconfirmed_substate, OutputPolicy::InitContract(trace_output.as_mut()), &mut subtracer)
 		};
 
-		if let Some((TraceAction::Create(ref mut c), _)) = trace_info {
-			c.result = res.as_ref().ok().map(|gas_left| TraceCreateResult {
-				gas_used: c.gas - *gas_left,
-				address: created,
-				code: trace_output.expect("trace_info is Some: qed")
-			});
-		}
+		match res {
+			Ok(gas_left) => tracer.trace_create(
+				trace_info,
+				gas - gas_left,
+				trace_output,
+				created,
+				self.depth,
+				subtracer.traces()
+			),
+			_ => tracer.trace_failed_create(trace_info, self.depth, subtracer.traces())
+		};
 
-		trace!(target: "executive", "trace_info={:?}", trace_info);
-
-		self.enact_result(&res, substate, unconfirmed_substate, trace_info);
+		self.enact_result(&res, substate, unconfirmed_substate);
 		res
 	}
 
 	/// Finalizes the transaction (does refunds and suicides).
-	fn finalize(&mut self, t: &SignedTransaction, substate: Substate, result: evm::Result, output: Bytes) -> ExecutionResult {
+	fn finalize(&mut self, t: &SignedTransaction, substate: Substate, result: evm::Result, output: Bytes, trace: Option<Trace>) -> ExecutionResult {
 		let schedule = self.engine.schedule(self.info);
 
 		// refunds from SSTORE nonzero -> zero
@@ -378,8 +389,6 @@ impl<'a> Executive<'a> {
 			self.state.kill_account(address);
 		}
 
-		let trace = substate.subtraces.and_then(|mut v| v.pop());
-
 		match result {
 			Err(evm::Error::Internal) => Err(ExecutionError::Internal),
 			Err(_) => {
@@ -409,19 +418,18 @@ impl<'a> Executive<'a> {
 		}
 	}
 
-	fn enact_result(&mut self, result: &evm::Result, substate: &mut Substate, un_substate: Substate, maybe_info: Option<(TraceAction, usize)>) {
+	fn enact_result(&mut self, result: &evm::Result, substate: &mut Substate, un_substate: Substate) {
 		match *result {
 			Err(evm::Error::OutOfGas)
 				| Err(evm::Error::BadJumpDestination {..})
 				| Err(evm::Error::BadInstruction {.. })
 				| Err(evm::Error::StackUnderflow {..})
 				| Err(evm::Error::OutOfStack {..}) => {
-				self.state.revert_snapshot();
-				substate.accrue_trace(un_substate.subtraces, maybe_info)
+					self.state.revert_snapshot();
 			},
 			Ok(_) | Err(evm::Error::Internal) => {
 				self.state.clear_snapshot();
-				substate.accrue(un_substate, maybe_info)
+				substate.accrue(un_substate);
 			}
 		}
 	}
@@ -459,11 +467,11 @@ mod tests {
 		state.add_balance(&sender, &U256::from(0x100u64));
 		let info = EnvInfo::default();
 		let engine = TestEngine::new(0, factory);
-		let mut substate = Substate::new(false);
+		let mut substate = Substate::new();
 
 		let gas_left = {
 			let mut ex = Executive::new(&mut state, &info, &engine);
-			ex.create(params, &mut substate).unwrap()
+			ex.create(params, &mut substate, &mut NoopTracer).unwrap()
 		};
 
 		assert_eq!(gas_left, U256::from(79_975));
@@ -518,11 +526,11 @@ mod tests {
 		state.add_balance(&sender, &U256::from(100));
 		let info = EnvInfo::default();
 		let engine = TestEngine::new(0, factory);
-		let mut substate = Substate::new(false);
+		let mut substate = Substate::new();
 
 		let gas_left = {
 			let mut ex = Executive::new(&mut state, &info, &engine);
-			ex.create(params, &mut substate).unwrap()
+			ex.create(params, &mut substate, &mut NoopTracer).unwrap()
 		};
 
 		assert_eq!(gas_left, U256::from(62_976));
@@ -573,16 +581,16 @@ mod tests {
 		state.add_balance(&sender, &U256::from(100));
 		let info = EnvInfo::default();
 		let engine = TestEngine::new(5, factory);
-		let mut substate = Substate::new(true);
+		let mut substate = Substate::new();
+		let mut tracer = ExecutiveTracer::default();
 
 		let gas_left = {
 			let mut ex = Executive::new(&mut state, &info, &engine);
 			let output = BytesRef::Fixed(&mut[0u8;0]);
-			ex.call(params, &mut substate, output).unwrap()
+			ex.call(params, &mut substate, output, &mut tracer).unwrap()
 		};
 
-		println!("trace: {:?}", substate.subtraces);
-		let expected_trace = Some(vec![ Trace {
+		let expected_trace = vec![ Trace {
 			depth: 0,
 			action: TraceAction::Call(TraceCall {
 				from: x!("cd1722f3947def4cf144679da39c4c32bdc35681"),
@@ -590,10 +598,10 @@ mod tests {
 				value: x!(100),
 				gas: x!(100000),
 				input: vec![],
-				result: Some(TraceCallResult {
-					gas_used: U256::from(55_248),
-					output: vec![],
-				})
+			}),
+			result: TraceResult::Call(TraceCallResult {
+				gas_used: U256::from(55_248),
+				output: vec![],
 			}),
 			subs: vec![Trace {
 				depth: 1,
@@ -601,17 +609,17 @@ mod tests {
 					from: x!("b010143a42d5980c7e5ef0e4a4416dc098a4fed3"),
 					value: x!(23),
 					gas: x!(67979),
-					init: vec![96, 16, 128, 96, 12, 96, 0, 57, 96, 0, 243, 0, 96, 0, 53, 84, 21, 96, 9, 87, 0, 91, 96, 32, 53, 96, 0, 53, 85],
-					result: Some(TraceCreateResult {
-						gas_used: U256::from(3224),
-						address: Address::from_str("c6d80f262ae5e0f164e5fde365044d7ada2bfa34").unwrap(),
-						code: vec![96, 0, 53, 84, 21, 96, 9, 87, 0, 91, 96, 32, 53, 96, 0, 53]
-					})
+					init: vec![96, 16, 128, 96, 12, 96, 0, 57, 96, 0, 243, 0, 96, 0, 53, 84, 21, 96, 9, 87, 0, 91, 96, 32, 53, 96, 0, 53, 85]
+				}),
+				result: TraceResult::Create(TraceCreateResult {
+					gas_used: U256::from(3224),
+					address: Address::from_str("c6d80f262ae5e0f164e5fde365044d7ada2bfa34").unwrap(),
+					code: vec![96, 0, 53, 84, 21, 96, 9, 87, 0, 91, 96, 32, 53, 96, 0, 53]
 				}),
 				subs: vec![]
 			}]
-		} ]);
-		assert_eq!(substate.subtraces, expected_trace);
+		}];
+		assert_eq!(tracer.traces(), expected_trace);
 		assert_eq!(gas_left, U256::from(44_752));
 	}
 
@@ -645,30 +653,31 @@ mod tests {
 		state.add_balance(&sender, &U256::from(100));
 		let info = EnvInfo::default();
 		let engine = TestEngine::new(5, factory);
-		let mut substate = Substate::new(true);
+		let mut substate = Substate::new();
+		let mut tracer = ExecutiveTracer::default();
 
 		let gas_left = {
 			let mut ex = Executive::new(&mut state, &info, &engine);
-			ex.create(params.clone(), &mut substate).unwrap()
+			ex.create(params.clone(), &mut substate, &mut tracer).unwrap()
 		};
 
-		println!("trace: {:?}", substate.subtraces);
-		let expected_trace = Some(vec![Trace {
+		let expected_trace = vec![Trace {
 			depth: 0,
 			action: TraceAction::Create(TraceCreate {
 				from: params.sender,
 				value: x!(100),
 				gas: params.gas,
 				init: vec![96, 16, 128, 96, 12, 96, 0, 57, 96, 0, 243, 0, 96, 0, 53, 84, 21, 96, 9, 87, 0, 91, 96, 32, 53, 96, 0, 53, 85],
-				result: Some(TraceCreateResult {
-					gas_used: U256::from(3224),
-					address: params.address,
-					code: vec![96, 0, 53, 84, 21, 96, 9, 87, 0, 91, 96, 32, 53, 96, 0, 53]
-				})
+			}),
+			result: TraceResult::Create(TraceCreateResult {
+				gas_used: U256::from(3224),
+				address: params.address,
+				code: vec![96, 0, 53, 84, 21, 96, 9, 87, 0, 91, 96, 32, 53, 96, 0, 53]
 			}),
 			subs: vec![]
-		} ]);
-		assert_eq!(substate.subtraces, expected_trace);
+		}];
+
+		assert_eq!(tracer.traces(), expected_trace);
 		assert_eq!(gas_left, U256::from(96_776));
 	}
 
@@ -714,11 +723,11 @@ mod tests {
 		state.add_balance(&sender, &U256::from(100));
 		let info = EnvInfo::default();
 		let engine = TestEngine::new(0, factory);
-		let mut substate = Substate::new(false);
+		let mut substate = Substate::new();
 
 		let gas_left = {
 			let mut ex = Executive::new(&mut state, &info, &engine);
-			ex.create(params, &mut substate).unwrap()
+			ex.create(params, &mut substate, &mut NoopTracer).unwrap()
 		};
 
 		assert_eq!(gas_left, U256::from(62_976));
@@ -766,11 +775,11 @@ mod tests {
 		state.add_balance(&sender, &U256::from(100));
 		let info = EnvInfo::default();
 		let engine = TestEngine::new(1024, factory);
-		let mut substate = Substate::new(false);
+		let mut substate = Substate::new();
 
 		{
 			let mut ex = Executive::new(&mut state, &info, &engine);
-			ex.create(params, &mut substate).unwrap();
+			ex.create(params, &mut substate, &mut NoopTracer).unwrap();
 		}
 
 		assert_eq!(substate.contracts_created.len(), 1);
@@ -827,11 +836,11 @@ mod tests {
 
 		let info = EnvInfo::default();
 		let engine = TestEngine::new(0, factory);
-		let mut substate = Substate::new(false);
+		let mut substate = Substate::new();
 
 		let gas_left = {
 			let mut ex = Executive::new(&mut state, &info, &engine);
-			ex.call(params, &mut substate, BytesRef::Fixed(&mut [])).unwrap()
+			ex.call(params, &mut substate, BytesRef::Fixed(&mut []), &mut NoopTracer).unwrap()
 		};
 
 		assert_eq!(gas_left, U256::from(73_237));
@@ -872,11 +881,11 @@ mod tests {
 		state.init_code(&address, code.clone());
 		let info = EnvInfo::default();
 		let engine = TestEngine::new(0, factory);
-		let mut substate = Substate::new(false);
+		let mut substate = Substate::new();
 
 		let gas_left = {
 			let mut ex = Executive::new(&mut state, &info, &engine);
-			ex.call(params, &mut substate, BytesRef::Fixed(&mut [])).unwrap()
+			ex.call(params, &mut substate, BytesRef::Fixed(&mut []), &mut NoopTracer).unwrap()
 		};
 
 		assert_eq!(gas_left, U256::from(59_870));
@@ -1074,11 +1083,11 @@ mod tests {
 		state.add_balance(&sender, &U256::from_str("152d02c7e14af6800000").unwrap());
 		let info = EnvInfo::default();
 		let engine = TestEngine::new(0, factory);
-		let mut substate = Substate::new(false);
+		let mut substate = Substate::new();
 
 		let result = {
 			let mut ex = Executive::new(&mut state, &info, &engine);
-			ex.create(params, &mut substate)
+			ex.create(params, &mut substate, &mut NoopTracer)
 		};
 
 		match result {

--- a/ethcore/src/json_tests/executive.rs
+++ b/ethcore/src/json_tests/executive.rs
@@ -76,13 +76,13 @@ impl From<ethjson::vm::Call> for CallCreate {
 
 /// Tiny wrapper around executive externalities.
 /// Stores callcreates.
-struct TestExt<'a> {
-	ext: Externalities<'a>,
+struct TestExt<'a, T> where T: 'a + Tracer {
+	ext: Externalities<'a, T>,
 	callcreates: Vec<CallCreate>,
 	contract_address: Address
 }
 
-impl<'a> TestExt<'a> {
+impl<'a, T> TestExt<'a, T> where T: 'a + Tracer {
 	fn new(state: &'a mut State,
 			   info: &'a EnvInfo,
 			   engine: &'a Engine,
@@ -90,16 +90,17 @@ impl<'a> TestExt<'a> {
 			   origin_info: OriginInfo,
 			   substate: &'a mut Substate,
 			   output: OutputPolicy<'a, 'a>,
-			   address: Address) -> Self {
+			   address: Address,
+			   tracer: &'a mut T) -> Self {
 		TestExt {
 			contract_address: contract_address(&address, &state.nonce(&address)),
-			ext: Externalities::new(state, info, engine, depth, origin_info, substate, output),
+			ext: Externalities::new(state, info, engine, depth, origin_info, substate, output, tracer),
 			callcreates: vec![]
 		}
 	}
 }
 
-impl<'a> Ext for TestExt<'a> {
+impl<'a, T> Ext for TestExt<'a, T> where T: Tracer {
 	fn storage_at(&self, key: &H256) -> H256 {
 		self.ext.storage_at(key)
 	}
@@ -209,7 +210,8 @@ fn do_json_test_for(vm_type: &VMType, json_data: &[u8]) -> Vec<String> {
 		let engine = TestEngineFrontier::new(1, vm_type.clone());
 		let params = ActionParams::from(vm.transaction);
 
-		let mut substate = Substate::new(false);
+		let mut substate = Substate::new();
+		let mut tracer = NoopTracer;
 		let mut output = vec![];
 
 		// execute
@@ -222,7 +224,8 @@ fn do_json_test_for(vm_type: &VMType, json_data: &[u8]) -> Vec<String> {
 				OriginInfo::from(&params),
 				&mut substate,
 				OutputPolicy::Return(BytesRef::Flexible(&mut output), None),
-				params.address.clone()
+				params.address.clone(),
+				&mut tracer,
 			);
 			let evm = engine.vm_factory().create();
 			let res = evm.exec(params, &mut ex);

--- a/ethcore/src/state.rs
+++ b/ethcore/src/state.rs
@@ -398,11 +398,11 @@ fn should_apply_create_transaction() {
 			value: x!(100),
 			gas: x!(77412),
 			init: vec![96, 16, 128, 96, 12, 96, 0, 57, 96, 0, 243, 0, 96, 0, 53, 84, 21, 96, 9, 87, 0, 91, 96, 32, 53, 96, 0, 53, 85],
-			result: Some(TraceCreateResult {
-				gas_used: U256::from(3224),
-				address: Address::from_str("8988167e088c87cd314df6d3c2b83da5acb93ace").unwrap(),
-				code: vec![96, 0, 53, 84, 21, 96, 9, 87, 0, 91, 96, 32, 53, 96, 0, 53]
-			})
+		}),
+		result: TraceResult::Create(TraceCreateResult {
+			gas_used: U256::from(3224),
+			address: Address::from_str("8988167e088c87cd314df6d3c2b83da5acb93ace").unwrap(),
+			code: vec![96, 0, 53, 84, 21, 96, 9, 87, 0, 91, 96, 32, 53, 96, 0, 53]
 		}),
 		subs: vec![]
 	});
@@ -458,8 +458,8 @@ fn should_trace_failed_create_transaction() {
 			value: x!(100),
 			gas: x!(78792),
 			init: vec![91, 96, 0, 86],
-			result: None
 		}),
+		result: TraceResult::FailedCreate,
 		subs: vec![]
 	});
 
@@ -497,10 +497,10 @@ fn should_trace_call_transaction() {
 			value: x!(100),
 			gas: x!(79000),
 			input: vec![],
-			result: Some(TraceCallResult {
-				gas_used: U256::from(3),
-				output: vec![]
-			})
+		}),
+		result: TraceResult::Call(TraceCallResult {
+			gas_used: U256::from(3),
+			output: vec![]
 		}),
 		subs: vec![]
 	});
@@ -538,10 +538,10 @@ fn should_trace_basic_call_transaction() {
 			value: x!(100),
 			gas: x!(79000),
 			input: vec![],
-			result: Some(TraceCallResult {
-				gas_used: U256::from(0),
-				output: vec![]
-			})
+		}),
+		result: TraceResult::Call(TraceCallResult {
+			gas_used: U256::from(0),
+			output: vec![]
 		}),
 		subs: vec![]
 	});
@@ -605,10 +605,10 @@ fn should_not_trace_subcall_transaction_to_builtin() {
 			value: x!(0),
 			gas: x!(79000),
 			input: vec![],
-			result: Some(TraceCallResult {
-				gas_used: U256::from(28_061),
-				output: vec![]
-			})
+		}),
+		result: TraceResult::Call(TraceCallResult {
+			gas_used: U256::from(28_061),
+			output: vec![]
 		}),
 		subs: vec![]
 	});
@@ -647,10 +647,10 @@ fn should_not_trace_callcode() {
 			value: x!(0),
 			gas: x!(79000),
 			input: vec![],
-			result: Some(TraceCallResult {
-				gas_used: U256::from(64),
-				output: vec![]
-			})
+		}),
+		result: TraceResult::Call(TraceCallResult {
+			gas_used: U256::from(64),
+			output: vec![]
 		}),
 		subs: vec![]
 	});
@@ -692,10 +692,10 @@ fn should_not_trace_delegatecall() {
 			value: x!(0),
 			gas: x!(79000),
 			input: vec![],
-			result: Some(TraceCallResult {
-				gas_used: U256::from(61),
-				output: vec![]
-			})
+		}),
+		result: TraceResult::Call(TraceCallResult {
+			gas_used: U256::from(61),
+			output: vec![]
 		}),
 		subs: vec![]
 	});
@@ -733,8 +733,8 @@ fn should_trace_failed_call_transaction() {
 			value: x!(100),
 			gas: x!(79000),
 			input: vec![],
-			result: None
 		}),
+		result: TraceResult::FailedCall,
 		subs: vec![]
 	});
 
@@ -775,10 +775,10 @@ fn should_trace_call_with_subcall_transaction() {
 			value: x!(100),
 			gas: x!(79000),
 			input: vec![],
-			result: Some(TraceCallResult {
-				gas_used: U256::from(69),
-				output: vec![]
-			})
+		}),
+		result: TraceResult::Call(TraceCallResult {
+			gas_used: U256::from(69),
+			output: vec![]
 		}),
 		subs: vec![Trace {
 			depth: 1,
@@ -788,10 +788,10 @@ fn should_trace_call_with_subcall_transaction() {
 				value: x!(0),
 				gas: x!(78934),
 				input: vec![],
-				result: Some(TraceCallResult {
-					gas_used: U256::from(3),
-					output: vec![]
-				})
+			}),
+			result: TraceResult::Call(TraceCallResult {
+				gas_used: U256::from(3),
+				output: vec![]
 			}),
 			subs: vec![]
 		}]
@@ -831,10 +831,10 @@ fn should_trace_call_with_basic_subcall_transaction() {
 			value: x!(100),
 			gas: x!(79000),
 			input: vec![],
-			result: Some(TraceCallResult {
-				gas_used: U256::from(31761),
-				output: vec![]
-			})
+		}),
+		result: TraceResult::Call(TraceCallResult {
+			gas_used: U256::from(31761),
+			output: vec![]
 		}),
 		subs: vec![Trace {
 			depth: 1,
@@ -844,8 +844,8 @@ fn should_trace_call_with_basic_subcall_transaction() {
 				value: x!(69),
 				gas: x!(2300),
 				input: vec![],
-				result: Some(TraceCallResult::default())
 			}),
+			result: TraceResult::Call(TraceCallResult::default()),
 			subs: vec![]
 		}]
 	});
@@ -884,10 +884,10 @@ fn should_not_trace_call_with_invalid_basic_subcall_transaction() {
 			value: x!(100),
 			gas: x!(79000),
 			input: vec![],
-			result: Some(TraceCallResult {
-				gas_used: U256::from(31761),
-				output: vec![]
-			})
+		}),
+		result: TraceResult::Call(TraceCallResult {
+			gas_used: U256::from(31761),
+			output: vec![]
 		}),
 		subs: vec![]
 	});
@@ -927,12 +927,10 @@ fn should_trace_failed_subcall_transaction() {
 			value: x!(100),
 			gas: x!(79000),
 			input: vec![],
-			result: Some(TraceCallResult {
-				gas_used: U256::from(79_000),
-				output: vec![]
-			})
-
-			//	Some((x!(79000), vec![]))
+		}),
+		result: TraceResult::Call(TraceCallResult {
+			gas_used: U256::from(79_000),
+			output: vec![]
 		}),
 		subs: vec![Trace {
 			depth: 1,
@@ -942,8 +940,8 @@ fn should_trace_failed_subcall_transaction() {
 				value: x!(0),
 				gas: x!(78934),
 				input: vec![],
-				result: None
 			}),
+			result: TraceResult::FailedCall,
 			subs: vec![]
 		}]
 	});
@@ -984,10 +982,10 @@ fn should_trace_call_with_subcall_with_subcall_transaction() {
 			value: x!(100),
 			gas: x!(79000),
 			input: vec![],
-			result: Some(TraceCallResult {
-				gas_used: U256::from(135),
-				output: vec![]
-			})
+		}),
+		result: TraceResult::Call(TraceCallResult {
+			gas_used: U256::from(135),
+			output: vec![]
 		}),
 		subs: vec![Trace {
 			depth: 1,
@@ -997,10 +995,10 @@ fn should_trace_call_with_subcall_with_subcall_transaction() {
 				value: x!(0),
 				gas: x!(78934),
 				input: vec![],
-				result: Some(TraceCallResult {
-					gas_used: U256::from(69),
-					output: vec![]
-				})
+			}),
+			result: TraceResult::Call(TraceCallResult {
+				gas_used: U256::from(69),
+				output: vec![]
 			}),
 			subs: vec![Trace {
 				depth: 2,
@@ -1010,10 +1008,10 @@ fn should_trace_call_with_subcall_with_subcall_transaction() {
 					value: x!(0),
 					gas: x!(78868),
 					input: vec![],
-					result: Some(TraceCallResult {
-						gas_used: U256::from(3),
-						output: vec![]
-					})
+				}),
+				result: TraceResult::Call(TraceCallResult {
+					gas_used: U256::from(3),
+					output: vec![]
 				}),
 				subs: vec![]
 			}]
@@ -1056,10 +1054,10 @@ fn should_trace_failed_subcall_with_subcall_transaction() {
 			value: x!(100),
 			gas: x!(79000),
 			input: vec![],
-			result: Some(TraceCallResult {
-				gas_used: U256::from(79_000),
-				output: vec![]
-			})
+		}),
+		result: TraceResult::Call(TraceCallResult {
+			gas_used: U256::from(79_000),
+			output: vec![]
 		}),
 		subs: vec![Trace {
 			depth: 1,
@@ -1069,8 +1067,8 @@ fn should_trace_failed_subcall_with_subcall_transaction() {
 				value: x!(0),
 				gas: x!(78934),
 				input: vec![],
-				result: None
 			}),
+			result: TraceResult::FailedCall,
 			subs: vec![Trace {
 				depth: 2,
 				action: TraceAction::Call(TraceCall {
@@ -1079,10 +1077,10 @@ fn should_trace_failed_subcall_with_subcall_transaction() {
 					value: x!(0),
 					gas: x!(78868),
 					input: vec![],
-					result: Some(TraceCallResult {
-						gas_used: U256::from(3),
-						output: vec![]
-					})
+				}),
+				result: TraceResult::Call(TraceCallResult {
+					gas_used: U256::from(3),
+					output: vec![]
 				}),
 				subs: vec![]
 			}]

--- a/ethcore/src/state.rs
+++ b/ethcore/src/state.rs
@@ -398,7 +398,11 @@ fn should_apply_create_transaction() {
 			value: x!(100),
 			gas: x!(77412),
 			init: vec![96, 16, 128, 96, 12, 96, 0, 57, 96, 0, 243, 0, 96, 0, 53, 84, 21, 96, 9, 87, 0, 91, 96, 32, 53, 96, 0, 53, 85],
-			result: Some((x!(3224), x!("8988167e088c87cd314df6d3c2b83da5acb93ace"), vec![96, 0, 53, 84, 21, 96, 9, 87, 0, 91, 96, 32, 53, 96, 0, 53]))
+			result: Some(TraceCreateResult {
+				gas_used: U256::from(3224),
+				address: Address::from_str("8988167e088c87cd314df6d3c2b83da5acb93ace").unwrap(),
+				code: vec![96, 0, 53, 84, 21, 96, 9, 87, 0, 91, 96, 32, 53, 96, 0, 53]
+			})
 		}),
 		subs: vec![]
 	});
@@ -493,7 +497,10 @@ fn should_trace_call_transaction() {
 			value: x!(100),
 			gas: x!(79000),
 			input: vec![],
-			result: Some((x!(3), vec![]))
+			result: Some(TraceCallResult {
+				gas_used: U256::from(3),
+				output: vec![]
+			})
 		}),
 		subs: vec![]
 	});
@@ -531,7 +538,10 @@ fn should_trace_basic_call_transaction() {
 			value: x!(100),
 			gas: x!(79000),
 			input: vec![],
-			result: Some((x!(0), vec![]))
+			result: Some(TraceCallResult {
+				gas_used: U256::from(0),
+				output: vec![]
+			})
 		}),
 		subs: vec![]
 	});
@@ -595,7 +605,10 @@ fn should_not_trace_subcall_transaction_to_builtin() {
 			value: x!(0),
 			gas: x!(79000),
 			input: vec![],
-			result: Some((x!(28061), vec![]))
+			result: Some(TraceCallResult {
+				gas_used: U256::from(28_061),
+				output: vec![]
+			})
 		}),
 		subs: vec![]
 	});
@@ -634,7 +647,10 @@ fn should_not_trace_callcode() {
 			value: x!(0),
 			gas: x!(79000),
 			input: vec![],
-			result: Some((x!(64), vec![]))
+			result: Some(TraceCallResult {
+				gas_used: U256::from(64),
+				output: vec![]
+			})
 		}),
 		subs: vec![]
 	});
@@ -676,7 +692,10 @@ fn should_not_trace_delegatecall() {
 			value: x!(0),
 			gas: x!(79000),
 			input: vec![],
-			result: Some((x!(61), vec![]))
+			result: Some(TraceCallResult {
+				gas_used: U256::from(61),
+				output: vec![]
+			})
 		}),
 		subs: vec![]
 	});
@@ -756,7 +775,10 @@ fn should_trace_call_with_subcall_transaction() {
 			value: x!(100),
 			gas: x!(79000),
 			input: vec![],
-			result: Some((x!(69), vec![]))
+			result: Some(TraceCallResult {
+				gas_used: U256::from(69),
+				output: vec![]
+			})
 		}),
 		subs: vec![Trace {
 			depth: 1,
@@ -766,7 +788,10 @@ fn should_trace_call_with_subcall_transaction() {
 				value: x!(0),
 				gas: x!(78934),
 				input: vec![],
-				result: Some((x!(3), vec![]))
+				result: Some(TraceCallResult {
+					gas_used: U256::from(3),
+					output: vec![]
+				})
 			}),
 			subs: vec![]
 		}]
@@ -806,7 +831,10 @@ fn should_trace_call_with_basic_subcall_transaction() {
 			value: x!(100),
 			gas: x!(79000),
 			input: vec![],
-			result: Some((x!(31761), vec![]))
+			result: Some(TraceCallResult {
+				gas_used: U256::from(31761),
+				output: vec![]
+			})
 		}),
 		subs: vec![Trace {
 			depth: 1,
@@ -816,7 +844,7 @@ fn should_trace_call_with_basic_subcall_transaction() {
 				value: x!(69),
 				gas: x!(2300),
 				input: vec![],
-				result: Some((x!(0), vec![]))
+				result: Some(TraceCallResult::default())
 			}),
 			subs: vec![]
 		}]
@@ -856,7 +884,10 @@ fn should_not_trace_call_with_invalid_basic_subcall_transaction() {
 			value: x!(100),
 			gas: x!(79000),
 			input: vec![],
-			result: Some((x!(31761), vec![]))
+			result: Some(TraceCallResult {
+				gas_used: U256::from(31761),
+				output: vec![]
+			})
 		}),
 		subs: vec![]
 	});
@@ -896,7 +927,12 @@ fn should_trace_failed_subcall_transaction() {
 			value: x!(100),
 			gas: x!(79000),
 			input: vec![],
-			result: Some((x!(79000), vec![]))
+			result: Some(TraceCallResult {
+				gas_used: U256::from(79_000),
+				output: vec![]
+			})
+
+			//	Some((x!(79000), vec![]))
 		}),
 		subs: vec![Trace {
 			depth: 1,
@@ -948,7 +984,10 @@ fn should_trace_call_with_subcall_with_subcall_transaction() {
 			value: x!(100),
 			gas: x!(79000),
 			input: vec![],
-			result: Some((x!(135), vec![]))
+			result: Some(TraceCallResult {
+				gas_used: U256::from(135),
+				output: vec![]
+			})
 		}),
 		subs: vec![Trace {
 			depth: 1,
@@ -958,7 +997,10 @@ fn should_trace_call_with_subcall_with_subcall_transaction() {
 				value: x!(0),
 				gas: x!(78934),
 				input: vec![],
-				result: Some((x!(69), vec![]))
+				result: Some(TraceCallResult {
+					gas_used: U256::from(69),
+					output: vec![]
+				})
 			}),
 			subs: vec![Trace {
 				depth: 2,
@@ -968,7 +1010,10 @@ fn should_trace_call_with_subcall_with_subcall_transaction() {
 					value: x!(0),
 					gas: x!(78868),
 					input: vec![],
-					result: Some((x!(3), vec![]))
+					result: Some(TraceCallResult {
+						gas_used: U256::from(3),
+						output: vec![]
+					})
 				}),
 				subs: vec![]
 			}]
@@ -1011,7 +1056,10 @@ fn should_trace_failed_subcall_with_subcall_transaction() {
 			value: x!(100),
 			gas: x!(79000),
 			input: vec![],
-			result: Some((x!(79000), vec![]))
+			result: Some(TraceCallResult {
+				gas_used: U256::from(79_000),
+				output: vec![]
+			})
 		}),
 		subs: vec![Trace {
 			depth: 1,
@@ -1031,7 +1079,10 @@ fn should_trace_failed_subcall_with_subcall_transaction() {
 					value: x!(0),
 					gas: x!(78868),
 					input: vec![],
-					result: Some((x!(3), vec![])),
+					result: Some(TraceCallResult {
+						gas_used: U256::from(3),
+						output: vec![]
+					})
 				}),
 				subs: vec![]
 			}]

--- a/ethcore/src/trace/mod.rs
+++ b/ethcore/src/trace/mod.rs
@@ -1,0 +1,21 @@
+// Copyright 2015, 2016 Ethcore (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Tracing
+
+mod trace;
+
+pub use self::trace::*;

--- a/ethcore/src/trace/mod.rs
+++ b/ethcore/src/trace/mod.rs
@@ -19,3 +19,181 @@
 mod trace;
 
 pub use self::trace::*;
+use util::bytes::Bytes;
+use util::hash::Address;
+use util::numbers::U256;
+use action_params::ActionParams;
+
+/// This trait is used by executive to build traces.
+pub trait Tracer: Send {
+	/// Prepares call trace for given params. Noop tracer should return None.
+	fn prepare_trace_call(&self, params: &ActionParams) -> Option<TraceCall>;
+
+	/// Prepares create trace for given params. Noop tracer should return None.
+	fn prepare_trace_create(&self, params: &ActionParams) -> Option<TraceCreate>;
+
+	/// Prepare trace output. Noop tracer should return None.
+	fn prepare_trace_output(&self) -> Option<Bytes>;
+
+	/// Stores trace call info.
+	fn trace_call(
+		&mut self,
+		call: Option<TraceCall>,
+		gas_used: U256,
+		output: Option<Bytes>,
+		depth: usize,
+		subs: Vec<Trace>,
+		delegate_call: bool
+	);
+
+	/// Stores trace create info.
+	fn trace_create(
+		&mut self,
+		create: Option<TraceCreate>,
+		gas_used: U256,
+		code: Option<Bytes>,
+		address: Address,
+		depth: usize,
+		subs: Vec<Trace>
+	);
+
+	/// Stores failed call trace.
+	fn trace_failed_call(&mut self, call: Option<TraceCall>, depth: usize, subs: Vec<Trace>, delegate_call: bool);
+
+	/// Stores failed create trace.
+	fn trace_failed_create(&mut self, create: Option<TraceCreate>, depth: usize, subs: Vec<Trace>);
+
+	/// Spawn subracer which will be used to trace deeper levels of execution.
+	fn subtracer(&self) -> Self where Self: Sized;
+
+	/// Consumes self and returns all traces.
+	fn traces(self) -> Vec<Trace>;
+}
+
+/// Nonoperative tracer. Does not trace anything.
+pub struct NoopTracer;
+
+impl Tracer for NoopTracer {
+	fn prepare_trace_call(&self, _: &ActionParams) -> Option<TraceCall> {
+		None
+	}
+
+	fn prepare_trace_create(&self, _: &ActionParams) -> Option<TraceCreate> {
+		None
+	}
+
+	fn prepare_trace_output(&self) -> Option<Bytes> {
+		None
+	}
+
+	fn trace_call(&mut self, call: Option<TraceCall>, _: U256, output: Option<Bytes>, _: usize, _: Vec<Trace>,
+				  _: bool) {
+		assert!(call.is_none());
+		assert!(output.is_none());
+	}
+
+	fn trace_create(&mut self, create: Option<TraceCreate>, _: U256, code: Option<Bytes>, _: Address, _: usize, _: Vec<Trace>) {
+		assert!(create.is_none());
+		assert!(code.is_none());
+	}
+
+	fn trace_failed_call(&mut self, call: Option<TraceCall>, _: usize, _: Vec<Trace>, _: bool) {
+		assert!(call.is_none());
+	}
+
+	fn trace_failed_create(&mut self, create: Option<TraceCreate>, _: usize, _: Vec<Trace>) {
+		assert!(create.is_none());
+	}
+
+	fn subtracer(&self) -> Self {
+		NoopTracer
+	}
+
+	fn traces(self) -> Vec<Trace> {
+		vec![]
+	}
+}
+
+/// Simple executive tracer. Traces all calls and creates. Ignores delegatecalls.
+#[derive(Default)]
+pub struct ExecutiveTracer {
+	traces: Vec<Trace>
+}
+
+impl Tracer for ExecutiveTracer {
+	fn prepare_trace_call(&self, params: &ActionParams) -> Option<TraceCall> {
+		Some(TraceCall::from(params.clone()))
+	}
+
+	fn prepare_trace_create(&self, params: &ActionParams) -> Option<TraceCreate> {
+		Some(TraceCreate::from(params.clone()))
+	}
+
+	fn prepare_trace_output(&self) -> Option<Bytes> {
+		Some(vec![])
+	}
+
+	fn trace_call(&mut self, call: Option<TraceCall>, gas_used: U256, output: Option<Bytes>, depth: usize, subs:
+				  Vec<Trace>, delegate_call: bool) {
+		if delegate_call {
+			return;
+		}
+
+		let trace = Trace {
+			depth: depth,
+			subs: subs,
+			action: TraceAction::Call(call.expect("Trace call expected to be Some.")),
+			result: TraceResult::Call(TraceCallResult {
+				gas_used: gas_used,
+				output: output.expect("Trace call output expected to be Some.")
+			})
+		};
+		self.traces.push(trace);
+	}
+
+	fn trace_create(&mut self, create: Option<TraceCreate>, gas_used: U256, code: Option<Bytes>, address: Address, depth: usize, subs: Vec<Trace>) {
+		let trace = Trace {
+			depth: depth,
+			subs: subs,
+			action: TraceAction::Create(create.expect("Trace create expected to be Some.")),
+			result: TraceResult::Create(TraceCreateResult {
+				gas_used: gas_used,
+				code: code.expect("Trace create code expected to be Some."),
+				address: address
+			})
+		};
+		self.traces.push(trace);
+	}
+
+	fn trace_failed_call(&mut self, call: Option<TraceCall>, depth: usize, subs: Vec<Trace>, delegate_call: bool) {
+		if delegate_call {
+			return;
+		}
+
+		let trace = Trace {
+			depth: depth,
+			subs: subs,
+			action: TraceAction::Call(call.expect("Trace call expected to be Some.")),
+			result: TraceResult::FailedCall,
+		};
+		self.traces.push(trace);
+	}
+
+	fn trace_failed_create(&mut self, create: Option<TraceCreate>, depth: usize, subs: Vec<Trace>) {
+		let trace = Trace {
+			depth: depth,
+			subs: subs,
+			action: TraceAction::Create(create.expect("Trace create expected to be Some.")),
+			result: TraceResult::FailedCreate,
+		};
+		self.traces.push(trace);
+	}
+
+	fn subtracer(&self) -> Self {
+		ExecutiveTracer::default()
+	}
+
+	fn traces(self) -> Vec<Trace> {
+		self.traces
+	}
+}

--- a/ethcore/src/trace/mod.rs
+++ b/ethcore/src/trace/mod.rs
@@ -135,6 +135,7 @@ impl Tracer for ExecutiveTracer {
 
 	fn trace_call(&mut self, call: Option<TraceCall>, gas_used: U256, output: Option<Bytes>, depth: usize, subs:
 				  Vec<Trace>, delegate_call: bool) {
+		// don't trace if it's DELEGATECALL or CALLCODE.
 		if delegate_call {
 			return;
 		}
@@ -166,6 +167,7 @@ impl Tracer for ExecutiveTracer {
 	}
 
 	fn trace_failed_call(&mut self, call: Option<TraceCall>, depth: usize, subs: Vec<Trace>, delegate_call: bool) {
+		// don't trace if it's DELEGATECALL or CALLCODE.
 		if delegate_call {
 			return;
 		}

--- a/ethcore/src/trace/trace.rs
+++ b/ethcore/src/trace/trace.rs
@@ -17,6 +17,26 @@
 //! Tracing datatypes.
 use common::*;
 
+/// TraceCall result.
+#[derive(Debug, Clone, PartialEq, Default)]
+pub struct TraceCallResult {
+	/// Gas used by call.
+	pub gas_used: U256,
+	/// Call Output.
+	pub output: Bytes,
+}
+
+/// TraceCreate result.
+#[derive(Debug, Clone, PartialEq)]
+pub struct TraceCreateResult {
+	/// Gas used by create.
+	pub gas_used: U256,
+	/// Code of the newly created contract.
+	pub code: Bytes,
+	/// Address of the newly created contract.
+	pub address: Address,
+}
+
 /// Description of a _call_ action, either a `CALL` operation or a message transction.
 #[derive(Debug, Clone, PartialEq)]
 pub struct TraceCall {
@@ -31,7 +51,7 @@ pub struct TraceCall {
 	/// The input data provided to the call.
 	pub input: Bytes,
 	/// The result of the operation; the gas used and the output data of the call.
-	pub result: Option<(U256, Bytes)>,
+	pub result: Option<TraceCallResult>,
 }
 
 /// Description of a _create_ action, either a `CREATE` operation or a create transction.
@@ -47,15 +67,12 @@ pub struct TraceCreate {
 	pub init: Bytes,
 	/// The result of the operation; tuple of the gas used, the address of the newly created account and its code.
 	/// NOTE: Presently failed operations are not reported so this will always be `Some`.
-	pub result: Option<(U256, Address, Bytes)>,
-//	pub output: Bytes,
+	pub result: Option<TraceCreateResult>,
 }
 
 /// Description of an action that we trace; will be either a call or a create.
 #[derive(Debug, Clone, PartialEq)]
 pub enum TraceAction {
-	/// Action isn't yet known.
-	Unknown,
 	/// It's a call action.
 	Call(TraceCall),
 	/// It's a create action.
@@ -72,16 +89,6 @@ pub struct Trace {
 	pub action: TraceAction,
 	/// The sub traces for each interior action performed as part of this call.
 	pub subs: Vec<Trace>,
-}
-
-impl Default for Trace {
-	fn default() -> Trace {
-		Trace {
-			depth: 0,
-			action: TraceAction::Unknown,
-			subs: vec![],
-		}
-	}
 }
 
 impl TraceAction {


### PR DESCRIPTION
- moved tracing logic to `Tracer` trait implementations
- moved `result` field from `TraceAction` variants to `Trace`
- named fields of the `result`
- removed `TraceAction::Unknown` variant
- reduced code complexity by reducing number of `if` / `if let` statements and moving tracing logic to tracer

// this pr is prelude to db tracing module (more to come tomorrow)