### PR TITLE
Switching to geth-attach supporting version of rpc core and server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,8 +316,8 @@ dependencies = [
  "ethcore-util 1.1.0",
  "ethminer 1.1.0",
  "ethsync 1.1.0",
- "jsonrpc-core 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-http-server 5.1.0 (git+https://github.com/debris/jsonrpc-http-server.git)",
+ "jsonrpc-core 2.0.3 (git+https://github.com/tomusdrw/jsonrpc-core.git)",
+ "jsonrpc-http-server 5.1.0 (git+https://github.com/tomusdrw/jsonrpc-http-server.git)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -370,8 +370,8 @@ dependencies = [
  "ethcore-rpc 1.1.0",
  "ethcore-util 1.1.0",
  "hyper 0.9.0-mio (git+https://github.com/hyperium/hyper?branch=mio)",
- "jsonrpc-core 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-http-server 5.1.0 (git+https://github.com/debris/jsonrpc-http-server.git)",
+ "jsonrpc-core 2.0.3 (git+https://github.com/tomusdrw/jsonrpc-core.git)",
+ "jsonrpc-http-server 5.1.0 (git+https://github.com/tomusdrw/jsonrpc-http-server.git)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-status 0.3.3 (git+https://github.com/tomusdrw/parity-status.git)",
  "parity-webapp 0.1.0 (git+https://github.com/tomusdrw/parity-webapp.git)",
@@ -571,12 +571,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpc-core"
+version = "2.0.3"
+source = "git+https://github.com/tomusdrw/jsonrpc-core.git#9d51f1b6679938846d93cbafdd052733c816d28b"
+dependencies = [
+ "serde 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_codegen 0.7.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "serde_json 0.7.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "syntex 0.31.0 (registry+https://github.com/rust-lang/crates.io-index)",
+]
+
+[[package]]
 name = "jsonrpc-http-server"
 version = "5.1.0"
-source = "git+https://github.com/debris/jsonrpc-http-server.git#b32815330c191aff06a6e017ba00c10e872bb4f6"
+source = "git+https://github.com/tomusdrw/jsonrpc-http-server.git#fafd6410284710b7e662fe7d76249cc496451f27"
 dependencies = [
  "hyper 0.9.0-mio (git+https://github.com/hyperium/hyper?branch=mio)",
- "jsonrpc-core 2.0.2 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core 2.0.3 (git+https://github.com/tomusdrw/jsonrpc-core.git)",
  "unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -12,8 +12,8 @@ build = "build.rs"
 log = "0.3"
 serde = "0.7.0"
 serde_json = "0.7.0"
-jsonrpc-core = "2.0"
-jsonrpc-http-server = { git = "https://github.com/debris/jsonrpc-http-server.git", version = "5.1.0" }
+jsonrpc-core = { git = "https://github.com/tomusdrw/jsonrpc-core.git" }
+jsonrpc-http-server = { git = "https://github.com/tomusdrw/jsonrpc-http-server.git", version = "5.1.0" }
 ethcore-util = { path = "../util" }
 ethcore = { path = "../ethcore" }
 ethash = { path = "../ethash" }

--- a/webapp/Cargo.toml
+++ b/webapp/Cargo.toml
@@ -9,8 +9,8 @@ authors = ["Ethcore <admin@ethcore.io"]
 
 [dependencies]
 log = "0.3"
-jsonrpc-core = "2.0"
-jsonrpc-http-server = { git = "https://github.com/debris/jsonrpc-http-server.git", version = "5.1.0" }
+jsonrpc-core = { git = "https://github.com/tomusdrw/jsonrpc-core.git" }
+jsonrpc-http-server = { git = "https://github.com/tomusdrw/jsonrpc-http-server.git", version = "5.1.0" }
 hyper = { default-features = false, git = "https://github.com/hyperium/hyper", branch = "mio" }
 url = "1.0"
 ethcore-rpc = { path = "../rpc" }


### PR DESCRIPTION
We should switch back to use "official ones" (preferably from crates.io) after https://github.com/debris/jsonrpc-core/pull/15 is merged.