### PR TITLE
Fixing hyper-mio revision

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -348,6 +348,7 @@ dependencies = [
  "libc 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "nix 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocksdb 0.4.3 (git+https://github.com/arkpar/rust-rocksdb.git)",
  "rust-crypto 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -369,7 +370,7 @@ dependencies = [
  "clippy 0.0.64 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethcore-rpc 1.2.0",
  "ethcore-util 1.2.0",
- "hyper 0.9.0-mio (git+https://github.com/hyperium/hyper?branch=mio)",
+ "hyper 0.9.1 (git+https://github.com/hyperium/hyper?branch=mio)",
  "jsonrpc-core 2.0.3 (git+https://github.com/tomusdrw/jsonrpc-core.git)",
  "jsonrpc-http-server 5.1.0 (git+https://github.com/tomusdrw/jsonrpc-http-server.git)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -504,8 +505,8 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "0.9.0-mio"
-source = "git+https://github.com/hyperium/hyper?branch=mio#fab6c4173063a10f2aacfe3872150537da3dcfdd"
+version = "0.9.1"
+source = "git+https://github.com/hyperium/hyper?branch=mio#8d121824231651cf22e7ad929e404032b28406df"
 dependencies = [
  "cookie 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -586,7 +587,7 @@ name = "jsonrpc-http-server"
 version = "5.1.0"
 source = "git+https://github.com/tomusdrw/jsonrpc-http-server.git#fafd6410284710b7e662fe7d76249cc496451f27"
 dependencies = [
- "hyper 0.9.0-mio (git+https://github.com/hyperium/hyper?branch=mio)",
+ "hyper 0.9.1 (git+https://github.com/hyperium/hyper?branch=mio)",
  "jsonrpc-core 2.0.3 (git+https://github.com/tomusdrw/jsonrpc-core.git)",
  "unicase 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]


### PR DESCRIPTION
Rebase in `mio` branch of `hyper` (older revision is not valid anymore)