### PR TITLE
JSON-RPC over IPC

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -316,6 +316,7 @@ dependencies = [
  "ethcore-util 1.2.0",
  "ethminer 1.2.0",
  "ethsync 1.2.0",
+ "json-ipc-server 0.1.0 (git+https://github.com/NikVolf/json-ipc-server.git)",
  "jsonrpc-core 2.0.3 (git+https://github.com/tomusdrw/jsonrpc-core.git)",
  "jsonrpc-http-server 5.1.0 (git+https://github.com/tomusdrw/jsonrpc-http-server.git)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -550,6 +551,17 @@ dependencies = [
 name = "itertools"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "json-ipc-server"
+version = "0.1.0"
+source = "git+https://github.com/NikVolf/json-ipc-server.git#734f3eba637173a882ec7456032b1af05557b13a"
+dependencies = [
+ "bytes 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
+ "jsonrpc-core 2.0.3 (git+https://github.com/tomusdrw/jsonrpc-core.git)",
+ "mio 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "slab 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "json-tests"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -20,6 +20,7 @@ dependencies = [
  "ethsync 1.2.0",
  "fdlimit 0.1.0",
  "hyper 0.8.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "json-ipc-server 0.1.0 (git+https://github.com/NikVolf/json-ipc-server.git)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "number_prefix 0.2.5 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -556,7 +556,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "json-ipc-server"
 version = "0.1.0"
-source = "git+https://github.com/NikVolf/json-ipc-server.git#734f3eba637173a882ec7456032b1af05557b13a"
+source = "git+https://github.com/NikVolf/json-ipc-server.git#bd987c75b5f23c35eb7e2b0bd8b30ba88f758338"
 dependencies = [
  "bytes 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 2.0.3 (git+https://github.com/tomusdrw/jsonrpc-core.git)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ ethcore-ipc-nano = { path = "ipc/nano" }
 "ethcore-ipc" = { path = "ipc/rpc" }
 bincode = "*"
 serde = "0.7.0"
+json-ipc-server = { git = "https://github.com/NikVolf/json-ipc-server.git" }
 
 [dependencies.hyper]
 version = "0.8"

--- a/parity/cli.rs
+++ b/parity/cli.rs
@@ -85,7 +85,7 @@ API and Console Options:
                            conjunction with --webapp-user.
 
   --ipc-disable            Disable JSON-RPC over IPC service
-  --ipc-path PATH          Specify custom path for IPC servie
+  --ipc-path PATH          Specify custom path for IPC service
                            [default: $HOME/.parity/jsonrpc.ipc]
   --ipc-api APIS           Specify custom API set available via IPC service
                            [default: web3,eth,net,personal,ethcore]

--- a/parity/cli.rs
+++ b/parity/cli.rs
@@ -84,6 +84,12 @@ API and Console Options:
   --webapp-pass PASSWORD   Specify password for WebApps server. Use only in
                            conjunction with --webapp-user.
 
+  --ipc-disable            Disable JSON-RPC over IPC service
+  --ipc-path PATH          Specify custom path for IPC servie
+                           [default: $HOME/.parity/jsonrpc.ipc]
+  --ipc-api APIS           Specify custom API set available via IPC service
+                           [default: web3,eth,net,personal,ethcore,traces]
+
 Sealing/Mining Options:
   --force-sealing          Force the node to author new blocks as if it were
                            always sealing/mining.
@@ -197,6 +203,9 @@ pub struct Args {
 	pub flag_tx_limit: usize,
 	pub flag_logging: Option<String>,
 	pub flag_version: bool,
+	pub flag_ipc_disable: bool,
+	pub flag_ipc_path: String,
+	pub flag_ipc_api: String,
 	// geth-compatibility...
 	pub flag_nodekey: Option<String>,
 	pub flag_nodiscover: bool,

--- a/parity/cli.rs
+++ b/parity/cli.rs
@@ -88,7 +88,7 @@ API and Console Options:
   --ipc-path PATH          Specify custom path for IPC servie
                            [default: $HOME/.parity/jsonrpc.ipc]
   --ipc-api APIS           Specify custom API set available via IPC service
-                           [default: web3,eth,net,personal,ethcore,traces]
+                           [default: web3,eth,net,personal,ethcore]
 
 Sealing/Mining Options:
   --force-sealing          Force the node to author new blocks as if it were

--- a/parity/configuration.rs
+++ b/parity/configuration.rs
@@ -268,10 +268,11 @@ impl Configuration {
 	}
 
 	pub fn ipc_settings(&self) -> IpcConfiguration {
-		IpcSettings {
-			enabled: self.args.flag_ipc,
-			socket_addr: self.args.flag_ipc_path.clone(),
-			apis: self.flag_ipc_apis.clone(),
+		IpcConfiguration {
+			enabled: !self.args.flag_ipc_disable,
+			socket_addr: self.args.flag_ipc_path.clone()
+				.replace("$HOME", env::home_dir().unwrap().to_str().unwrap()),
+			apis: self.args.flag_ipc_api.clone(),
 		}
 	}
 

--- a/parity/configuration.rs
+++ b/parity/configuration.rs
@@ -31,6 +31,7 @@ use ethcore::ethereum;
 use ethcore::spec::Spec;
 use ethsync::SyncConfig;
 use price_info::PriceInfo;
+use rpc::IpcConfiguration;
 
 pub struct Configuration {
 	pub args: Args
@@ -264,6 +265,14 @@ impl Configuration {
 
 	pub fn rpc_cors(&self) -> Option<String> {
 		self.args.flag_jsonrpc_cors.clone().or(self.args.flag_rpccorsdomain.clone())
+	}
+
+	pub fn ipc_settings(&self) -> IpcConfiguration {
+		IpcSettings {
+			enabled: self.args.flag_ipc,
+			socket_addr: self.args.flag_ipc_path.clone(),
+			apis: self.flag_ipc_apis.clone(),
+		}
 	}
 
 	pub fn network_settings(&self) -> NetworkSettings {

--- a/parity/main.rs
+++ b/parity/main.rs
@@ -159,14 +159,7 @@ fn execute_client(conf: Configuration) {
 	// Sync
 	let sync = EthSync::register(service.network(), sync_config, client.clone(), miner.clone());
 
-	// Setup rpc
-	let rpc_server = rpc::new(rpc::Configuration {
-		enabled: network_settings.rpc_enabled,
-		interface: network_settings.rpc_interface.clone(),
-		port: network_settings.rpc_port,
-		apis: conf.rpc_apis(),
-		cors: conf.rpc_cors(),
-	}, rpc::Dependencies {
+	let dependencies = Arc::new(rpc::Dependencies {
 		panic_handler: panic_handler.clone(),
 		client: client.clone(),
 		sync: sync.clone(),
@@ -176,6 +169,15 @@ fn execute_client(conf: Configuration) {
 		logger: logger.clone(),
 		settings: network_settings.clone(),
 	});
+
+	// Setup rpc
+	let rpc_server = rpc::new_http(rpc::HttpConfiguration {
+		enabled: network_settings.rpc_enabled,
+		interface: network_settings.rpc_interface.clone(),
+		port: network_settings.rpc_port,
+		apis: conf.rpc_apis(),
+		cors: conf.rpc_cors(),
+	}, &dependencies);
 
 	let webapp_server = webapp::new(webapp::Configuration {
 		enabled: conf.args.flag_webapp,

--- a/parity/main.rs
+++ b/parity/main.rs
@@ -44,6 +44,7 @@ extern crate serde;
 extern crate bincode;
 #[macro_use]
 extern crate hyper; // for price_info.rs
+extern crate json_ipc_server as ipc;
 
 #[cfg(feature = "rpc")]
 extern crate ethcore_rpc;
@@ -170,7 +171,7 @@ fn execute_client(conf: Configuration) {
 		settings: network_settings.clone(),
 	});
 
-	// Setup rpc
+	// Setup http rpc
 	let rpc_server = rpc::new_http(rpc::HttpConfiguration {
 		enabled: network_settings.rpc_enabled,
 		interface: network_settings.rpc_interface.clone(),
@@ -178,6 +179,9 @@ fn execute_client(conf: Configuration) {
 		apis: conf.rpc_apis(),
 		cors: conf.rpc_cors(),
 	}, &dependencies);
+
+	// setup ipc rpc
+	let ipc_server = rpc::new_ipc(conf.ipc_settings());
 
 	let webapp_server = webapp::new(webapp::Configuration {
 		enabled: conf.args.flag_webapp,

--- a/parity/main.rs
+++ b/parity/main.rs
@@ -44,7 +44,7 @@ extern crate serde;
 extern crate bincode;
 #[macro_use]
 extern crate hyper; // for price_info.rs
-extern crate json_ipc_server as ipc;
+extern crate json_ipc_server as jsonipc;
 
 #[cfg(feature = "rpc")]
 extern crate ethcore_rpc;
@@ -181,7 +181,7 @@ fn execute_client(conf: Configuration) {
 	}, &dependencies);
 
 	// setup ipc rpc
-	let ipc_server = rpc::new_ipc(conf.ipc_settings());
+	let ipc_server = rpc::new_ipc(conf.ipc_settings(), &dependencies);
 
 	let webapp_server = webapp::new(webapp::Configuration {
 		enabled: conf.args.flag_webapp,

--- a/parity/rpc.rs
+++ b/parity/rpc.rs
@@ -79,12 +79,8 @@ pub fn new_http(conf: HttpConfiguration, deps: &Arc<Dependencies>) -> Option<Rpc
 }
 
 pub fn new_ipc(conf: IpcConfiguration, deps: &Arc<Dependencies>) -> Option<jsonipc::Server> {
-	if !conf.enabled {
-		return None;
-	}
-
+	if !conf.enabled { return None; }
 	let apis = conf.apis.split(',').collect();
-
 	Some(setup_ipc_rpc_server(deps, &conf.socket_addr, apis))
 }
 

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -23,6 +23,7 @@ rustc-serialize = "0.3"
 transient-hashmap = "0.1"
 serde_macros = { version = "0.7.0", optional = true }
 clippy = { version = "0.0.64", optional = true}
+json-ipc-server = { git = "https://github.com/NikVolf/json-ipc-server.git" }
 
 [build-dependencies]
 serde_codegen = { version = "0.7.0", optional = true }


### PR DESCRIPTION
cli options are exactly like geth has
```
--ipc-path
--ipc-disable (enabled by default)
--ipc-api (separate config from http-rpc)
```

to test against geth (mac os)
```
cargo run -- --ipc-path=$HOME/Library/Ethereum/geth.ipc
geth attach
```