### PR TITLE
Removed unused crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -243,7 +243,6 @@ dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
- "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/ethcore/Cargo.toml
+++ b/ethcore/Cargo.toml
@@ -9,7 +9,6 @@ authors = ["Ethcore <admin@ethcore.io>"]
 [dependencies]
 log = "0.3"
 env_logger = "0.3"
-rustc-serialize = "0.3"
 heapsize = "0.3"
 rust-crypto = "0.2.34"
 time = "0.1"

--- a/ethcore/src/env_info.rs
+++ b/ethcore/src/env_info.rs
@@ -72,8 +72,6 @@ impl From<ethjson::vm::Env> for EnvInfo {
 
 #[cfg(test)]
 mod tests {
-	extern crate rustc_serialize;
-
 	use super::*;
 	use util::hash::*;
 	use util::numbers::U256;

--- a/ethcore/src/lib.rs
+++ b/ethcore/src/lib.rs
@@ -76,7 +76,6 @@
 #[macro_use] extern crate log;
 #[macro_use] extern crate ethcore_util as util;
 #[macro_use] extern crate lazy_static;
-extern crate rustc_serialize;
 #[macro_use] extern crate heapsize;
 extern crate crypto;
 extern crate time;


### PR DESCRIPTION
rustc-serialize is no longer needed in `ethcore`.