### PR TITLE
Limiting result of the execution to execution-specific errors

### DIFF
--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -440,8 +440,8 @@ impl<V> BlockChainClient for Client<V> where V: Verifier {
 		// that's just a copy of the state.
 		let mut state = self.state();
 		let sender = try!(t.sender().map_err(|e| {
-			warn!(target: "evm", "Transaction mallformed: {:?}", e);
-			ExecutionError::TransactionMallformed
+			let message = format!("Transaction mallformed: {:?}", e);
+			ExecutionError::TransactionMallformed(message)
 		}));
 		let balance = state.balance(&sender);
 		// give the sender max balance

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -440,8 +440,8 @@ impl<V> BlockChainClient for Client<V> where V: Verifier {
 		// that's just a copy of the state.
 		let mut state = self.state();
 		let sender = try!(t.sender().map_err(|e| {
-			let message = format!("Transaction mallformed: {:?}", e);
-			ExecutionError::TransactionMallformed(message)
+			let message = format!("Transaction malformed: {:?}", e);
+			ExecutionError::TransactionMalformed(message)
 		}));
 		let balance = state.balance(&sender);
 		// give the sender max balance

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -424,7 +424,7 @@ impl<V> Client<V> where V: Verifier {
 }
 
 impl<V> BlockChainClient for Client<V> where V: Verifier {
-	fn call(&self, t: &SignedTransaction) -> Result<Executed, Error> {
+	fn call(&self, t: &SignedTransaction) -> Result<Executed, ExecutionError> {
 		let header = self.block_header(BlockId::Latest).unwrap();
 		let view = HeaderView::new(&header);
 		let last_hashes = self.build_last_hashes(view.hash());
@@ -439,7 +439,10 @@ impl<V> BlockChainClient for Client<V> where V: Verifier {
 		};
 		// that's just a copy of the state.
 		let mut state = self.state();
-		let sender = try!(t.sender());
+		let sender = try!(t.sender().map_err(|e| {
+			warn!(target: "evm", "Transaction mallformed: {:?}", e);
+			ExecutionError::TransactionMallformed
+		}));
 		let balance = state.balance(&sender);
 		// give the sender max balance
 		state.sub_balance(&sender, &balance);

--- a/ethcore/src/client/mod.rs
+++ b/ethcore/src/client/mod.rs
@@ -42,7 +42,7 @@ use header::{BlockNumber, Header};
 use transaction::{LocalizedTransaction, SignedTransaction};
 use log_entry::LocalizedLogEntry;
 use filter::Filter;
-use error::{ImportResult, Error};
+use error::{ImportResult, ExecutionError};
 use receipt::LocalizedReceipt;
 use engine::{Engine};
 use trace::LocalizedTrace;
@@ -133,7 +133,7 @@ pub trait BlockChainClient : Sync + Send {
 	fn try_seal(&self, block: LockedBlock, seal: Vec<Bytes>) -> Result<SealedBlock, LockedBlock>;
 
 	/// Makes a non-persistent transaction call.
-	fn call(&self, t: &SignedTransaction) -> Result<Executed, Error>;
+	fn call(&self, t: &SignedTransaction) -> Result<Executed, ExecutionError>;
 
 	/// Attempt to seal the block internally. See `Engine`.
 	fn generate_seal(&self, block: &ExecutedBlock, accounts: Option<&AccountProvider>) -> Option<Vec<Bytes>> { self.engine().generate_seal(block, accounts) }

--- a/ethcore/src/client/test_client.rs
+++ b/ethcore/src/client/test_client.rs
@@ -31,7 +31,7 @@ use error::{ImportResult};
 use block_queue::BlockQueueInfo;
 use block::{SealedBlock, ClosedBlock, LockedBlock};
 use executive::Executed;
-use error::Error;
+use error::{ExecutionError};
 use engine::Engine;
 use trace::LocalizedTrace;
 
@@ -221,7 +221,7 @@ impl TestBlockChainClient {
 }
 
 impl BlockChainClient for TestBlockChainClient {
-	fn call(&self, _t: &SignedTransaction) -> Result<Executed, Error> {
+	fn call(&self, _t: &SignedTransaction) -> Result<Executed, ExecutionError> {
 		Ok(self.execution_result.read().unwrap().clone().unwrap())
 	}
 

--- a/ethcore/src/error.rs
+++ b/ethcore/src/error.rs
@@ -60,8 +60,8 @@ pub enum ExecutionError {
 	},
 	/// Returned when internal evm error occurs.
 	Internal,
-	/// Returned when transaction mallformed.
-	TransactionMallformed,
+	/// Returned when generic transaction occurs
+	TransactionMallformed(String),
 }
 
 #[derive(Debug, PartialEq)]

--- a/ethcore/src/error.rs
+++ b/ethcore/src/error.rs
@@ -61,7 +61,7 @@ pub enum ExecutionError {
 	/// Returned when internal evm error occurs.
 	Internal,
 	/// Returned when transaction mallformed.
-	TransactionMallformed
+	TransactionMallformed,
 }
 
 #[derive(Debug, PartialEq)]

--- a/ethcore/src/error.rs
+++ b/ethcore/src/error.rs
@@ -61,7 +61,7 @@ pub enum ExecutionError {
 	/// Returned when internal evm error occurs.
 	Internal,
 	/// Returned when generic transaction occurs
-	TransactionMallformed(String),
+	TransactionMalformed(String),
 }
 
 #[derive(Debug, PartialEq)]

--- a/ethcore/src/error.rs
+++ b/ethcore/src/error.rs
@@ -59,7 +59,9 @@ pub enum ExecutionError {
 		got: U512
 	},
 	/// Returned when internal evm error occurs.
-	Internal
+	Internal,
+	/// Returned when transaction mallformed.
+	TransactionMallformed
 }
 
 #[derive(Debug, PartialEq)]

--- a/ethcore/src/executive.rs
+++ b/ethcore/src/executive.rs
@@ -130,8 +130,8 @@ impl<'a> Executive<'a> {
 	/// Execute transaction/call with tracing enabled
 	pub fn transact_with_tracer<T>(&'a mut self, t: &SignedTransaction, check_nonce: bool, mut tracer: T) -> Result<Executed, ExecutionError> where T: Tracer {
 		let sender = try!(t.sender().map_err(|e| {
-			let message = format!("Transaction mallformed: {:?}", e);
-			ExecutionError::TransactionMallformed(message)
+			let message = format!("Transaction malformed: {:?}", e);
+			ExecutionError::TransactionMalformed(message)
 		}));
 		let nonce = self.state.nonce(&sender);
 
@@ -986,7 +986,7 @@ mod tests {
 		};
 
 		match res {
-			Err(ExecutionError::TransactionMallformed(_)) => (),
+			Err(ExecutionError::TransactionMalformed(_)) => (),
 			_ => assert!(false, "Expected an invalid transaction error.")
 		}
 	}

--- a/ethcore/src/executive.rs
+++ b/ethcore/src/executive.rs
@@ -130,8 +130,8 @@ impl<'a> Executive<'a> {
 	/// Execute transaction/call with tracing enabled
 	pub fn transact_with_tracer<T>(&'a mut self, t: &SignedTransaction, check_nonce: bool, mut tracer: T) -> Result<Executed, ExecutionError> where T: Tracer {
 		let sender = try!(t.sender().map_err(|e| {
-			warn!(target: "evm", "Transaction mallformed: {:?}", e);
-			ExecutionError::TransactionMallformed
+			let message = format!("Transaction mallformed: {:?}", e);
+			ExecutionError::TransactionMallformed(message)
 		}));
 		let nonce = self.state.nonce(&sender);
 
@@ -986,8 +986,8 @@ mod tests {
 		};
 
 		match res {
-			Err(ExecutionError::TransactionMallformed) => (),
-			_ => assert!(false, "Expected invalid signature error.")
+			Err(ExecutionError::TransactionMallformed(_)) => (),
+			_ => assert!(false, "Expected an invalid transaction error.")
 		}
 	}
 

--- a/ethcore/src/executive.rs
+++ b/ethcore/src/executive.rs
@@ -986,7 +986,7 @@ mod tests {
 		};
 
 		match res {
-			Err(Error::Util(UtilError::Crypto(CryptoError::InvalidSignature))) => (),
+			Err(ExecutionError::TransactionMallformed) => (),
 			_ => assert!(false, "Expected invalid signature error.")
 		}
 	}
@@ -1018,7 +1018,7 @@ mod tests {
 		};
 
 		match res {
-			Err(Error::Execution(ExecutionError::InvalidNonce { expected, got }))
+			Err(ExecutionError::InvalidNonce { expected, got })
 				if expected == U256::zero() && got == U256::one() => (),
 			_ => assert!(false, "Expected invalid nonce error.")
 		}
@@ -1052,7 +1052,7 @@ mod tests {
 		};
 
 		match res {
-			Err(Error::Execution(ExecutionError::BlockGasLimitReached { gas_limit, gas_used, gas }))
+			Err(ExecutionError::BlockGasLimitReached { gas_limit, gas_used, gas })
 				if gas_limit == U256::from(100_000) && gas_used == U256::from(20_000) && gas == U256::from(80_001) => (),
 			_ => assert!(false, "Expected block gas limit error.")
 		}
@@ -1086,7 +1086,7 @@ mod tests {
 		};
 
 		match res {
-			Err(Error::Execution(ExecutionError::NotEnoughCash { required , got }))
+			Err(ExecutionError::NotEnoughCash { required , got })
 				if required == U512::from(100_018) && got == U512::from(100_017) => (),
 			_ => assert!(false, "Expected not enough cash error. {:?}", res)
 		}

--- a/miner/src/lib.rs
+++ b/miner/src/lib.rs
@@ -63,7 +63,7 @@ pub use external::{ExternalMiner, ExternalMinerService};
 use util::{H256, U256, Address, Bytes};
 use ethcore::client::{BlockChainClient, Executed};
 use ethcore::block::{ClosedBlock};
-use ethcore::error::{Error};
+use ethcore::error::{Error, ExecutionError};
 use ethcore::transaction::SignedTransaction;
 
 /// Miner client API
@@ -150,7 +150,7 @@ pub trait MinerService : Send + Sync {
 	fn balance(&self, chain: &BlockChainClient, address: &Address) -> U256;
 
 	/// Call into contract code using pending state.
-	fn call(&self, chain: &BlockChainClient, t: &SignedTransaction) -> Result<Executed, Error>;
+	fn call(&self, chain: &BlockChainClient, t: &SignedTransaction) -> Result<Executed, ExecutionError>;
 
 	/// Get storage value in pending state.
 	fn storage_at(&self, chain: &BlockChainClient, address: &Address, position: &H256) -> H256;

--- a/miner/src/miner.rs
+++ b/miner/src/miner.rs
@@ -240,7 +240,7 @@ impl MinerService for Miner {
 		}
 	}
 
-	fn call(&self, chain: &BlockChainClient, t: &SignedTransaction) -> Result<Executed, Error> {
+	fn call(&self, chain: &BlockChainClient, t: &SignedTransaction) -> Result<Executed, ExecutionError> {
 		let sealing_work = self.sealing_work.lock().unwrap();
 		match sealing_work.peek_last_ref() {
 			Some(work) => {
@@ -258,7 +258,10 @@ impl MinerService for Miner {
 				};
 				// that's just a copy of the state.
 				let mut state = block.state().clone();
-				let sender = try!(t.sender());
+				let sender = try!(t.sender().map_err(|e| {
+					warn!(target: "miner", "Transaction mallformed: {:?}", e);
+					ExecutionError::TransactionMallformed
+				}));
 				let balance = state.balance(&sender);
 				// give the sender max balance
 				state.sub_balance(&sender, &balance);

--- a/miner/src/miner.rs
+++ b/miner/src/miner.rs
@@ -259,8 +259,8 @@ impl MinerService for Miner {
 				// that's just a copy of the state.
 				let mut state = block.state().clone();
 				let sender = try!(t.sender().map_err(|e| {
-					let message = format!("Transaction mallformed: {:?}", e);
-					ExecutionError::TransactionMallformed(message)
+					let message = format!("Transaction malformed: {:?}", e);
+					ExecutionError::TransactionMalformed(message)
 				}));
 				let balance = state.balance(&sender);
 				// give the sender max balance

--- a/miner/src/miner.rs
+++ b/miner/src/miner.rs
@@ -259,8 +259,8 @@ impl MinerService for Miner {
 				// that's just a copy of the state.
 				let mut state = block.state().clone();
 				let sender = try!(t.sender().map_err(|e| {
-					warn!(target: "miner", "Transaction mallformed: {:?}", e);
-					ExecutionError::TransactionMallformed
+					let message = format!("Transaction mallformed: {:?}", e);
+					ExecutionError::TransactionMallformed(message)
 				}));
 				let balance = state.balance(&sender);
 				// give the sender max balance

--- a/rpc/src/v1/tests/helpers/miner_service.rs
+++ b/rpc/src/v1/tests/helpers/miner_service.rs
@@ -18,7 +18,7 @@
 
 use util::{Address, H256, Bytes, U256, FixedHash, Uint};
 use util::standard::*;
-use ethcore::error::Error;
+use ethcore::error::{Error, ExecutionError};
 use ethcore::client::{BlockChainClient, Executed};
 use ethcore::block::{ClosedBlock, IsBlock};
 use ethcore::transaction::SignedTransaction;
@@ -179,7 +179,7 @@ impl MinerService for TestMinerService {
 		self.latest_closed_block.lock().unwrap().as_ref().map_or_else(U256::zero, |b| b.block().fields().state.balance(address).clone())
 	}
 
-	fn call(&self, _chain: &BlockChainClient, _t: &SignedTransaction) -> Result<Executed, Error> {
+	fn call(&self, _chain: &BlockChainClient, _t: &SignedTransaction) -> Result<Executed, ExecutionError> {
 		unimplemented!();
 	}
 

--- a/sync/src/chain.rs
+++ b/sync/src/chain.rs
@@ -1193,7 +1193,7 @@ impl ChainSync {
 						let mut rlp_stream = RlpStream::new_list(route.blocks.len());
 						for block_hash in route.blocks {
 							let mut hash_rlp = RlpStream::new_list(2);
-							let difficulty = chain.block_total_difficulty(BlockId::Hash(block_hash.clone())).expect("Mallformed block without a difficulty on the chain!");
+							let difficulty = chain.block_total_difficulty(BlockId::Hash(block_hash.clone())).expect("Malformed block without a difficulty on the chain!");
 							hash_rlp.append(&block_hash);
 							hash_rlp.append(&difficulty);
 							rlp_stream.append_raw(&hash_rlp.out(), 1);
@@ -1570,7 +1570,7 @@ mod tests {
 	}
 
 	#[test]
-	fn handles_peer_new_block_mallformed() {
+	fn handles_peer_new_block_malformed() {
 		let mut client = TestBlockChainClient::new();
 		client.add_blocks(10, EachBlockWith::Uncle);
 

--- a/util/src/keys/directory.rs
+++ b/util/src/keys/directory.rs
@@ -381,7 +381,7 @@ impl KeyFileContent {
 		}
 	}
 
-	/// Loads key from valid json, returns error and records warning if key is mallformed
+	/// Loads key from valid json, returns error and records warning if key is malformed
 	pub fn load(json: &Json) -> Result<KeyFileContent, ()> {
 		match Self::from_json(json) {
 			Ok(key_file) => Ok(key_file),


### PR DESCRIPTION
Before this refactoring api calling parity should have an idea, what kind of errors it should or should not handle, because `fn call`/`fn transact` returned the most broad error type combined from erros of several crates (including some external ones)

After refactoring it should return error type designed specifically to the execution logic (or initial condition), and calling party has a complete number of errors it can possibly encounter in the single enum `ExecitionResult`