### PR TITLE
IPC RPC codegen for generic implementation

### DIFF
--- a/ipc/codegen/src/typegen.rs
+++ b/ipc/codegen/src/typegen.rs
@@ -36,6 +36,10 @@ fn is_new_entry(path: &Path) -> Option<String> {
 			false
 		} else {
 			let ident = format!("{}", path.segments[0].identifier.name.as_str());
+			ident == "u8"        ||
+			ident == "i8"        ||
+			ident == "u16"       ||
+			ident == "i16"       ||
 			ident == "u32"       ||
 			ident == "u64"       ||
 			ident == "usize"     ||
@@ -199,12 +203,14 @@ pub fn match_unknown_tys(
 				}
 			},
 			TyKind::Path(_, ref path) => {
-				if path.segments.len() > 0 && path.segments[0].identifier.name.as_str() == "Option" ||
-					path.segments[0].identifier.name.as_str() == "Result" {
-					for extra_type in path.segments[0].parameters.types() {
-						if !stop_list.contains(extra_type) {
-							fringe.push(extra_type);
-						}
+				if path.segments.len() > 0 && {
+					let first_segment = path.segments[0].identifier.name.as_str();
+					first_segment == "Option" || first_segment  == "Result" || first_segment == "Vec"
+				}
+				{
+					let extra_type = &path.segments[0].parameters.types()[0];
+					if !stop_list.contains(extra_type) {
+						fringe.push(extra_type);
 					}
 					continue;
 				}

--- a/ipc/tests/build.rs
+++ b/ipc/tests/build.rs
@@ -26,6 +26,24 @@ pub fn main() {
 
 	// ipc pass
 	{
+		let src = Path::new("nested.rs.in");
+		let dst = Path::new(&out_dir).join("nested_ipc.rs");
+		let mut registry = syntex::Registry::new();
+		codegen::register(&mut registry);
+		registry.expand("", &src, &dst).unwrap();
+	}
+
+	// serde pass
+	{
+		let src = Path::new(&out_dir).join("nested_ipc.rs");
+		let dst = Path::new(&out_dir).join("nested_cg.rs");
+		let mut registry = syntex::Registry::new();
+		serde_codegen::register(&mut registry);
+		registry.expand("", &src, &dst).unwrap();
+	}
+
+	// ipc pass
+	{
 		let src = Path::new("service.rs.in");
 		let dst = Path::new(&out_dir).join("service_ipc.rs");
 		let mut registry = syntex::Registry::new();
@@ -41,4 +59,5 @@ pub fn main() {
 		serde_codegen::register(&mut registry);
 		registry.expand("", &src, &dst).unwrap();
 	}
+
 }

--- a/ipc/tests/examples.rs
+++ b/ipc/tests/examples.rs
@@ -18,6 +18,7 @@
 mod tests {
 
 	use super::super::service::*;
+	use super::super::nested::DBClient;
 	use ipc::*;
 	use devtools::*;
 	use semver::Version;
@@ -120,5 +121,26 @@ mod tests {
 			11, 0, 0, 0, 0, 0, 0, 0],
 			service_client.socket().borrow().write_buffer.clone());
 		assert_eq!(true, result);
+	}
+
+	#[test]
+	fn can_invoke_generic_service() {
+		let mut socket = TestSocket::new();
+		socket.read_buffer = vec![0, 0, 0, 0];
+		let db_client = DBClient::<u64, _>::init(socket);
+
+		let result = db_client.write(vec![0u8; 100]);
+
+		assert!(result.is_ok());
+	}
+	#[test]
+	fn can_handshake_generic_service() {
+		let mut socket = TestSocket::new();
+		socket.read_buffer = vec![1];
+		let db_client = DBClient::<u64, _>::init(socket);
+
+		let result = db_client.handshake();
+
+		assert!(result.is_ok());
 	}
 }

--- a/ipc/tests/nested.rs
+++ b/ipc/tests/nested.rs
@@ -14,18 +14,4 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-#![allow(dead_code)]
-
-extern crate bincode;
-extern crate ethcore_ipc as ipc;
-extern crate serde;
-extern crate ethcore_devtools as devtools;
-extern crate semver;
-extern crate nanomsg;
-extern crate ethcore_ipc_nano as nanoipc;
-extern crate ethcore_util as util;
-
-pub mod service;
-mod examples;
-mod over_nano;
-mod nested;
+include!(concat!(env!("OUT_DIR"), "/nested_cg.rs"));

--- a/ipc/tests/nested.rs.in
+++ b/ipc/tests/nested.rs.in
@@ -14,18 +14,31 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-#![allow(dead_code)]
+use std::sync::RwLock;
+use std::ops::*;
+use ipc::IpcConfig;
 
-extern crate bincode;
-extern crate ethcore_ipc as ipc;
-extern crate serde;
-extern crate ethcore_devtools as devtools;
-extern crate semver;
-extern crate nanomsg;
-extern crate ethcore_ipc_nano as nanoipc;
-extern crate ethcore_util as util;
+pub struct DB<L: Sized> {
+	pub writes: RwLock<u64>,
+	pub reads: RwLock<u64>,
+	pub holdings: L,
+}
 
-pub mod service;
-mod examples;
-mod over_nano;
-mod nested;
+trait DBWriter {
+	fn write(&self, data: Vec<u8>)  -> Result<(), DBError>;
+}
+
+impl<L: Sized> IpcConfig for DB<L> {}
+
+#[derive(Serialize, Deserialize)]
+pub enum DBError { Write, Read }
+
+#[derive(Ipc)]
+impl<L: Sized> DBWriter for DB<L> {
+	fn write(&self, data: Vec<u8>) -> Result<(), DBError> {
+		let mut writes = self.writes.write().unwrap();
+		*writes = *writes + data.len() as u64;
+		Ok(())
+	}
+}
+


### PR DESCRIPTION
another cryptic AST code to allow such things:

```
#[derive(Ipc)]
impl<L: Sized> DBWriter for DB<L> {
	fn write(&self, data: Vec<u8>) -> Result<(), DBError> {
		let mut writes = self.writes.write().unwrap();
		*writes = *writes + data.len() as u64;
		Ok(())
	}
}
```