### PR TITLE
IPC RPC codegen extra feature

### DIFF
--- a/ipc/tests/examples.rs
+++ b/ipc/tests/examples.rs
@@ -18,7 +18,7 @@
 mod tests {
 
 	use super::super::service::*;
-	use super::super::nested::DBClient;
+	use super::super::nested::{DBClient,DBWriter};
 	use ipc::*;
 	use devtools::*;
 	use semver::Version;

--- a/ipc/tests/nested.rs.in
+++ b/ipc/tests/nested.rs.in
@@ -24,7 +24,7 @@ pub struct DB<L: Sized> {
 	pub holdings: L,
 }
 
-trait DBWriter {
+pub trait DBWriter {
 	fn write(&self, data: Vec<u8>)  -> Result<(), DBError>;
 }
 


### PR DESCRIPTION
allows to reuse client side objects with the same traits as original objects

so if 
```
#[derive(Ipc)]
impl<L: Sized> DBWriter for DB<L> {
    fn write(&self, data: Vec<u8>) -> Result<(), DBError> {
        let mut writes = self.writes.write().unwrap();
        *writes = *writes + data.len() as u64;
        Ok(())
    }
}
```

generated object `DBClient` will implement `DBWriter` trait as well