### PR TITLE
Fixing RPC modules compatibility

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,6 +348,7 @@ dependencies = [
  "libc 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocksdb 0.4.3 (git+https://github.com/arkpar/rust-rocksdb.git)",
  "rust-crypto 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/parity/rpc.rs
+++ b/parity/rpc.rs
@@ -112,7 +112,7 @@ pub fn setup_rpc_server(
 				server.add_delegate(PersonalClient::new(&deps.secret_store).to_delegate())
 			},
 			"ethcore" => {
-				// not adding to modules, since `ethcore` is not supported in geth
+				modules.insert("ethcore".to_owned(), "1.0".to_owned());
 				server.add_delegate(EthcoreClient::new(&deps.miner, deps.logger.clone(), deps.settings.clone()).to_delegate())
 			},
 			"traces" => {

--- a/rpc/src/v1/tests/mod.rs
+++ b/rpc/src/v1/tests/mod.rs
@@ -27,3 +27,5 @@ mod web3;
 mod personal;
 #[cfg(test)]
 mod ethcore;
+#[cfg(test)]
+mod rpc;

--- a/rpc/src/v1/tests/rpc.rs
+++ b/rpc/src/v1/tests/rpc.rs
@@ -22,7 +22,21 @@ use v1::{Rpc, RpcClient};
 fn rpc_client() -> RpcClient {
 	let mut modules = BTreeMap::new();
 	modules.insert("rpc".to_owned(), "1.0".to_owned());
+	modules.insert("web3".to_owned(), "1.0".to_owned());
+	modules.insert("ethcore".to_owned(), "1.0".to_owned());
 	RpcClient::new(modules)
+}
+
+#[test]
+fn modules() {
+	let rpc = rpc_client().to_delegate();
+	let io = IoHandler::new();
+	io.add_delegate(rpc);
+
+	let request = r#"{"jsonrpc": "2.0", "method": "modules", "params": [], "id": 1}"#;
+	let response = r#"{"jsonrpc":"2.0","result":{"rpc":"1.0","web3":"1.0"},"id":1}"#;
+
+	assert_eq!(io.handle_request(request), Some(response.to_owned()));
 }
 
 #[test]
@@ -31,8 +45,8 @@ fn rpc_modules() {
 	let io = IoHandler::new();
 	io.add_delegate(rpc);
 
-	let request = r#"{"jsonrpc": "2.0", "method": "modules", "params": [], "id": 1}"#;
-	let response = r#"{"jsonrpc":"2.0","result":{"eth": "1.0"},"id":1}"#;
+	let request = r#"{"jsonrpc": "2.0", "method": "rpc_modules", "params": [], "id": 1}"#;
+	let response = r#"{"jsonrpc":"2.0","result":{"ethcore":"1.0","rpc":"1.0","web3":"1.0"},"id":1}"#;
 
 	assert_eq!(io.handle_request(request), Some(response.to_owned()));
 }

--- a/rpc/src/v1/traits/rpc.rs
+++ b/rpc/src/v1/traits/rpc.rs
@@ -22,8 +22,11 @@ use jsonrpc_core::*;
 /// RPC Interface.
 pub trait Rpc: Sized + Send + Sync + 'static {
 
-	/// Returns supported modules.
+	/// Returns supported modules for Geth 1.3.6
 	fn modules(&self, _: Params) -> Result<Value, Error> { rpc_unimplemented!() }
+
+	/// Returns supported modules for Geth 1.4.0
+	fn rpc_modules(&self, _: Params) -> Result<Value, Error> { rpc_unimplemented!() }
 
 	/// Should be used to convert object to io delegate.
 	fn to_delegate(self) -> IoDelegate<Self> {
@@ -31,7 +34,7 @@ pub trait Rpc: Sized + Send + Sync + 'static {
 		// Geth 1.3.6 compatibility
 		delegate.add_method("modules", Rpc::modules);
 		// Geth 1.4.0 compatibility
-		delegate.add_method("rpc_modules", Rpc::modules);
+		delegate.add_method("rpc_modules", Rpc::rpc_modules);
 		delegate
 	}
 }


### PR DESCRIPTION
Geth 1.3.6 doesn't allow any non-supported module to be returned when calling `modules` rpc method.

This PR fixes running `geth attach rpc://localhost` in Geth 1.3.6 (which is now broken, because we are returning `traces` module).