### PR TITLE
Auto (with codegen) binary serializer 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -237,11 +237,15 @@ dependencies = [
 name = "ethcore"
 version = "1.1.0"
 dependencies = [
+ "bincode 0.5.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "clippy 0.0.63 (registry+https://github.com/rust-lang/crates.io-index)",
  "crossbeam 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethash 1.1.0",
  "ethcore-devtools 1.1.0",
+ "ethcore-ipc 1.1.0",
+ "ethcore-ipc-codegen 1.1.0",
+ "ethcore-ipc-nano 1.1.0",
  "ethcore-util 1.1.0",
  "ethjson 0.1.0",
  "heapsize 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -250,6 +254,10 @@ dependencies = [
  "num_cpus 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "rust-crypto 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "semver 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_codegen 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntex 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/ipc/codegen/src/codegen.rs
+++ b/ipc/codegen/src/codegen.rs
@@ -298,14 +298,14 @@ fn implement_dispatch_arms(
 		.map(|dispatch| { index = index + 1; implement_dispatch_arm(cx, builder, index as u32, dispatch, buffer, replacements) }).collect()
 }
 
-fn strip_ptr(ty: &P<ast::Ty>) -> P<ast::Ty> {
+pub fn strip_ptr(ty: &P<ast::Ty>) -> P<ast::Ty> {
 	if let ast::TyKind::Rptr(_, ref ptr_mut) = ty.node {
 		ptr_mut.ty.clone()
 	}
 	else { ty.clone() }
 }
 
-fn has_ptr(ty: &P<ast::Ty>) -> bool {
+pub fn has_ptr(ty: &P<ast::Ty>) -> bool {
 	if let ast::TyKind::Rptr(_, ref ptr_mut) = ty.node {
 		true
 	}

--- a/ipc/codegen/src/codegen.rs
+++ b/ipc/codegen/src/codegen.rs
@@ -305,7 +305,7 @@ pub fn strip_ptr(ty: &P<ast::Ty>) -> P<ast::Ty> {
 	else { ty.clone() }
 }
 
-fn has_ptr(ty: &P<ast::Ty>) -> bool {
+pub fn has_ptr(ty: &P<ast::Ty>) -> bool {
 	if let ast::TyKind::Rptr(_, ref _ptr_mut) = ty.node {
 		true
 	}

--- a/ipc/codegen/src/lib.rs
+++ b/ipc/codegen/src/lib.rs
@@ -54,6 +54,7 @@ pub fn register(reg: &mut syntex::Registry) {
 	reg.add_attr("feature(custom_attribute)");
 
 	reg.add_decorator("derive_Ipc", codegen::expand_ipc_implementation);
+	reg.add_decorator("derive_Binary", serialization::expand_serialization_implementation);
 }
 
 #[cfg(not(feature = "with-syntex"))]
@@ -62,4 +63,8 @@ pub fn register(reg: &mut rustc_plugin::Registry) {
 		syntax::parse::token::intern("derive_Ipc"),
 		syntax::ext::base::MultiDecorator(
 			Box::new(codegen::expand_ipc_implementation)));
+	reg.register_syntax_extension(
+		syntax::parse::token::intern("derive_Binary"),
+		syntax::ext::base::MultiDecorator(
+			Box::new(serialization::expand_serialization_implementation)));
 }

--- a/ipc/codegen/src/serialization.rs
+++ b/ipc/codegen/src/serialization.rs
@@ -1,0 +1,202 @@
+// Copyright 2015, 2016 Ethcore (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+use aster;
+
+use syntax::ast::{
+	MetaItem,
+	Item,
+	ImplItemKind,
+	ImplItem,
+	MethodSig,
+	Arg,
+	PatKind,
+	FunctionRetTy,
+	Ty,
+	TraitRef,
+	Ident,
+	Generics,
+};
+
+use syntax::ast;
+use syntax::codemap::Span;
+use syntax::ext::base::{Annotatable, ExtCtxt};
+use syntax::ext::build::AstBuilder;
+use syntax::ptr::P;
+
+pub struct Error;
+
+pub fn expand_serialization_implementation(
+	cx: &mut ExtCtxt,
+	span: Span,
+	meta_item: &MetaItem,
+	annotatable: &Annotatable,
+	push: &mut FnMut(Annotatable)
+) {
+	let item = match *annotatable {
+		Annotatable::Item(ref item) => item,
+		_ => {
+			cx.span_err(meta_item.span, "`#[derive(Binary)]` may only be applied to structs and enums");
+			return;
+		}
+	};
+
+	let builder = aster::AstBuilder::new().span(span);
+
+    let impl_item = match serialize_item(cx, &builder, &item) {
+        Ok(item) => item,
+        Err(Error) => {
+            // An error occured, but it should have been reported already.
+            return;
+        }
+    };
+
+    push(Annotatable::Item(impl_item))
+}
+
+fn serialize_item(
+    cx: &ExtCtxt,
+    builder: &aster::AstBuilder,
+    item: &Item,
+) -> Result<P<ast::Item>, Error> {
+	let generics = match item.node {
+		ast::ItemKind::Struct(_, ref generics) => generics,
+		ast::ItemKind::Enum(_, ref generics) => generics,
+		_ => {
+			cx.span_err(
+				item.span,
+				"`#[derive(Serialize)]` may only be applied to structs and enums");
+			return Err(Error);
+		}
+	};
+
+	let impl_generics = build_impl_generics(cx, builder, item, generics);
+
+	let ty = builder.ty().path()
+		.segment(item.ident).with_generics(impl_generics.clone()).build()
+		.build();
+
+	let where_clause = &impl_generics.where_clause;
+
+	let binary_expressions = try!(binary_expr(cx,
+		&builder,
+		&item,
+		&impl_generics,
+		ty.clone()));
+
+	Ok(quote_item!(cx,
+		impl $impl_generics ::ipc::BinaryConvertable for $ty $where_clause {
+			fn size(&self) -> usize {
+				$size_expr
+			}
+
+			fn to_bytes(buffer: &mut [u8]) {
+				$write_expr
+			}
+
+			fn from_bytes(buffer: &[u8]) -> Self {
+				$create_expr
+			}
+        }
+    ).unwrap())
+}
+
+fn binary_expr(
+    cx: &ExtCtxt,
+    builder: &aster::AstBuilder,
+    item: &Item,
+    impl_generics: &ast::Generics,
+    ty: P<ast::Ty>,
+) -> Result<BinaryExpressions, Error> {
+	match item.node {
+		ast::ItemKind::Struct(ref variant_data, _) => {
+			binary_expr_struct(
+				cx,
+				builder,
+				impl_generics,
+				ty,
+				item.span,
+				variant_data,
+			)
+		}
+		ast::ItemKind::Enum(ref enum_def, _) => {
+			binary_expr_enum(
+				cx,
+				builder,
+				item.ident,
+				impl_generics,
+				ty,
+				enum_def,
+			)
+		}
+		_ => {
+			cx.span_bug(item.span,
+						"expected ItemStruct or ItemEnum in #[derive(Serialize)]");
+		}
+	}
+}
+
+struct BinaryExpressions {
+	size: P<ast::Expr>,
+	write: P<ast::Stmt>,
+	read: P<ast::Expr>,
+}
+
+fn serialize_tuple_struct(
+	cx: &ExtCtxt,
+	builder: &aster::AstBuilder,
+	impl_generics: &ast::Generics,
+	ty: P<ast::Ty>,
+	fields: usize,
+) -> Result<P<ast::Expr>, Error> {
+    let type_name = field.ty;
+	let id = field.id;
+
+    Ok(BinaryExpressions {
+		size: quote_expr!(cx, self. $id .size() ),
+		write: quote_stmt!(cx, self. $id .write(buffer); ),
+		read: quote_expr!(cx, Self { $id: $type_name ::from_bytes(buffer) }),
+	});
+}
+
+fn binary_expr_struct(
+	cx: &ExtCtxt,
+	builder: &aster::AstBuilder,
+	impl_generics: &ast::Generics,
+	ty: P<ast::Ty>,
+	span: Span,
+	variant_data: &ast::VariantData,
+) -> Result<BinaryExpressions, Error> {
+	match *variant_data {
+		ast::VariantData::Tuple(ref fields, _) => {
+			binary_expr_struct_tuple(
+				cx,
+				&builder,
+				impl_generics,
+				ty,
+				fields,
+			)
+		}
+		ast::VariantData::Struct(ref fields, _) => {
+			binary_expr_struct_inner(
+				cx,
+				&builder,
+				impl_generics,
+				ty,
+				fields,
+			)
+		}
+	}
+}

--- a/ipc/codegen/src/serialization.rs
+++ b/ipc/codegen/src/serialization.rs
@@ -159,7 +159,7 @@ fn binary_expr_struct(
 	cx: &ExtCtxt,
 	builder: &aster::AstBuilder,
 	ty: P<ast::Ty>,
-    fields: &[ast::StructField],
+	fields: &[ast::StructField],
 	value_ident: Option<ast::Ident>,
 	instance_ident: Option<ast::Ident>,
 ) -> Result<BinaryExpressions, Error> {

--- a/ipc/codegen/src/serialization.rs
+++ b/ipc/codegen/src/serialization.rs
@@ -48,15 +48,15 @@ pub fn expand_serialization_implementation(
 
 	let builder = aster::AstBuilder::new().span(span);
 
-    let impl_item = match serialize_item(cx, &builder, &item) {
-        Ok(item) => item,
-        Err(Error) => {
-            // An error occured, but it should have been reported already.
-            return;
-        }
-    };
+	let impl_item = match serialize_item(cx, &builder, &item) {
+		Ok(item) => item,
+		Err(Error) => {
+			// An error occured, but it should have been reported already.
+			return;
+		}
+	};
 
-    push(Annotatable::Item(impl_item))
+	push(Annotatable::Item(impl_item))
 }
 
 fn serialize_item(

--- a/ipc/codegen/src/serialization.rs
+++ b/ipc/codegen/src/serialization.rs
@@ -111,6 +111,7 @@ fn serialize_item(
     ).unwrap())
 }
 
+#[allow(unreachable_code)]
 fn binary_expr(
     cx: &ExtCtxt,
     builder: &aster::AstBuilder,
@@ -128,7 +129,7 @@ fn binary_expr(
 				item.span,
 				variant_data,
 			)
-		}
+		},
 		ast::ItemKind::Enum(ref enum_def, _) => {
 			binary_expr_enum(
 				cx,
@@ -139,7 +140,7 @@ fn binary_expr(
 				item.span,
 				enum_def,
 			)
-		}
+		},
 		_ => {
 			cx.span_bug(item.span,
 						"expected ItemStruct or ItemEnum in #[derive(Binary)]");
@@ -255,10 +256,11 @@ fn binary_expr_struct(
 	})
 }
 
+#[allow(unreachable_code)]
 fn binary_expr_item_struct(
 	cx: &ExtCtxt,
 	builder: &aster::AstBuilder,
-	impl_generics: &ast::Generics,
+	_impl_generics: &ast::Generics,
 	ty: P<ast::Ty>,
 	span: Span,
 	variant_data: &ast::VariantData,

--- a/ipc/codegen/src/serialization.rs
+++ b/ipc/codegen/src/serialization.rs
@@ -113,11 +113,11 @@ fn serialize_item(
 
 #[allow(unreachable_code)]
 fn binary_expr(
-    cx: &ExtCtxt,
-    builder: &aster::AstBuilder,
-    item: &Item,
-    impl_generics: &ast::Generics,
-    ty: P<ast::Ty>,
+	cx: &ExtCtxt,
+	builder: &aster::AstBuilder,
+	item: &Item,
+	impl_generics: &ast::Generics,
+	ty: P<ast::Ty>,
 ) -> Result<BinaryExpressions, Error> {
 	match item.node {
 		ast::ItemKind::Struct(ref variant_data, _) => {

--- a/ipc/codegen/src/serialization.rs
+++ b/ipc/codegen/src/serialization.rs
@@ -43,7 +43,7 @@ pub fn expand_serialization_implementation(
 		_ => {
 			cx.span_err(meta_item.span, "`#[derive(Binary)]` may only be applied to structs and enums");
 			return;
-		}
+		},
 	};
 
 	let builder = aster::AstBuilder::new().span(span);
@@ -53,7 +53,7 @@ pub fn expand_serialization_implementation(
 		Err(Error) => {
 			// An error occured, but it should have been reported already.
 			return;
-		}
+		},
 	};
 
 	push(Annotatable::Item(impl_item))
@@ -72,7 +72,7 @@ fn serialize_item(
 				item.span,
 				"`#[derive(Binary)]` may only be applied to structs and enums");
 			return Err(Error);
-		}
+		},
 	};
 
 	let ty = builder.ty().path()
@@ -145,7 +145,7 @@ fn binary_expr(
 			cx.span_bug(item.span,
 						"expected ItemStruct or ItemEnum in #[derive(Binary)]");
 			Err(Error)
-		}
+		},
 	}
 }
 
@@ -174,12 +174,12 @@ fn binary_expr_struct(
 				Some(quote_expr!(cx,
 					match $field_type_ident::len_params() {
 						0 => mem::size_of::<$field_type_ident>(),
-						_ => $x. $field_id .size()
+						_ => $x. $field_id .size(),
 					}))
 			})
 			.unwrap_or_else(|| quote_expr!(cx, match $field_type_ident::len_params() {
 				0 => mem::size_of::<$field_type_ident>(),
-				_ => $index_ident .size()
+				_ => $index_ident .size(),
 			}))
 	}).collect();
 
@@ -210,12 +210,12 @@ fn binary_expr_struct(
 			None => {
 				let index_ident = builder.id(format!("__field{}", index));
 				quote_expr!(cx, $index_ident)
-			}
+			},
 		};
 
 		write_stmts.push(quote_stmt!(cx, let next_line = offset + match $field_type_ident::len_params() {
 				0 => mem::size_of::<$field_type_ident>(),
-				_ => { let size = $member_expr .size(); length_stack.push_back(size); size }
+				_ => { let size = $member_expr .size(); length_stack.push_back(size); size },
 			}).unwrap());
 
 		write_stmts.push(quote_stmt!(cx,
@@ -227,7 +227,7 @@ fn binary_expr_struct(
 		map_stmts.push(quote_stmt!(cx, map[$field_index] = total;).unwrap());
 		map_stmts.push(quote_stmt!(cx, let size = match $field_type_ident::len_params() {
 				0 => mem::size_of::<$field_type_ident>(),
-				_ => length_stack.pop_front().unwrap()
+				_ => length_stack.pop_front().unwrap(),
 			}).unwrap());
 		map_stmts.push(quote_stmt!(cx, total = total + size;).unwrap());
 	};
@@ -246,7 +246,7 @@ fn binary_expr_struct(
 				let map_variant = P(fields_sequence(cx, &ty, fields, &instance_ident.unwrap_or(builder.id("Self"))));
 				quote_expr!(cx, { $map_stmts; Ok($map_variant) })
 			}
-		}
+		},
 	};
 
     Ok(BinaryExpressions {
@@ -275,7 +275,7 @@ fn binary_expr_item_struct(
 				Some(builder.id("self")),
 				None,
 			)
-		}
+		},
 		ast::VariantData::Struct(ref fields, _) => {
 			binary_expr_struct(
 				cx,
@@ -544,7 +544,7 @@ fn binary_expr_variant(
 				}),
 				read: quote_arm!(cx, $variant_index_ident => { $read_expr } ),
 			})
-		}
+		},
 		ast::VariantData::Struct(ref fields, _) => {
 			let field_names: Vec<_> = (0 .. fields.len())
 				.map(|i| builder.id(format!("__field{}", i)))

--- a/ipc/codegen/src/serialization.rs
+++ b/ipc/codegen/src/serialization.rs
@@ -60,9 +60,9 @@ pub fn expand_serialization_implementation(
 }
 
 fn serialize_item(
-    cx: &ExtCtxt,
-    builder: &aster::AstBuilder,
-    item: &Item,
+	cx: &ExtCtxt,
+	builder: &aster::AstBuilder,
+	item: &Item,
 ) -> Result<P<ast::Item>, Error> {
 	let generics = match item.node {
 		ast::ItemKind::Struct(_, ref generics) => generics,
@@ -296,13 +296,13 @@ fn binary_expr_item_struct(
 }
 
 fn binary_expr_enum(
-    cx: &ExtCtxt,
-    builder: &aster::AstBuilder,
-    type_ident: Ident,
-    impl_generics: &ast::Generics,
-    ty: P<ast::Ty>,
+	cx: &ExtCtxt,
+	builder: &aster::AstBuilder,
+	type_ident: Ident,
+	impl_generics: &ast::Generics,
+	ty: P<ast::Ty>,
 	span: Span,
-    enum_def: &ast::EnumDef,
+	enum_def: &ast::EnumDef,
 ) -> Result<BinaryExpressions, Error> {
 	let arms: Vec<_> = try!(
 		enum_def.variants.iter()
@@ -345,7 +345,7 @@ struct BinaryArm {
 fn fields_sequence(
 	ext_cx: &ExtCtxt,
 	_ty: &P<ast::Ty>,
-    fields: &[ast::StructField],
+	fields: &[ast::StructField],
 	variant_ident: &ast::Ident,
 ) -> ast::Expr {
 	use syntax::parse::token;
@@ -413,7 +413,7 @@ fn fields_sequence(
 fn named_fields_sequence(
 	ext_cx: &ExtCtxt,
 	ty: &P<ast::Ty>,
-    fields: &[ast::StructField],
+	fields: &[ast::StructField],
 ) -> ast::Stmt {
 	use syntax::parse::token;
 	use syntax::ast::TokenTree::Token;
@@ -485,14 +485,14 @@ fn named_fields_sequence(
 }
 
 fn binary_expr_variant(
-    cx: &ExtCtxt,
-    builder: &aster::AstBuilder,
-    type_ident: Ident,
-    _generics: &ast::Generics,
-    ty: P<ast::Ty>,
+	cx: &ExtCtxt,
+	builder: &aster::AstBuilder,
+	type_ident: Ident,
+	_generics: &ast::Generics,
+	ty: P<ast::Ty>,
 	_span: Span,
-    variant: &ast::Variant,
-    variant_index: usize,
+	variant: &ast::Variant,
+	variant_index: usize,
 ) -> Result<BinaryArm, Error> {
 	let variant_ident = variant.node.name;
 	let variant_index_ident = builder.id(format!("{}", variant_index));

--- a/ipc/codegen/src/typegen.rs
+++ b/ipc/codegen/src/typegen.rs
@@ -50,7 +50,8 @@ fn is_new_entry(path: &Path) -> Option<String> {
 			ident == "H256"      ||
 			ident == "U256"      ||
 			ident == "H2048"     ||
-			ident == "Address"
+			ident == "Address"   ||
+			ident == "Bytes"
 		}
 	};
 

--- a/ipc/rpc/Cargo.toml
+++ b/ipc/rpc/Cargo.toml
@@ -10,3 +10,4 @@ license = "GPL-3.0"
 ethcore-devtools = { path = "../../devtools" }
 semver = "0.2.0"
 nanomsg = { git = "https://github.com/ethcore/nanomsg.rs.git" }
+ethcore-util = { path = "../../util" }

--- a/ipc/rpc/src/binary.rs
+++ b/ipc/rpc/src/binary.rs
@@ -16,7 +16,7 @@
 
 //! Binary representation of types
 
-trait BinaryConvertable {
+pub trait BinaryConvertable {
 	fn size(&self) -> usize;
 
 	fn to_bytes(buffer: &mut [u8]);

--- a/ipc/rpc/src/binary.rs
+++ b/ipc/rpc/src/binary.rs
@@ -14,6 +14,12 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-mod codegen;
-mod serialization;
-pub mod typegen;
+//! Binary representation of types
+
+trait BinaryConvertable {
+	fn size(&self) -> usize;
+
+	fn to_bytes(buffer: &mut [u8]);
+
+	fn from_bytes(buffer: &[u8]) -> Self;
+}

--- a/ipc/rpc/src/lib.rs
+++ b/ipc/rpc/src/lib.rs
@@ -21,4 +21,4 @@ extern crate semver;
 extern crate nanomsg;
 
 pub mod interface;
-pub use interface::{IpcInterface, IpcSocket, invoke, IpcConfig, Handshake, Error, WithSocket};
+pub use interface::{IpcInterface, IpcSocket, invoke, IpcConfig, Handshake, Error, WithSocket, BinaryConvertable};

--- a/ipc/rpc/src/lib.rs
+++ b/ipc/rpc/src/lib.rs
@@ -21,4 +21,6 @@ extern crate semver;
 extern crate nanomsg;
 
 pub mod interface;
-pub use interface::{IpcInterface, IpcSocket, invoke, IpcConfig, Handshake, Error, WithSocket, BinaryConvertable};
+pub mod binary;
+pub use interface::{IpcInterface, IpcSocket, invoke, IpcConfig, Handshake, Error, WithSocket};
+pub use binary::{BinaryConvertable};

--- a/ipc/rpc/src/lib.rs
+++ b/ipc/rpc/src/lib.rs
@@ -19,8 +19,9 @@
 extern crate ethcore_devtools as devtools;
 extern crate semver;
 extern crate nanomsg;
+extern crate ethcore_util as util;
 
 pub mod interface;
 pub mod binary;
 pub use interface::{IpcInterface, IpcSocket, invoke, IpcConfig, Handshake, Error, WithSocket};
-pub use binary::{BinaryConvertable};
+pub use binary::{BinaryConvertable, BinaryConvertError};

--- a/ipc/tests/binary.rs
+++ b/ipc/tests/binary.rs
@@ -14,14 +14,4 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-//! Binary representation of types
-
-pub struct BinaryConvertError;
-
-pub trait BinaryConvertable : Sized {
-	fn size(&self) -> Result<usize, BinaryConvertError>;
-
-	fn to_bytes(buffer: &mut [u8]) -> Result<(), BinaryConvertError>;
-
-	fn from_bytes(buffer: &[u8]) -> Result<Self, BinaryConvertError>;
-}
+include!(concat!(env!("OUT_DIR"), "/binary.rs"));

--- a/ipc/tests/binary.rs
+++ b/ipc/tests/binary.rs
@@ -14,6 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-#![allow(dead_code, unused_assignments)] // codegen issues
+#![allow(dead_code, unused_assignments, unused_variables)] // codegen issues
 
 include!(concat!(env!("OUT_DIR"), "/binary.rs"));

--- a/ipc/tests/binary.rs
+++ b/ipc/tests/binary.rs
@@ -14,4 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
+#![allow(dead_code, unused_assignments)] // codegen issues
+
 include!(concat!(env!("OUT_DIR"), "/binary.rs"));

--- a/ipc/tests/binary.rs.in
+++ b/ipc/tests/binary.rs.in
@@ -14,14 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-//! Binary representation of types
-
-pub struct BinaryConvertError;
-
-pub trait BinaryConvertable : Sized {
-	fn size(&self) -> Result<usize, BinaryConvertError>;
-
-	fn to_bytes(buffer: &mut [u8]) -> Result<(), BinaryConvertError>;
-
-	fn from_bytes(buffer: &[u8]) -> Result<Self, BinaryConvertError>;
+#[derive(Binary)]
+enum Root {
+	Top,
+	Middle(String)
 }

--- a/ipc/tests/binary.rs.in
+++ b/ipc/tests/binary.rs.in
@@ -14,8 +14,14 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
+use ipc::*;
+
 #[derive(Binary)]
 enum Root {
 	Top,
-	Middle(String)
+	Middle(u32, u64),
+	Bottom {
+		number1: u32,
+		number2: u64,
+	},
 }

--- a/ipc/tests/binary.rs.in
+++ b/ipc/tests/binary.rs.in
@@ -25,3 +25,10 @@ enum Root {
 		number2: u64,
 	},
 }
+
+#[derive(Binary)]
+struct DoubleRoot {
+	x1: u32,
+	x2: u64,
+	x3: u32,
+}

--- a/ipc/tests/binary.rs.in
+++ b/ipc/tests/binary.rs.in
@@ -15,15 +15,12 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 use ipc::*;
+use std::mem;
 
 #[derive(Binary)]
 enum Root {
 	Top,
 	Middle(u32, u64),
-	Bottom {
-		number1: u32,
-		number2: u64,
-	},
 }
 
 #[derive(Binary)]

--- a/ipc/tests/binary.rs.in
+++ b/ipc/tests/binary.rs.in
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
+
 use ipc::*;
 use std::mem;
 use std::collections::VecDeque;

--- a/ipc/tests/binary.rs.in
+++ b/ipc/tests/binary.rs.in
@@ -31,3 +31,8 @@ pub struct DoubleRoot {
 	pub x2: u64,
 	pub x3: u32,
 }
+
+#[derive(Binary, PartialEq, Debug)]
+pub struct ReferenceStruct<'a> {
+	pub ref_data: &'a u64,
+}

--- a/ipc/tests/binary.rs.in
+++ b/ipc/tests/binary.rs.in
@@ -16,16 +16,17 @@
 
 use ipc::*;
 use std::mem;
+use std::collections::VecDeque;
 
 #[derive(Binary)]
-enum Root {
+pub enum Root {
 	Top,
 	Middle(u32, u64),
 }
 
-#[derive(Binary)]
-struct DoubleRoot {
-	x1: u32,
-	x2: u64,
-	x3: u32,
+#[derive(Binary, PartialEq, Debug)]
+pub struct DoubleRoot {
+	pub x1: u32,
+	pub x2: u64,
+	pub x3: u32,
 }

--- a/ipc/tests/build.rs
+++ b/ipc/tests/build.rs
@@ -60,4 +60,13 @@ pub fn main() {
 		registry.expand("", &src, &dst).unwrap();
 	}
 
+
+	// ipc pass
+	{
+		let src = Path::new("binary.rs.in");
+		let dst = Path::new(&out_dir).join("binary.rs");
+		let mut registry = syntex::Registry::new();
+		codegen::register(&mut registry);
+		registry.expand("", &src, &dst).unwrap();
+	}
 }

--- a/ipc/tests/examples.rs
+++ b/ipc/tests/examples.rs
@@ -18,6 +18,7 @@
 mod tests {
 
 	use super::super::service::*;
+	use super::super::binary::*;
 	use super::super::nested::{DBClient,DBWriter};
 	use ipc::*;
 	use devtools::*;
@@ -142,5 +143,20 @@ mod tests {
 		let result = db_client.handshake();
 
 		assert!(result.is_ok());
+	}
+
+	#[test]
+	fn can_serialize_dummy_structs() {
+		let mut socket = TestSocket::new();
+
+		let struct_ = DoubleRoot { x1: 0, x2: 100, x3: 100000};
+		let res = ::ipc::binary::serialize_into(&struct_, &mut socket);
+
+		assert!(res.is_ok());
+
+		let mut read_socket = TestSocket::new_ready(socket.write_buffer.clone());
+		let new_struct: DoubleRoot = ::ipc::binary::deserialize_from(&mut read_socket).unwrap();
+
+		assert_eq!(struct_, new_struct);
 	}
 }

--- a/ipc/tests/run.rs
+++ b/ipc/tests/run.rs
@@ -29,3 +29,4 @@ pub mod service;
 mod examples;
 mod over_nano;
 mod nested;
+mod binary;


### PR DESCRIPTION
codegen for serialization so that

```
#[derive(Binary)]
pub enum Root {
	Top,
	Middle(u32, u64),
}
```

could be serialized without additional code via

```
let res = ::ipc::binary::serialize_into(&Root::Middle(10, 100), &mut socket);
```

- with the exception of header info, no intermediate allocations, whole payloads serializes from the one stream of bytes
- packed (size 0) representation of some values (Option::None, empty vector, etc..)
- ... a lot of space for optimizations