### PR TITLE
Pruning auto

### DIFF
--- a/util/src/journaldb/archivedb.rs
+++ b/util/src/journaldb/archivedb.rs
@@ -41,7 +41,7 @@ pub struct ArchiveDB {
 // all keys must be at least 12 bytes
 const LATEST_ERA_KEY : [u8; 12] = [ b'l', b'a', b's', b't', 0, 0, 0, 0, 0, 0, 0, 0 ];
 const VERSION_KEY : [u8; 12] = [ b'j', b'v', b'e', b'r', 0, 0, 0, 0, 0, 0, 0, 0 ];
-const DB_VERSION : u32 = 259;
+const DB_VERSION : u32 = 0x103;
 
 impl ArchiveDB {
 	/// Create a new instance from file
@@ -55,7 +55,7 @@ impl ArchiveDB {
 		if !backing.is_empty() {
 			match backing.get(&VERSION_KEY).map(|d| d.map(|v| decode::<u32>(&v))) {
 				Ok(Some(DB_VERSION)) => {},
-				v => panic!("Incompatible DB version, expected {}, got {:?}", DB_VERSION, v)
+				v => panic!("Incompatible DB version, expected {}, got {:?}; to resolve, remove {} and restart.", DB_VERSION, v, path)
 			}
 		} else {
 			backing.put(&VERSION_KEY, &encode(&DB_VERSION)).expect("Error writing version to database");
@@ -168,7 +168,7 @@ impl JournalDB for ArchiveDB {
 		Ok((inserts + deletes) as u32)
 	}
 
-	fn latest_era() -> Option<u64> { self.latest_era }
+	fn latest_era(&self) -> Option<u64> { self.latest_era }
 
 	fn state(&self, id: &H256) -> Option<Bytes> {
 		self.backing.get_by_prefix(&id.bytes()[0..12]).and_then(|b| Some(b.to_vec()))

--- a/util/src/journaldb/archivedb.rs
+++ b/util/src/journaldb/archivedb.rs
@@ -168,6 +168,8 @@ impl JournalDB for ArchiveDB {
 		Ok((inserts + deletes) as u32)
 	}
 
+	fn latest_era() -> Option<u64> { self.latest_era }
+
 	fn state(&self, id: &H256) -> Option<Bytes> {
 		self.backing.get_by_prefix(&id.bytes()[0..12]).and_then(|b| Some(b.to_vec()))
 	}

--- a/util/src/journaldb/earlymergedb.rs
+++ b/util/src/journaldb/earlymergedb.rs
@@ -70,7 +70,7 @@ pub struct EarlyMergeDB {
 // all keys must be at least 12 bytes
 const LATEST_ERA_KEY : [u8; 12] = [ b'l', b'a', b's', b't', 0, 0, 0, 0, 0, 0, 0, 0 ];
 const VERSION_KEY : [u8; 12] = [ b'j', b'v', b'e', b'r', 0, 0, 0, 0, 0, 0, 0, 0 ];
-const DB_VERSION : u32 = 3;
+const DB_VERSION : u32 = 0x003;
 const PADDING : [u8; 10] = [ 0u8; 10 ];
 
 impl EarlyMergeDB {
@@ -85,7 +85,7 @@ impl EarlyMergeDB {
 		if !backing.is_empty() {
 			match backing.get(&VERSION_KEY).map(|d| d.map(|v| decode::<u32>(&v))) {
 				Ok(Some(DB_VERSION)) => {},
-				v => panic!("Incompatible DB version, expected {}, got {:?}", DB_VERSION, v)
+				v => panic!("Incompatible DB version, expected {}, got {:?}; to resolve, remove {} and restart.", DB_VERSION, v, path)
 			}
 		} else {
 			backing.put(&VERSION_KEY, &encode(&DB_VERSION)).expect("Error writing version to database");
@@ -333,7 +333,7 @@ impl JournalDB for EarlyMergeDB {
 		self.backing.get(&LATEST_ERA_KEY).expect("Low level database error").is_none()
 	}
 
-	fn latest_era() -> Option<u64> { self.latest_era }
+	fn latest_era(&self) -> Option<u64> { self.latest_era }
 
 	fn mem_used(&self) -> usize {
 		self.overlay.mem_used() + match self.refs {
@@ -341,7 +341,6 @@ impl JournalDB for EarlyMergeDB {
 			None => 0
 		}
  	}
-
 
 	#[cfg_attr(feature="dev", allow(cyclomatic_complexity))]
 	fn commit(&mut self, now: u64, id: &H256, end: Option<(u64, H256)>) -> Result<u32, UtilError> {

--- a/util/src/journaldb/earlymergedb.rs
+++ b/util/src/journaldb/earlymergedb.rs
@@ -333,6 +333,8 @@ impl JournalDB for EarlyMergeDB {
 		self.backing.get(&LATEST_ERA_KEY).expect("Low level database error").is_none()
 	}
 
+	fn latest_era() -> Option<u64> { self.latest_era }
+
 	fn mem_used(&self) -> usize {
 		self.overlay.mem_used() + match self.refs {
 			Some(ref c) => c.read().unwrap().heap_size_of_children(),

--- a/util/src/journaldb/mod.rs
+++ b/util/src/journaldb/mod.rs
@@ -29,7 +29,7 @@ mod refcounteddb;
 pub use self::traits::JournalDB;
 
 /// A journal database algorithm.
-#[derive(Debug)]
+#[derive(Debug, Clone, Copy)]
 pub enum Algorithm {
 	/// Keep all keys forever.
 	Archive,

--- a/util/src/journaldb/overlayrecentdb.rs
+++ b/util/src/journaldb/overlayrecentdb.rs
@@ -213,6 +213,8 @@ impl JournalDB for OverlayRecentDB {
 		self.backing.get(&LATEST_ERA_KEY).expect("Low level database error").is_none()
 	}
 
+	fn latest_era() -> Option<u64> { self.latest_era }
+
 	fn commit(&mut self, now: u64, id: &H256, end: Option<(u64, H256)>) -> Result<u32, UtilError> {
 		// record new commit's details.
 		trace!("commit: #{} ({}), end era: {:?}", now, id, end);

--- a/util/src/journaldb/refcounteddb.rs
+++ b/util/src/journaldb/refcounteddb.rs
@@ -42,7 +42,7 @@ pub struct RefCountedDB {
 
 const LATEST_ERA_KEY : [u8; 12] = [ b'l', b'a', b's', b't', 0, 0, 0, 0, 0, 0, 0, 0 ];
 const VERSION_KEY : [u8; 12] = [ b'j', b'v', b'e', b'r', 0, 0, 0, 0, 0, 0, 0, 0 ];
-const DB_VERSION : u32 = 512;
+const DB_VERSION : u32 = 0x200;
 const PADDING : [u8; 10] = [ 0u8; 10 ];
 
 impl RefCountedDB {
@@ -57,7 +57,7 @@ impl RefCountedDB {
 		if !backing.is_empty() {
 			match backing.get(&VERSION_KEY).map(|d| d.map(|v| decode::<u32>(&v))) {
 				Ok(Some(DB_VERSION)) => {},
-				v => panic!("Incompatible DB version, expected {}, got {:?}", DB_VERSION, v)
+				v => panic!("Incompatible DB version, expected {}, got {:?}; to resolve, remove {} and restart.", DB_VERSION, v, path)
 			}
 		} else {
 			backing.put(&VERSION_KEY, &encode(&DB_VERSION)).expect("Error writing version to database");
@@ -112,7 +112,7 @@ impl JournalDB for RefCountedDB {
 		self.latest_era.is_none()
 	}
 
-	fn latest_era() -> Option<u64> { self.latest_era }
+	fn latest_era(&self) -> Option<u64> { self.latest_era }
 
 	fn commit(&mut self, now: u64, id: &H256, end: Option<(u64, H256)>) -> Result<u32, UtilError> {
 		// journal format:

--- a/util/src/journaldb/traits.rs
+++ b/util/src/journaldb/traits.rs
@@ -31,6 +31,9 @@ pub trait JournalDB : HashDB + Send + Sync {
 	/// Check if this database has any commits
 	fn is_empty(&self) -> bool;
 
+	/// Get the latest era in the DB. None if there isn't yet any data in there.
+	fn latest_era() -> Option<u64> { self.latest_era }
+
 	/// Commit all recent insert operations and canonical historical commits' removals from the
 	/// old era to the backing database, reverting any non-canonical historical commit's inserts.
 	fn commit(&mut self, now: u64, id: &H256, end: Option<(u64, H256)>) -> Result<u32, UtilError>;

--- a/util/src/journaldb/traits.rs
+++ b/util/src/journaldb/traits.rs
@@ -32,7 +32,7 @@ pub trait JournalDB : HashDB + Send + Sync {
 	fn is_empty(&self) -> bool;
 
 	/// Get the latest era in the DB. None if there isn't yet any data in there.
-	fn latest_era() -> Option<u64> { self.latest_era }
+	fn latest_era(&self) -> Option<u64>;
 
 	/// Commit all recent insert operations and canonical historical commits' removals from the
 	/// old era to the backing database, reverting any non-canonical historical commit's inserts.


### PR DESCRIPTION
fixes #762.

some minor refactoring to pull out useful code to create DB paths.

we could really do with a reorg of where we store our DBs to make the code simpler. really, the location of the state DB should be looked after in the journaldb module, not client.rs & main.rs. that's for the future, though.
