### PR TITLE
Switching to rust-url@1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,7 +364,7 @@ dependencies = [
  "parity-status 0.2.2 (git+https://github.com/tomusdrw/parity-status.git)",
  "parity-wallet 0.1.1 (git+https://github.com/tomusdrw/parity-wallet.git)",
  "parity-webapp 0.1.0 (git+https://github.com/tomusdrw/parity-webapp.git)",
- "url 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -494,21 +494,22 @@ dependencies = [
 [[package]]
 name = "hyper"
 version = "0.9.0-mio"
-source = "git+https://github.com/hyperium/hyper?branch=mio#55c7d7a1d88001e529b3d3b3a6783548ce8c3d06"
+source = "git+https://github.com/hyperium/hyper?branch=mio#fab6c4173063a10f2aacfe3872150537da3dcfdd"
 dependencies = [
  "cookie 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "language-tags 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "mime 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+ "mime 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rotor 0.6.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
+ "spmc 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "traitobject 0.0.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "typeable 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "url 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
+ "url 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "vecio 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1060,6 +1061,11 @@ dependencies = [
  "hpack 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "spmc"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "strsim"

--- a/webapp/Cargo.toml
+++ b/webapp/Cargo.toml
@@ -12,7 +12,7 @@ log = "0.3"
 jsonrpc-core = "2.0"
 jsonrpc-http-server = { git = "https://github.com/debris/jsonrpc-http-server.git" }
 hyper = { default-features = false, git = "https://github.com/hyperium/hyper", branch = "mio" }
-url = "0.5"
+url = "1.0"
 ethcore-rpc = { path = "../rpc" }
 ethcore-util = { path = "../util" }
 parity-webapp = { git = "https://github.com/tomusdrw/parity-webapp.git" }

--- a/webapp/src/router/url.rs
+++ b/webapp/src/router/url.rs
@@ -17,8 +17,7 @@
 //! HTTP/HTTPS URL type. Based on URL type from Iron library.
 
 use url::Host;
-use url::{whatwg_scheme_type_mapper};
-use url::{self, SchemeData, SchemeType};
+use url::{self};
 
 /// HTTP/HTTPS URL type for Iron.
 #[derive(PartialEq, Eq, Clone, Debug)]
@@ -83,50 +82,38 @@ impl Url {
 
 	/// Create a `Url` from a `rust-url` `Url`.
 	pub fn from_generic_url(raw_url: url::Url) -> Result<Url, String> {
-		// Create an Iron URL by extracting the special scheme data.
-		match raw_url.scheme_data {
-			SchemeData::Relative(data) => {
-				// Extract the port as a 16-bit unsigned integer.
-				let port: u16 = match data.port {
-					// If explicitly defined, unwrap it.
-					Some(port) => port,
+		// Extract the port as a 16-bit unsigned integer.
+		let port: u16 = match raw_url.port_or_known_default() {
+			Some(port) => port,
+			None => {
+				return Err(format!("Unknown port for scheme: `{}`", raw_url.scheme()))
+			}
+		};
 
-					// Otherwise, use the scheme's default port.
-					None => {
-					match whatwg_scheme_type_mapper(&raw_url.scheme) {
-						SchemeType::Relative(port) => port,
-						_ => return Err(format!("Invalid special scheme: `{}`",
-												raw_url.scheme))
-					}
-					}
-				};
+		// Map empty usernames to None.
+		let username = match &*raw_url.username() {
+			"" => None,
+			_ => Some(raw_url.username().to_owned())
+		};
 
-				// Map empty usernames to None.
-				let username = match &*data.username {
-					"" => None,
-					_ => Some(data.username)
-				};
+		// Map empty passwords to None.
+		let password = match raw_url.password() {
+			None => None,
+			Some(ref x) if x.is_empty() => None,
+			Some(password) => Some(password.to_owned())
+		};
+		let as_string = |x: &str| x.to_owned();
 
-				// Map empty passwords to None.
-				let password = match data.password {
-					None => None,
-					Some(ref x) if x.is_empty() => None,
-					Some(password) => Some(password)
-				};
-
-				Ok(Url {
-					scheme: raw_url.scheme,
-					host: data.host,
-					port: port,
-					path: data.path,
-					username: username,
-					password: password,
-					query: raw_url.query,
-					fragment: raw_url.fragment
-				})
-			},
-			_ => Err(format!("Not a special scheme: `{}`", raw_url.scheme))
-		}
+		Ok(Url {
+			scheme: raw_url.scheme().to_owned(),
+			host: raw_url.host().expect("Valid host, because only data:, mailto: protocols does not have host.").to_owned(),
+			port: port,
+			path: raw_url.path_segments().expect("Valid path segments. In HTTP we won't get cannot-be-a-base URLs").map(&as_string).collect(),
+			username: username,
+			password: password,
+			query: raw_url.query().map(&as_string),
+			fragment: raw_url.fragment().map(&as_string),
+		})
 	}
 }
 

--- a/webapp/src/router/url.rs
+++ b/webapp/src/router/url.rs
@@ -22,8 +22,8 @@ use url::{self};
 /// HTTP/HTTPS URL type for Iron.
 #[derive(PartialEq, Eq, Clone, Debug)]
 pub struct Url {
-	/// The lower-cased scheme of the URL, typically "http" or "https".
-	pub scheme: String,
+	/// Raw url of url
+	pub raw: url::Url,
 
 	/// The host field of the URL, probably a domain.
 	pub host: Host,
@@ -50,18 +50,6 @@ pub struct Url {
 	/// if a blank password was provided.
 	/// Otherwise, a non-empty string.
 	pub password: Option<String>,
-
-	/// The URL query string.
-	///
-	/// `None` if the `?` character was not part of the input.
-	/// Otherwise, a possibly empty, percent encoded string.
-	pub query: Option<String>,
-
-	/// The URL fragment.
-	///
-	/// `None` if the `#` character was not part of the input.
-	/// Otherwise, a possibly empty, percent encoded string.
-	pub fragment: Option<String>
 }
 
 impl Url {
@@ -82,37 +70,30 @@ impl Url {
 
 	/// Create a `Url` from a `rust-url` `Url`.
 	pub fn from_generic_url(raw_url: url::Url) -> Result<Url, String> {
-		// Extract the port as a 16-bit unsigned integer.
-		let port: u16 = match raw_url.port_or_known_default() {
-			Some(port) => port,
-			None => {
-				return Err(format!("Unknown port for scheme: `{}`", raw_url.scheme()))
-			}
-		};
-
 		// Map empty usernames to None.
-		let username = match &*raw_url.username() {
+		let username = match raw_url.username() {
 			"" => None,
-			_ => Some(raw_url.username().to_owned())
+			username => Some(username.to_owned())
 		};
 
 		// Map empty passwords to None.
 		let password = match raw_url.password() {
-			None => None,
-			Some(ref x) if x.is_empty() => None,
-			Some(password) => Some(password.to_owned())
+			Some(password) if !password.is_empty() => Some(password.to_owned()),
+			_ => None,
 		};
-		let as_string = |x: &str| x.to_owned();
+
+		let port = try!(raw_url.port_or_known_default().ok_or_else(|| format!("Unknown port for scheme: `{}`", raw_url.scheme())));
+		let host = try!(raw_url.host().ok_or_else(|| "Valid host, because only data:, mailto: protocols does not have host.".to_owned())).to_owned();
+		let path = try!(raw_url.path_segments().ok_or_else(|| "Valid path segments. In HTTP we won't get cannot-be-a-base URLs".to_owned()))
+					.map(|part| part.to_owned()).collect();
 
 		Ok(Url {
-			scheme: raw_url.scheme().to_owned(),
-			host: raw_url.host().expect("Valid host, because only data:, mailto: protocols does not have host.").to_owned(),
 			port: port,
-			path: raw_url.path_segments().expect("Valid path segments. In HTTP we won't get cannot-be-a-base URLs").map(&as_string).collect(),
+			host: host,
+			path: path,
+			raw: raw_url,
 			username: username,
 			password: password,
-			query: raw_url.query().map(&as_string),
-			fragment: raw_url.fragment().map(&as_string),
 		})
 	}
 }


### PR DESCRIPTION
Seems that the commit we were referring to in Cargo.lock has been removed from hyper-mio repository.
It was necessary to update to url@1.0.0 in webapps package.