### PR TITLE
refactored blockchain extras keys building

### DIFF
--- a/ethcore/src/blockchain/blockchain.rs
+++ b/ethcore/src/blockchain/blockchain.rs
@@ -30,6 +30,7 @@ use blockchain::bloom_indexer::BloomIndexer;
 use blockchain::tree_route::TreeRoute;
 use blockchain::update::ExtrasUpdate;
 use blockchain::{CacheSize, ImportRoute};
+use db::{Writable, Readable, Key};
 
 const BLOOM_INDEX_SIZE: usize = 16;
 const BLOOM_LEVELS: u8 = 3;
@@ -314,8 +315,8 @@ impl BlockChain {
 				bc.blocks_db.put(&hash, genesis).unwrap();
 
 				let batch = DBTransaction::new();
-				batch.put_extras(&hash, &details);
-				batch.put_extras(&header.number(), &hash);
+				batch.write(&hash, &details);
+				batch.write(&header.number(), &hash);
 				batch.put(b"best", &hash).unwrap();
 				bc.extras_db.write(batch).unwrap();
 
@@ -467,7 +468,7 @@ impl BlockChain {
 		{
 			let mut write_details = self.block_details.write().unwrap();
 			for (hash, details) in update.block_details.into_iter() {
-				batch.put_extras(&hash, &details);
+				batch.write(&hash, &details);
 				self.note_used(CacheID::Extras(ExtrasIndex::BlockDetails, hash.clone()));
 				write_details.insert(hash, details);
 			}
@@ -476,7 +477,7 @@ impl BlockChain {
 		{
 			let mut write_receipts = self.block_receipts.write().unwrap();
 			for (hash, receipt) in &update.block_receipts {
-				batch.put_extras(hash, receipt);
+				batch.write(hash, receipt);
 				write_receipts.remove(hash);
 			}
 		}
@@ -484,7 +485,7 @@ impl BlockChain {
 		{
 			let mut write_blocks_blooms = self.blocks_blooms.write().unwrap();
 			for (bloom_hash, blocks_bloom) in &update.blocks_blooms {
-				batch.put_extras(bloom_hash, blocks_bloom);
+				batch.write(bloom_hash, blocks_bloom);
 				write_blocks_blooms.remove(bloom_hash);
 			}
 		}
@@ -508,12 +509,12 @@ impl BlockChain {
 			}
 
 			for (number, hash) in &update.block_hashes {
-				batch.put_extras(number, hash);
+				batch.write(number, hash);
 				write_hashes.remove(number);
 			}
 
 			for (hash, tx_address) in &update.transactions_addresses {
-				batch.put_extras(hash, tx_address);
+				batch.write(hash, tx_address);
 				write_txs.remove(hash);
 			}
 
@@ -747,8 +748,9 @@ impl BlockChain {
 	}
 
 	fn query_extras<K, T>(&self, hash: &K, cache: &RwLock<HashMap<K, T>>) -> Option<T> where
-		T: Clone + Decodable + ExtrasIndexable,
-		K: ExtrasSliceConvertable + Eq + Hash + Clone {
+		T: ExtrasIndexable + Clone + Decodable,
+		K: Key<T> + Eq + Hash + Clone,
+		H256: From<K> {
 		{
 			let read = cache.read().unwrap();
 			if let Some(v) = read.get(hash) {
@@ -756,11 +758,9 @@ impl BlockChain {
 			}
 		}
 
-		if let Some(h) = hash.as_h256() {
-			self.note_used(CacheID::Extras(T::extras_index(), h.clone()));
-		}
+		self.note_used(CacheID::Extras(T::index(), H256::from(hash.clone())));
 
-		self.extras_db.get_extras(hash).map(| t: T | {
+		self.extras_db.read(hash).map(|t: T| {
 			let mut write = cache.write().unwrap();
 			write.insert(hash.clone(), t.clone());
 			t
@@ -768,8 +768,7 @@ impl BlockChain {
 	}
 
 	fn query_extras_exist<K, T>(&self, hash: &K, cache: &RwLock<HashMap<K, T>>) -> bool where
-		K: ExtrasSliceConvertable + Eq + Hash + Clone,
-		T: ExtrasIndexable {
+		K: Key<T> + Eq + Hash + Clone {
 		{
 			let read = cache.read().unwrap();
 			if let Some(_) = read.get(hash) {
@@ -777,7 +776,7 @@ impl BlockChain {
 			}
 		}
 
-		self.extras_db.extras_exists::<_, T>(hash)
+		self.extras_db.exists::<T>(hash)
 	}
 
 	/// Get current cache size.

--- a/ethcore/src/db.rs
+++ b/ethcore/src/db.rs
@@ -1,0 +1,61 @@
+// Copyright 2015, 2016 Ethcore (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Extras db utils.
+
+use util::{H264, DBTransaction, Database};
+use util::rlp::{encode, Encodable, decode, Decodable};
+
+/// Should be used to get database key associated with given value.
+pub trait Key<T> {
+	/// Returns db key.
+	fn key(&self) -> H264;
+}
+
+/// Should be used to write value into database.
+pub trait Writable {
+	/// Writes key into database.
+	fn write<T>(&self, key: &Key<T>, value: &T) where T: Encodable;
+}
+
+/// Should be used to read values from database.
+pub trait Readable {
+	/// Returns value for given key.
+	fn read<T>(&self, key: &Key<T>) -> Option<T> where T: Decodable;
+	/// Returns true if given value exists.
+	fn exists<T>(&self, key: &Key<T>) -> bool;
+}
+
+impl Writable for DBTransaction {
+	fn write<T>(&self, key: &Key<T>, value: &T) where T: Encodable {
+		self.put(&key.key(), &encode(value))
+			.expect("db put failed");
+	}
+}
+
+impl Readable for Database {
+	fn read<T>(&self, key: &Key<T>) -> Option<T> where T: Decodable {
+		self.get(&key.key())
+			.expect("db get failed")
+			.map(|v| decode(&v))
+	}
+
+	fn exists<T>(&self, key: &Key<T>) -> bool {
+		self.get(&key.key())
+			.expect("db get failed")
+			.is_some()
+	}
+}

--- a/ethcore/src/db.rs
+++ b/ethcore/src/db.rs
@@ -41,21 +41,33 @@ pub trait Readable {
 
 impl Writable for DBTransaction {
 	fn write<T>(&self, key: &Key<T>, value: &T) where T: Encodable {
-		self.put(&key.key(), &encode(value))
-			.expect("db put failed");
+		let result = self.put(&key.key(), &encode(value));
+		if let Err(err) = result {
+			panic!("db put failed, key: {:?}, err: {:?}", key.key(), err);
+		}
 	}
 }
 
 impl Readable for Database {
 	fn read<T>(&self, key: &Key<T>) -> Option<T> where T: Decodable {
-		self.get(&key.key())
-			.expect("db get failed")
-			.map(|v| decode(&v))
+		let result = self.get(&key.key());
+
+		match result {
+			Ok(option) => option.map(|v| decode(&v)),
+			Err(err) => {
+				panic!("db get failed, key: {:?}, err: {:?}", key.key(), err);
+			}
+		}
 	}
 
 	fn exists<T>(&self, key: &Key<T>) -> bool {
-		self.get(&key.key())
-			.expect("db get failed")
-			.is_some()
+		let result = self.get(&key.key());
+
+		match result {
+			Ok(v) => v.is_some(),
+			Err(err) => {
+				panic!("db get failed, key: {:?}, err: {:?}", key.key(), err);
+			}
+		}
 	}
 }

--- a/ethcore/src/lib.rs
+++ b/ethcore/src/lib.rs
@@ -104,6 +104,7 @@ pub mod views;
 pub mod receipt;
 pub mod pod_state;
 
+mod db;
 mod common;
 mod basic_types;
 #[macro_use] mod evm;


### PR DESCRIPTION
changes:
- simplified interface for writing and reading extras from database (less template params and traits)
- inserted values are no longer tied to specific `ExtrasIndex`.
- writing and reading can be now reused in fatdb module