### PR TITLE
RPC method for supported modules

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -295,6 +295,7 @@ name = "ethcore-ipc-nano"
 version = "1.1.0"
 dependencies = [
  "ethcore-ipc 1.1.0",
+ "jsonrpc-core 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "nanomsg 0.5.0 (git+https://github.com/ethcore/nanomsg.rs.git)",
 ]

--- a/parity/rpc.rs
+++ b/parity/rpc.rs
@@ -15,6 +15,7 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 
+use std::collections::BTreeMap;
 use std::str::FromStr;
 use std::sync::Arc;
 use std::net::SocketAddr;
@@ -90,21 +91,36 @@ pub fn setup_rpc_server(
 	use ethcore_rpc::v1::*;
 
 	let server = Server::new();
+	let mut modules = BTreeMap::new();
 	for api in apis.into_iter() {
 		match api {
-			"web3" => server.add_delegate(Web3Client::new().to_delegate()),
-			"net" => server.add_delegate(NetClient::new(&deps.sync).to_delegate()),
+			"web3" => {
+				modules.insert("web3".to_owned(), "1.0".to_owned());
+				server.add_delegate(Web3Client::new().to_delegate());
+			},
+			"net" => {
+				modules.insert("web3".to_owned(), "1.0".to_owned());
+				server.add_delegate(NetClient::new(&deps.sync).to_delegate());
+			},
 			"eth" => {
+				modules.insert("eth".to_owned(), "1.0".to_owned());
 				server.add_delegate(EthClient::new(&deps.client, &deps.sync, &deps.secret_store, &deps.miner, &deps.external_miner).to_delegate());
 				server.add_delegate(EthFilterClient::new(&deps.client, &deps.miner).to_delegate());
 			},
-			"personal" => server.add_delegate(PersonalClient::new(&deps.secret_store).to_delegate()),
-			"ethcore" => server.add_delegate(EthcoreClient::new(&deps.miner, deps.logger.clone(), deps.settings.clone()).to_delegate()),
+			"personal" => {
+				modules.insert("personal".to_owned(), "1.0".to_owned());
+				server.add_delegate(PersonalClient::new(&deps.secret_store).to_delegate())
+			},
+			"ethcore" => {
+				// not adding to modules, since `ethcore` is not supported in geth
+				server.add_delegate(EthcoreClient::new(&deps.miner, deps.logger.clone(), deps.settings.clone()).to_delegate())
+			},
 			_ => {
 				die!("{}: Invalid API name to be enabled.", api);
 			},
 		}
 	}
+	server.add_delegate(RpcClient::new(modules).to_delegate());
 	let start_result = server.start_http(url, cors_domain);
 	match start_result {
 		Err(RpcServerError::IoError(err)) => die_with_io_error(err),

--- a/rpc/src/v1/impls/mod.rs
+++ b/rpc/src/v1/impls/mod.rs
@@ -30,10 +30,12 @@ mod eth;
 mod net;
 mod personal;
 mod ethcore;
+mod rpc;
 
 pub use self::web3::Web3Client;
 pub use self::eth::{EthClient, EthFilterClient};
 pub use self::net::NetClient;
 pub use self::personal::PersonalClient;
 pub use self::ethcore::EthcoreClient;
+pub use self::rpc::RpcClient;
 

--- a/rpc/src/v1/impls/rpc.rs
+++ b/rpc/src/v1/impls/rpc.rs
@@ -14,16 +14,31 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-//! Ethcore rpc v1.
-//!
-//! Compliant with ethereum rpc.
+//! RPC generic methods implementation.
+use std::collections::BTreeMap;
+use jsonrpc_core::*;
+use v1::traits::Rpc;
 
-pub mod traits;
-mod impls;
-mod types;
-mod helpers;
+/// RPC generic methods implementation.
+pub struct RpcClient {
+	modules: BTreeMap<String, String>,
+}
 
-pub mod tests;
+impl RpcClient {
+	/// Creates new `RpcClient`.
+	pub fn new(modules: BTreeMap<String, String>) -> Self {
+		RpcClient {
+			modules: modules
+		}
+	}
+}
 
-pub use self::traits::{Web3, Eth, EthFilter, Personal, Net, Ethcore, Rpc};
-pub use self::impls::*;
+impl Rpc for RpcClient {
+	fn modules(&self, _: Params) -> Result<Value, Error> {
+		let modules = self.modules.iter().fold(BTreeMap::new(), |mut map, (k, v)| {
+			map.insert(k.to_owned(), Value::String(v.to_owned()));
+			map
+		});
+		Ok(Value::Object(modules))
+	}
+}

--- a/rpc/src/v1/tests/rpc.rs
+++ b/rpc/src/v1/tests/rpc.rs
@@ -14,16 +14,25 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-//! Ethcore rpc v1.
-//!
-//! Compliant with ethereum rpc.
+use std::collections::BTreeMap;
+use jsonrpc_core::IoHandler;
+use v1::{Rpc, RpcClient};
 
-pub mod traits;
-mod impls;
-mod types;
-mod helpers;
 
-pub mod tests;
+fn rpc_client() -> RpcClient {
+	let mut modules = BTreeMap::new();
+	modules.insert("rpc".to_owned(), "1.0".to_owned());
+	RpcClient::new(modules)
+}
 
-pub use self::traits::{Web3, Eth, EthFilter, Personal, Net, Ethcore, Rpc};
-pub use self::impls::*;
+#[test]
+fn rpc_modules() {
+	let rpc = rpc_client().to_delegate();
+	let io = IoHandler::new();
+	io.add_delegate(rpc);
+
+	let request = r#"{"jsonrpc": "2.0", "method": "modules", "params": [], "id": 1}"#;
+	let response = r#"{"jsonrpc":"2.0","result":{"eth": "1.0"},"id":1}"#;
+
+	assert_eq!(io.handle_request(request), Some(response.to_owned()));
+}

--- a/rpc/src/v1/traits/mod.rs
+++ b/rpc/src/v1/traits/mod.rs
@@ -25,9 +25,11 @@ pub mod eth;
 pub mod net;
 pub mod personal;
 pub mod ethcore;
+pub mod rpc;
 
 pub use self::web3::Web3;
 pub use self::eth::{Eth, EthFilter};
 pub use self::net::Net;
 pub use self::personal::Personal;
 pub use self::ethcore::Ethcore;
+pub use self::rpc::Rpc;

--- a/rpc/src/v1/traits/rpc.rs
+++ b/rpc/src/v1/traits/rpc.rs
@@ -14,16 +14,25 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-//! Ethcore rpc v1.
-//!
-//! Compliant with ethereum rpc.
+//! RPC interface.
 
-pub mod traits;
-mod impls;
-mod types;
-mod helpers;
+use std::sync::Arc;
+use jsonrpc_core::*;
 
-pub mod tests;
+/// RPC Interface.
+pub trait Rpc: Sized + Send + Sync + 'static {
 
-pub use self::traits::{Web3, Eth, EthFilter, Personal, Net, Ethcore, Rpc};
-pub use self::impls::*;
+	/// Returns supported modules.
+	fn modules(&self, _: Params) -> Result<Value, Error> { rpc_unimplemented!() }
+
+	/// Should be used to convert object to io delegate.
+	fn to_delegate(self) -> IoDelegate<Self> {
+		let mut delegate = IoDelegate::new(Arc::new(self));
+		// Geth 1.3.6 compatibility
+		delegate.add_method("modules", Rpc::modules);
+		// Geth 1.4.0 compatibility
+		delegate.add_method("rpc_modules", Rpc::modules);
+		delegate
+	}
+}
+


### PR DESCRIPTION
Allows `geth attach` for `geth 1.3.6`

In `geth 1.4` there was a difference in handling request ids - we expect numbers, in geth it can be any string(?) - calling RPC actually fails.
Culprit:
https://github.com/ethereum/go-ethereum/blob/release/1.4/rpc/utils.go#L235
```json
{"method":"rpc_modules","jsonrpc":"2.0","id":"MQ=="}
```

