### PR TITLE
ethcore-db crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,7 +332,7 @@ dependencies = [
  "mio 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "nix 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
- "rocksdb 0.4.3 (git+https://github.com/arkpar/rust-rocksdb.git)",
+ "rocksdb 0.4.3",
  "rust-crypto 0.2.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -623,7 +623,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "librocksdb-sys"
 version = "0.2.3"
-source = "git+https://github.com/arkpar/rust-rocksdb.git#ae44ef33ed1358ffc79aa05ed77839d555daba33"
 dependencies = [
  "libc 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -965,10 +964,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "rocksdb"
 version = "0.4.3"
-source = "git+https://github.com/arkpar/rust-rocksdb.git#ae44ef33ed1358ffc79aa05ed77839d555daba33"
 dependencies = [
  "libc 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "librocksdb-sys 0.2.3 (git+https://github.com/arkpar/rust-rocksdb.git)",
+ "librocksdb-sys 0.2.3",
 ]
 
 [[package]]

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -9,13 +9,13 @@ build = "build.rs"
 
 [build-dependencies]
 syntex = "*"
-"ethcore-ipc-codegen" = { path = "../ipc/codegen" }
+ethcore-ipc-codegen = { path = "../ipc/codegen" }
 
 [dependencies]
 ethcore-util = { path = "../util" }
 clippy = { version = "0.0.67", optional = true}
 ethcore-devtools = { path = "../devtools" }
-"ethcore-ipc" = { path = "../ipc/rpc" }
+ethcore-ipc = { path = "../ipc/rpc" }
 rocksdb = { git = "https://github.com/ethcore/rust-rocksdb" }
 semver = "0.2"
 ethcore-ipc-nano = { path = "../ipc/nano" }

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -15,6 +15,7 @@ ethcore-util = { path = "../util" }
 clippy = { version = "0.0.67", optional = true}
 ethcore-devtools = { path = "../devtools" }
 "ethcore-ipc" = { path = "../ipc/rpc" }
+rocksdb = { git = "https://github.com/arkpar/rust-rocksdb.git" }
 
 [features]
 dev = ["clippy"]

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -16,7 +16,7 @@ ethcore-util = { path = "../util" }
 clippy = { version = "0.0.67", optional = true}
 ethcore-devtools = { path = "../devtools" }
 "ethcore-ipc" = { path = "../ipc/rpc" }
-rocksdb = { path = "../../rust-rocksdb" }
+rocksdb = { git = "https://github.com/ethcore/rust-rocksdb" }
 semver = "0.2"
 ethcore-ipc-nano = { path = "../ipc/nano" }
 

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+description = "Ethcore Database"
+homepage = "http://ethcore.io"
+license = "GPL-3.0"
+name = "ethcore-db"
+version = "1.2.0"
+authors = ["Ethcore <admin@ethcore.io>"]
+
+[build-dependencies]
+syntex = "*"
+"ethcore-ipc-codegen" = { path = "../ipc/codegen" }
+
+[dependencies]
+ethcore-util = { path = "../util" }
+clippy = { version = "0.0.67", optional = true}
+ethcore-devtools = { path = "../devtools" }
+"ethcore-ipc" = { path = "../ipc/rpc" }
+
+[features]
+dev = ["clippy"]

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -5,6 +5,7 @@ license = "GPL-3.0"
 name = "ethcore-db"
 version = "1.2.0"
 authors = ["Ethcore <admin@ethcore.io>"]
+build = "build.rs"
 
 [build-dependencies]
 syntex = "*"
@@ -16,6 +17,8 @@ clippy = { version = "0.0.67", optional = true}
 ethcore-devtools = { path = "../devtools" }
 "ethcore-ipc" = { path = "../ipc/rpc" }
 rocksdb = { path = "../../rust-rocksdb" }
+semver = "0.2"
+ethcore-ipc-nano = { path = "../ipc/nano" }
 
 [features]
 dev = ["clippy"]

--- a/db/Cargo.toml
+++ b/db/Cargo.toml
@@ -15,7 +15,7 @@ ethcore-util = { path = "../util" }
 clippy = { version = "0.0.67", optional = true}
 ethcore-devtools = { path = "../devtools" }
 "ethcore-ipc" = { path = "../ipc/rpc" }
-rocksdb = { git = "https://github.com/arkpar/rust-rocksdb.git" }
+rocksdb = { path = "../../rust-rocksdb" }
 
 [features]
 dev = ["clippy"]

--- a/db/build.rs
+++ b/db/build.rs
@@ -14,7 +14,30 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-//! Database ipc service
+extern crate syntex;
+extern crate ethcore_ipc_codegen as codegen;
 
-#![allow(dead_code, unused_assignments, unused_variables)] // codegen issues
-include!(concat!(env!("OUT_DIR"), "/lib.rs"));
+use std::env;
+use std::path::Path;
+
+pub fn main() {
+	let out_dir = env::var_os("OUT_DIR").unwrap();
+
+	// ipc pass
+	{
+		let src = Path::new("src/lib.rs.in");
+		let dst = Path::new(&out_dir).join("lib.intermediate.rs.in");
+		let mut registry = syntex::Registry::new();
+		codegen::register(&mut registry);
+		registry.expand("", &src, &dst).unwrap();
+	}
+
+	// binary serialization pass
+	{
+		let src = Path::new(&out_dir).join("lib.intermediate.rs.in");
+		let dst = Path::new(&out_dir).join("lib.rs");
+		let mut registry = syntex::Registry::new();
+		codegen::register(&mut registry);
+		registry.expand("", &src, &dst).unwrap();
+	}
+}

--- a/db/src/database.rs
+++ b/db/src/database.rs
@@ -199,9 +199,9 @@ impl DatabaseService for Database {
 		next_transaction
 	}
 
-	fn test(&self) -> Option<H2048> {
+	fn test(&self) -> Result<(), H2048> {
 		use util::hash::FixedHash;
-		Some(H2048::zero())
+		Ok(())
 	}
 }
 
@@ -320,11 +320,7 @@ mod client_tests {
 		let client = nanoipc::init_duplex_client::<DatabaseClient<_>>(url).unwrap();
 
 		client.open(DatabaseConfig { prefix_size: Some(8) }, path.as_str().to_owned()).unwrap();
-		assert!(client.is_empty().is_ok());
 		assert!(client.iter_next(2).is_none());
 		worker_should_exit.store(true, Ordering::Relaxed);
-
-//		assert_eq!(client.test(), Some(H2048::zero()));
-
 	}
 }

--- a/db/src/database.rs
+++ b/db/src/database.rs
@@ -73,7 +73,6 @@ impl DatabaseService for Database {
 		*db = Some(try!(DB::open(&opts, &path)));
 
 		*is_open = true;
-		assert_eq!(1, 0);
 		Ok(())
 	}
 

--- a/db/src/database.rs
+++ b/db/src/database.rs
@@ -27,7 +27,6 @@ use std::ops::*;
 use std::mem;
 use ipc::binary::BinaryConvertError;
 use std::collections::VecDeque;
-use util::numbers::H2048;
 
 impl From<String> for Error {
 	fn from(s: String) -> Error {
@@ -256,7 +255,6 @@ mod client_tests {
 	use devtools::*;
 	use nanoipc;
 	use std::sync::Arc;
-	use std::io::Write;
 	use std::sync::atomic::{Ordering, AtomicBool};
 
 	fn init_worker(addr: &str) -> nanoipc::Worker<Database> {
@@ -292,9 +290,6 @@ mod client_tests {
 
 	#[test]
 	fn can_open_db() {
-		use util::numbers::H2048;
-		use util::hash::FixedHash;
-
 		let url = "ipc:///tmp/parity-db-ipc-test-20.ipc";
 		let path = RandomTempPath::create_dir();
 

--- a/db/src/database.rs
+++ b/db/src/database.rs
@@ -73,6 +73,7 @@ impl DatabaseService for Database {
 		*db = Some(try!(DB::open(&opts, &path)));
 
 		*is_open = true;
+		assert_eq!(1, 0);
 		Ok(())
 	}
 
@@ -310,9 +311,10 @@ mod client_tests {
 		while !worker_is_ready.load(Ordering::Relaxed) { }
 		let client = nanoipc::init_duplex_client::<DatabaseClient<_>>(url).unwrap();
 
-		client.open(DatabaseConfig { prefix_size: Some(8) }, path.as_str().to_owned()).unwrap();
-
+//		client.open(DatabaseConfig { prefix_size: Some(8) }, path.as_str().to_owned()).unwrap();
+//		assert!(client.is_empty().is_ok());
 		worker_should_exit.store(true, Ordering::Relaxed);
-		assert!(client.is_empty().is_ok());
+
+		assert!(client.iter_next(0).is_none());
 	}
 }

--- a/db/src/database.rs
+++ b/db/src/database.rs
@@ -38,6 +38,17 @@ pub struct Database {
 	iterators: RwLock<HashMap<IteratorHandle, DBIterator<'static>>>,
 }
 
+impl Database {
+	fn new() -> Database {
+		Database {
+			db: RwLock::new(None),
+			is_open: Mutex::new(false),
+			transactions: RwLock::new(HashMap::new()),
+			iterators: RwLock::new(HashMap::new()),
+		}
+	}
+}
+
 impl DatabaseService for Database {
 	fn open(&self, path: String) -> Result<(), Error> {
 		if *self.is_open.lock().unwrap() { return Err(Error::AlreadyOpen); }
@@ -157,5 +168,19 @@ impl DatabaseService for Database {
 		transactions.insert(next_transaction, WriteBatch::new());
 
 		next_transaction
+	}
+}
+
+
+#[cfg(test)]
+mod test {
+
+	use super::Database;
+	use traits::*;
+
+	#[test]
+	fn can_be_created() {
+		let db = Database::new();
+		assert!(db.is_empty().is_err());
 	}
 }

--- a/db/src/database.rs
+++ b/db/src/database.rs
@@ -19,7 +19,7 @@
 use traits::*;
 use rocksdb::{DB, Writable, WriteBatch, IteratorMode, DBIterator,
 	IndexType, Options, DBCompactionStyle, BlockBasedOptions, Direction};
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 use std::sync::{RwLock};
 use std::convert::From;
 use ipc::IpcConfig;
@@ -36,16 +36,16 @@ impl From<String> for Error {
 
 pub struct Database {
 	db: RwLock<Option<DB>>,
-	transactions: RwLock<HashMap<TransactionHandle, WriteBatch>>,
-	iterators: RwLock<HashMap<IteratorHandle, DBIterator>>,
+	transactions: RwLock<BTreeMap<TransactionHandle, WriteBatch>>,
+	iterators: RwLock<BTreeMap<IteratorHandle, DBIterator>>,
 }
 
 impl Database {
 	pub fn new() -> Database {
 		Database {
 			db: RwLock::new(None),
-			transactions: RwLock::new(HashMap::new()),
-			iterators: RwLock::new(HashMap::new()),
+			transactions: RwLock::new(BTreeMap::new()),
+			iterators: RwLock::new(BTreeMap::new()),
 		}
 	}
 }

--- a/db/src/database.rs
+++ b/db/src/database.rs
@@ -1,0 +1,63 @@
+// Copyright 2015, 2016 Ethcore (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Ethcore database trait
+
+pub type TransactionHandle = u32;
+pub type IteratorHandle = u32;
+
+use rocksdb::{DB, Writable, WriteBatch, IteratorMode, DBVector, DBIterator,
+	IndexType, Options, DBCompactionStyle, BlockBasedOptions, Direction};
+
+pub struct KeyValue {
+	pub key: Vec<u8>,
+	pub value: Vec<u8>,
+}
+
+pub trait Database {
+	/// Insert a key-value pair in the transaction. Any existing value value will be overwritten.
+	fn put(&self, key: Vec<u8>, value: Vec<u8>) -> Result<(), String>;
+
+	/// Delete value by key.
+	fn delete(&self, key: Vec<u8>) -> Result<(), String>;
+
+	/// Insert a key-value pair in the transaction. Any existing value value will be overwritten.
+	fn transaction_put(&self, transaction: TransactionHandle, key: Vec<u8>, value: Vec<u8>) -> Result<(), String>;
+
+	/// Delete value by key using transaction
+	fn transaction_delete(&self, transaction: TransactionHandle, key: Vec<u8>) -> Result<(), String>;
+
+	/// Commit transaction to database.
+	fn write(&self, tr: TransactionHandle) -> Result<(), String>;
+
+	/// Initiate new transaction on database
+	fn new_transaction(&self) -> TransactionHandle;
+
+	/// Get value by key.
+	fn get(&self, key: Vec<u8>) -> Result<Option<Vec<u8>>, String>;
+
+	/// Get value by partial key. Prefix size should match configured prefix size.
+	fn get_by_prefix(&self, prefix: Vec<u8>) -> Option<Vec<u8>>;
+
+	/// Check if there is anything in the database.
+	fn is_empty(&self) -> bool;
+
+	/// Get handle to iterate through keys
+	fn iter(&self) -> IteratorHandle;
+
+	/// Next key-value for the the given iterator
+	fn iter_next(&self, iterator: IteratorHandle) -> Option<KeyValue>;
+}

--- a/db/src/database.rs
+++ b/db/src/database.rs
@@ -310,10 +310,9 @@ mod client_tests {
 		while !worker_is_ready.load(Ordering::Relaxed) { }
 		let client = nanoipc::init_duplex_client::<DatabaseClient<_>>(url).unwrap();
 
-//		client.open(DatabaseConfig { prefix_size: Some(8) }, path.as_str().to_owned()).unwrap();
-//		assert!(client.is_empty().is_ok());
+		client.open(DatabaseConfig { prefix_size: Some(8) }, path.as_str().to_owned()).unwrap();
+		assert!(client.is_empty().is_ok());
 		worker_should_exit.store(true, Ordering::Relaxed);
 
-		assert!(client.iter_next(0).is_none());
 	}
 }

--- a/db/src/database.rs
+++ b/db/src/database.rs
@@ -198,11 +198,6 @@ impl DatabaseService for Database {
 
 		next_transaction
 	}
-
-	fn test(&self) -> Result<(), H2048> {
-		use util::hash::FixedHash;
-		Ok(())
-	}
 }
 
 // TODO : put proper at compile-time
@@ -320,7 +315,7 @@ mod client_tests {
 		let client = nanoipc::init_duplex_client::<DatabaseClient<_>>(url).unwrap();
 
 		client.open(DatabaseConfig { prefix_size: Some(8) }, path.as_str().to_owned()).unwrap();
-		assert!(client.iter_next(2).is_none());
+		assert!(client.is_empty().unwrap());
 		worker_should_exit.store(true, Ordering::Relaxed);
 	}
 }

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -16,6 +16,7 @@
 
 extern crate ethcore_ipc as ipc;
 extern crate rocksdb;
+extern crate ethcore_devtools as devtools;
 
 pub mod database;
 pub mod traits;

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -14,5 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-pub mod database;
+extern crate ethcore_ipc as ipc;
+extern crate rocksdb;
 
+pub mod database;
+pub mod traits;

--- a/db/src/lib.rs
+++ b/db/src/lib.rs
@@ -1,0 +1,18 @@
+// Copyright 2015, 2016 Ethcore (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+pub mod database;
+

--- a/db/src/lib.rs.in
+++ b/db/src/lib.rs.in
@@ -14,7 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-//! Database ipc service
+extern crate ethcore_ipc as ipc;
+extern crate rocksdb;
+extern crate ethcore_devtools as devtools;
+extern crate semver;
+extern crate ethcore_ipc_nano as nanoipc;
 
-#![allow(dead_code, unused_assignments, unused_variables)] // codegen issues
-include!(concat!(env!("OUT_DIR"), "/lib.rs"));
+pub mod database;
+pub mod traits;

--- a/db/src/lib.rs.in
+++ b/db/src/lib.rs.in
@@ -19,6 +19,7 @@ extern crate rocksdb;
 extern crate ethcore_devtools as devtools;
 extern crate semver;
 extern crate ethcore_ipc_nano as nanoipc;
+extern crate ethcore_util as util;
 
 pub mod database;
 pub mod traits;

--- a/db/src/traits.rs
+++ b/db/src/traits.rs
@@ -8,6 +8,7 @@ pub struct KeyValue {
 	pub value: Vec<u8>,
 }
 
+#[derive(Debug)]
 pub enum Error {
 	AlreadyOpen,
 	IsClosed,
@@ -30,16 +31,16 @@ pub trait DatabaseService {
 	fn close(&self) -> Result<(), Error>;
 
 	/// Insert a key-value pair in the transaction. Any existing value value will be overwritten.
-	fn put(&self, key: Vec<u8>, value: Vec<u8>) -> Result<(), Error>;
+	fn put(&self, key: &[u8], value: &[u8]) -> Result<(), Error>;
 
 	/// Delete value by key.
-	fn delete(&self, key: Vec<u8>) -> Result<(), Error>;
+	fn delete(&self, key: &[u8]) -> Result<(), Error>;
 
 	/// Insert a key-value pair in the transaction. Any existing value value will be overwritten.
-	fn transaction_put(&self, transaction: TransactionHandle, key: Vec<u8>, value: Vec<u8>) -> Result<(), Error>;
+	fn transaction_put(&self, transaction: TransactionHandle, key: &[u8], value: &[u8]) -> Result<(), Error>;
 
 	/// Delete value by key using transaction
-	fn transaction_delete(&self, transaction: TransactionHandle, key: Vec<u8>) -> Result<(), Error>;
+	fn transaction_delete(&self, transaction: TransactionHandle, key: &[u8]) -> Result<(), Error>;
 
 	/// Commit transaction to database.
 	fn write(&self, tr: TransactionHandle) -> Result<(), Error>;
@@ -48,10 +49,10 @@ pub trait DatabaseService {
 	fn new_transaction(&self) -> TransactionHandle;
 
 	/// Get value by key.
-	fn get(&self, key: Vec<u8>) -> Result<Option<Vec<u8>>, Error>;
+	fn get(&self, key: &[u8]) -> Result<Option<Vec<u8>>, Error>;
 
 	/// Get value by partial key. Prefix size should match configured prefix size.
-	fn get_by_prefix(&self, prefix: Vec<u8>) -> Result<Option<Vec<u8>>, Error>;
+	fn get_by_prefix(&self, prefix: &[u8]) -> Result<Option<Vec<u8>>, Error>;
 
 	/// Check if there is anything in the database.
 	fn is_empty(&self) -> Result<bool, Error>;

--- a/db/src/traits.rs
+++ b/db/src/traits.rs
@@ -16,9 +16,15 @@ pub enum Error {
 	IteratorUnknown,
 }
 
+/// Database configuration
+pub struct DatabaseConfig {
+	/// Optional prefix size in bytes. Allows lookup by partial key.
+	pub prefix_size: Option<usize>
+}
+
 pub trait DatabaseService {
 	/// Opens database in the specified path
-	fn open(&self, path: String) -> Result<(), Error>;
+	fn open(&self, config: DatabaseConfig, path: String) -> Result<(), Error>;
 
 	/// Closes database
 	fn close(&self) -> Result<(), Error>;

--- a/db/src/traits.rs
+++ b/db/src/traits.rs
@@ -1,0 +1,44 @@
+//! Ethcore database trait
+
+pub type TransactionHandle = u32;
+pub type IteratorHandle = u32;
+
+pub struct KeyValue {
+	pub key: Vec<u8>,
+	pub value: Vec<u8>,
+}
+
+pub trait Database {
+	/// Insert a key-value pair in the transaction. Any existing value value will be overwritten.
+	fn put(&self, key: Vec<u8>, value: Vec<u8>) -> Result<(), String>;
+
+	/// Delete value by key.
+	fn delete(&self, key: Vec<u8>) -> Result<(), String>;
+
+	/// Insert a key-value pair in the transaction. Any existing value value will be overwritten.
+	fn transaction_put(&self, transaction: TransactionHandle, key: Vec<u8>, value: Vec<u8>) -> Result<(), String>;
+
+	/// Delete value by key using transaction
+	fn transaction_delete(&self, transaction: TransactionHandle, key: Vec<u8>) -> Result<(), String>;
+
+	/// Commit transaction to database.
+	fn write(&self, tr: TransactionHandle) -> Result<(), String>;
+
+	/// Initiate new transaction on database
+	fn new_transaction(&self) -> TransactionHandle;
+
+	/// Get value by key.
+	fn get(&self, key: Vec<u8>) -> Result<Option<Vec<u8>>, String>;
+
+	/// Get value by partial key. Prefix size should match configured prefix size.
+	fn get_by_prefix(&self, prefix: Vec<u8>) -> Option<Vec<u8>>;
+
+	/// Check if there is anything in the database.
+	fn is_empty(&self) -> bool;
+
+	/// Get handle to iterate through keys
+	fn iter(&self) -> IteratorHandle;
+
+	/// Next key-value for the the given iterator
+	fn iter_next(&self, iterator: IteratorHandle) -> Option<KeyValue>;
+}

--- a/db/src/traits.rs
+++ b/db/src/traits.rs
@@ -21,6 +21,7 @@ pub enum Error {
 	RocksDb(String),
 	TransactionUnknown,
 	IteratorUnknown,
+	UncommitedTransactions,
 }
 
 /// Database configuration

--- a/db/src/traits.rs
+++ b/db/src/traits.rs
@@ -71,5 +71,5 @@ pub trait DatabaseService {
 	/// Next key-value for the the given iterator
 	fn iter_next(&self, iterator: IteratorHandle) -> Option<KeyValue>;
 
-	fn test(&self) -> Option<H2048>;
+	fn test(&self) -> Result<(), H2048>;
 }

--- a/db/src/traits.rs
+++ b/db/src/traits.rs
@@ -1,14 +1,20 @@
 //! Ethcore database trait
 
+use ipc::BinaryConvertable;
+use std::mem;
+use ipc::binary::BinaryConvertError;
+use std::collections::VecDeque;
+
 pub type TransactionHandle = u32;
 pub type IteratorHandle = u32;
 
+#[derive(Binary)]
 pub struct KeyValue {
 	pub key: Vec<u8>,
 	pub value: Vec<u8>,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Binary)]
 pub enum Error {
 	AlreadyOpen,
 	IsClosed,
@@ -18,6 +24,7 @@ pub enum Error {
 }
 
 /// Database configuration
+#[derive(Binary)]
 pub struct DatabaseConfig {
 	/// Optional prefix size in bytes. Allows lookup by partial key.
 	pub prefix_size: Option<usize>

--- a/db/src/traits.rs
+++ b/db/src/traits.rs
@@ -70,6 +70,4 @@ pub trait DatabaseService {
 
 	/// Next key-value for the the given iterator
 	fn iter_next(&self, iterator: IteratorHandle) -> Option<KeyValue>;
-
-	fn test(&self) -> Result<(), H2048>;
 }

--- a/db/src/traits.rs
+++ b/db/src/traits.rs
@@ -4,6 +4,7 @@ use ipc::BinaryConvertable;
 use std::mem;
 use ipc::binary::BinaryConvertError;
 use std::collections::VecDeque;
+use util::numbers::H2048;
 
 pub type TransactionHandle = u32;
 pub type IteratorHandle = u32;
@@ -69,4 +70,6 @@ pub trait DatabaseService {
 
 	/// Next key-value for the the given iterator
 	fn iter_next(&self, iterator: IteratorHandle) -> Option<KeyValue>;
+
+	fn test(&self) -> Option<H2048>;
 }

--- a/db/src/traits.rs
+++ b/db/src/traits.rs
@@ -4,7 +4,6 @@ use ipc::BinaryConvertable;
 use std::mem;
 use ipc::binary::BinaryConvertError;
 use std::collections::VecDeque;
-use util::numbers::H2048;
 
 pub type TransactionHandle = u32;
 pub type IteratorHandle = u32;

--- a/db/src/traits.rs
+++ b/db/src/traits.rs
@@ -8,36 +8,50 @@ pub struct KeyValue {
 	pub value: Vec<u8>,
 }
 
-pub trait Database {
+pub enum Error {
+	AlreadyOpen,
+	IsClosed,
+	RocksDb(String),
+	TransactionUnknown,
+	IteratorUnknown,
+}
+
+pub trait DatabaseService {
+	/// Opens database in the specified path
+	fn open(&self, path: String) -> Result<(), Error>;
+
+	/// Closes database
+	fn close(&self) -> Result<(), Error>;
+
 	/// Insert a key-value pair in the transaction. Any existing value value will be overwritten.
-	fn put(&self, key: Vec<u8>, value: Vec<u8>) -> Result<(), String>;
+	fn put(&self, key: Vec<u8>, value: Vec<u8>) -> Result<(), Error>;
 
 	/// Delete value by key.
-	fn delete(&self, key: Vec<u8>) -> Result<(), String>;
+	fn delete(&self, key: Vec<u8>) -> Result<(), Error>;
 
 	/// Insert a key-value pair in the transaction. Any existing value value will be overwritten.
-	fn transaction_put(&self, transaction: TransactionHandle, key: Vec<u8>, value: Vec<u8>) -> Result<(), String>;
+	fn transaction_put(&self, transaction: TransactionHandle, key: Vec<u8>, value: Vec<u8>) -> Result<(), Error>;
 
 	/// Delete value by key using transaction
-	fn transaction_delete(&self, transaction: TransactionHandle, key: Vec<u8>) -> Result<(), String>;
+	fn transaction_delete(&self, transaction: TransactionHandle, key: Vec<u8>) -> Result<(), Error>;
 
 	/// Commit transaction to database.
-	fn write(&self, tr: TransactionHandle) -> Result<(), String>;
+	fn write(&self, tr: TransactionHandle) -> Result<(), Error>;
 
 	/// Initiate new transaction on database
 	fn new_transaction(&self) -> TransactionHandle;
 
 	/// Get value by key.
-	fn get(&self, key: Vec<u8>) -> Result<Option<Vec<u8>>, String>;
+	fn get(&self, key: Vec<u8>) -> Result<Option<Vec<u8>>, Error>;
 
 	/// Get value by partial key. Prefix size should match configured prefix size.
-	fn get_by_prefix(&self, prefix: Vec<u8>) -> Option<Vec<u8>>;
+	fn get_by_prefix(&self, prefix: Vec<u8>) -> Result<Option<Vec<u8>>, Error>;
 
 	/// Check if there is anything in the database.
-	fn is_empty(&self) -> bool;
+	fn is_empty(&self) -> Result<bool, Error>;
 
 	/// Get handle to iterate through keys
-	fn iter(&self) -> IteratorHandle;
+	fn iter(&self) -> Result<IteratorHandle, Error>;
 
 	/// Next key-value for the the given iterator
 	fn iter_next(&self, iterator: IteratorHandle) -> Option<KeyValue>;

--- a/ipc/codegen/src/codegen.rs
+++ b/ipc/codegen/src/codegen.rs
@@ -88,6 +88,13 @@ fn field_name(builder: &aster::AstBuilder, arg: &Arg) -> ast::Ident {
 	}
 }
 
+pub fn replace_slice_u8(builder: &aster::AstBuilder, ty: &P<ast::Ty>) -> P<ast::Ty> {
+	if ::syntax::print::pprust::ty_to_string(&strip_ptr(ty)) == "[u8]" {
+		return builder.ty().id("Vec<u8>")
+	}
+	ty.clone()
+}
+
 fn push_invoke_signature_aster(
 	builder: &aster::AstBuilder,
 	implement: &ImplItem,
@@ -112,8 +119,8 @@ fn push_invoke_signature_aster(
 				.attr().word("derive(Binary)")
 				.attr().word("allow(non_camel_case_types)")
 				.struct_(name_str.as_str())
-				.field(arg_name.as_str()).ty()
-				.build(strip_ptr(arg_ty));
+				.field(arg_name.as_str())
+				.ty().build(replace_slice_u8(builder, &strip_ptr(arg_ty)));
 
 			arg_names.push(arg_name);
 			arg_tys.push(arg_ty.clone());
@@ -121,7 +128,7 @@ fn push_invoke_signature_aster(
 				let arg_name = format!("{}", field_name(builder, &arg));
 				let arg_ty = &arg.ty;
 
-				tree = tree.field(arg_name.as_str()).ty().build(strip_ptr(arg_ty));
+				tree = tree.field(arg_name.as_str()).ty().build(replace_slice_u8(builder, &strip_ptr(arg_ty)));
 				arg_names.push(arg_name);
 				arg_tys.push(arg_ty.clone());
 			}

--- a/ipc/codegen/src/codegen.rs
+++ b/ipc/codegen/src/codegen.rs
@@ -414,7 +414,7 @@ fn implement_client_method_body(
 		request_serialization_statements.push(
 			quote_stmt!(cx, let mut socket = socket_ref.deref_mut()));
 		request_serialization_statements.push(
-			quote_stmt!(cx, ::ipc::invoke($index_ident, Vec::new(), &mut socket)));
+			quote_stmt!(cx, ::ipc::invoke($index_ident, &None, &mut socket)));
 		request_serialization_statements
 	};
 

--- a/ipc/codegen/src/serialization.rs
+++ b/ipc/codegen/src/serialization.rs
@@ -175,30 +175,46 @@ fn binary_expr_struct(
 ) -> Result<BinaryExpressions, Error> {
 
 	let size_exprs: Vec<P<ast::Expr>> = fields.iter().enumerate().map(|(index, field)| {
-
-		if ::syntax::print::pprust::ty_to_string(&codegen::strip_ptr(&field.ty)) == "u8" {
-			return quote_expr!(cx, 1);
-		}
-
-		let field_type_ident = builder.id(
-			&::syntax::print::pprust::ty_to_string(&codegen::strip_ptr(&field.ty)));
-
-		let field_type_ident_qualified = builder.id(
-			replace_qualified(&::syntax::print::pprust::ty_to_string(&codegen::strip_ptr(&field.ty))));
-
+		let raw_ident = ::syntax::print::pprust::ty_to_string(&codegen::strip_ptr(&field.ty));
 		let index_ident = builder.id(format!("__field{}", index));
-		value_ident.and_then(|x| {
-				let field_id = builder.id(field.ident.unwrap());
-				Some(quote_expr!(cx,
-					match $field_type_ident_qualified::len_params() {
-						0 => mem::size_of::<$field_type_ident>(),
-						_ => $x. $field_id .size(),
-					}))
-			})
-			.unwrap_or_else(|| quote_expr!(cx, match $field_type_ident_qualified::len_params() {
-				0 => mem::size_of::<$field_type_ident>(),
-				_ => $index_ident .size(),
-			}))
+		match raw_ident.as_ref() {
+			"u8" => {
+				quote_expr!(cx, 1)
+			},
+			"[u8]" => {
+				value_ident.and_then(|x| {
+						let field_id = builder.id(field.ident.unwrap());
+						Some(quote_expr!(cx, $x. $field_id .len()))
+					})
+					.unwrap_or_else(|| {
+						quote_expr!(cx, $index_ident .len())
+					}
+				)
+			}
+			_ => {
+				let field_type_ident = builder.id(
+					&::syntax::print::pprust::ty_to_string(&codegen::strip_ptr(&field.ty)));
+
+				let field_type_ident_qualified = builder.id(
+					replace_qualified(&::syntax::print::pprust::ty_to_string(&codegen::strip_ptr(&field.ty))));
+
+				value_ident.and_then(|x|
+					{
+						let field_id = builder.id(field.ident.unwrap());
+						Some(quote_expr!(cx,
+							match $field_type_ident_qualified::len_params() {
+								0 => mem::size_of::<$field_type_ident>(),
+								_ => $x. $field_id .size(),
+							}))
+					})
+					.unwrap_or_else(|| {
+						quote_expr!(cx, match $field_type_ident_qualified::len_params() {
+							0 => mem::size_of::<$field_type_ident>(),
+							_ => $index_ident .size(),
+						})
+					})
+			}
+		}
 	}).collect();
 
 	let first_size_expr = size_exprs[0].clone();
@@ -233,17 +249,26 @@ fn binary_expr_struct(
 			},
 		};
 
-		if ::syntax::print::pprust::ty_to_string(&codegen::strip_ptr(&field.ty)) == "u8" {
-			write_stmts.push(quote_stmt!(cx, let next_line = offset + 1;).unwrap());
-			write_stmts.push(quote_stmt!(cx, buffer[offset] = $member_expr; ).unwrap());
-		}
-		else {
-			write_stmts.push(quote_stmt!(cx, let next_line = offset + match $field_type_ident_qualified::len_params() {
-					0 => mem::size_of::<$field_type_ident>(),
-					_ => { let size = $member_expr .size(); length_stack.push_back(size); size },
-				}).unwrap());
-			write_stmts.push(quote_stmt!(cx,
-				if let Err(e) = $member_expr .to_bytes(&mut buffer[offset..next_line], length_stack) { return Err(e) };).unwrap());
+		let raw_ident = ::syntax::print::pprust::ty_to_string(&codegen::strip_ptr(&field.ty));
+		match raw_ident.as_ref() {
+			"u8" => {
+				write_stmts.push(quote_stmt!(cx, let next_line = offset + 1;).unwrap());
+				write_stmts.push(quote_stmt!(cx, buffer[offset] = $member_expr; ).unwrap());
+			},
+			"[u8]" => {
+				write_stmts.push(quote_stmt!(cx, let size = $member_expr .len();).unwrap());
+				write_stmts.push(quote_stmt!(cx, let next_line = offset + size;).unwrap());
+				write_stmts.push(quote_stmt!(cx, length_stack.push_back(size);).unwrap());
+				write_stmts.push(quote_stmt!(cx, buffer[offset..next_line].clone_from_slice($member_expr); ).unwrap());
+			}
+			_ => {
+				write_stmts.push(quote_stmt!(cx, let next_line = offset + match $field_type_ident_qualified::len_params() {
+						0 => mem::size_of::<$field_type_ident>(),
+						_ => { let size = $member_expr .size(); length_stack.push_back(size); size },
+					}).unwrap());
+				write_stmts.push(quote_stmt!(cx,
+					if let Err(e) = $member_expr .to_bytes(&mut buffer[offset..next_line], length_stack) { return Err(e) };).unwrap());
+			}
 		}
 
 		write_stmts.push(quote_stmt!(cx, offset = next_line; ).unwrap());
@@ -251,15 +276,21 @@ fn binary_expr_struct(
 		let field_index = builder.id(&format!("{}", index));
 		map_stmts.push(quote_stmt!(cx, map[$field_index] = total;).unwrap());
 
-		if ::syntax::print::pprust::ty_to_string(&codegen::strip_ptr(&field.ty)) == "u8" {
-			map_stmts.push(quote_stmt!(cx, total = total + 1;).unwrap());
-		}
-		else {
-			map_stmts.push(quote_stmt!(cx, let size = match $field_type_ident_qualified::len_params() {
-					0 => mem::size_of::<$field_type_ident>(),
-					_ => length_stack.pop_front().unwrap(),
-				}).unwrap());
-			map_stmts.push(quote_stmt!(cx, total = total + size;).unwrap());
+		match raw_ident.as_ref() {
+			"u8" => {
+				map_stmts.push(quote_stmt!(cx, total = total + 1;).unwrap());
+			},
+			"[u8]" => {
+				map_stmts.push(quote_stmt!(cx, let size = length_stack.pop_front().unwrap();).unwrap());
+				map_stmts.push(quote_stmt!(cx, total = total + size;).unwrap());
+			},
+			_ => {
+				map_stmts.push(quote_stmt!(cx, let size = match $field_type_ident_qualified::len_params() {
+						0 => mem::size_of::<$field_type_ident>(),
+						_ => length_stack.pop_front().unwrap(),
+					}).unwrap());
+				map_stmts.push(quote_stmt!(cx, total = total + size;).unwrap());
+			}
 		}
 	};
 
@@ -419,6 +450,30 @@ fn fields_sequence(
 					continue;
 				}
 
+				// special case for [u8], it just takes a byte sequence
+				if ::syntax::print::pprust::ty_to_string(&field.ty) == "[u8]" {
+					tt.push(Token(_sp, token::Ident(ext_cx.ident_of("buffer"))));
+
+					tt.push(Token(_sp, token::OpenDelim(token::Bracket)));
+					tt.push(Token(_sp, token::Ident(ext_cx.ident_of("map"))));
+					tt.push(Token(_sp, token::OpenDelim(token::Bracket)));
+					tt.push(Token(_sp, token::Ident(ext_cx.ident_of(&format!("{}", idx)))));
+					tt.push(Token(_sp, token::CloseDelim(token::Bracket)));
+					tt.push(Token(_sp, token::DotDot));
+
+					if idx+1 != fields.len() {
+						tt.push(Token(_sp, token::Ident(ext_cx.ident_of("map"))));
+						tt.push(Token(_sp, token::OpenDelim(token::Bracket)));
+						tt.push(Token(_sp, token::Ident(ext_cx.ident_of(&format!("{}", idx+1)))));
+						tt.push(Token(_sp, token::CloseDelim(token::Bracket)));
+					}
+
+					tt.push(Token(_sp, token::CloseDelim(token::Bracket)));
+
+					tt.push(Token(_sp, token::Comma));
+					continue;
+				}
+
 				tt.push(Token(_sp, token::Ident(ext_cx.ident_of("try!"))));
 				tt.push(Token(_sp, token::OpenDelim(token::Paren)));
 				tt.push(
@@ -507,6 +562,30 @@ fn named_fields_sequence(
 					tt.push(Token(_sp, token::OpenDelim(token::Bracket)));
 					tt.push(Token(_sp, token::Ident(ext_cx.ident_of(&format!("{}", idx)))));
 					tt.push(Token(_sp, token::CloseDelim(token::Bracket)));
+					tt.push(Token(_sp, token::CloseDelim(token::Bracket)));
+
+					tt.push(Token(_sp, token::Comma));
+					continue;
+				}
+
+				// special case for [u8], it just takes a byte sequence
+				if ::syntax::print::pprust::ty_to_string(&field.ty) == "[u8]" {
+					tt.push(Token(_sp, token::Ident(ext_cx.ident_of("buffer"))));
+
+					tt.push(Token(_sp, token::OpenDelim(token::Bracket)));
+					tt.push(Token(_sp, token::Ident(ext_cx.ident_of("map"))));
+					tt.push(Token(_sp, token::OpenDelim(token::Bracket)));
+					tt.push(Token(_sp, token::Ident(ext_cx.ident_of(&format!("{}", idx)))));
+					tt.push(Token(_sp, token::CloseDelim(token::Bracket)));
+					tt.push(Token(_sp, token::DotDot));
+
+					if idx+1 != fields.len() {
+						tt.push(Token(_sp, token::Ident(ext_cx.ident_of("map"))));
+						tt.push(Token(_sp, token::OpenDelim(token::Bracket)));
+						tt.push(Token(_sp, token::Ident(ext_cx.ident_of(&format!("{}", idx+1)))));
+						tt.push(Token(_sp, token::CloseDelim(token::Bracket)));
+					}
+
 					tt.push(Token(_sp, token::CloseDelim(token::Bracket)));
 
 					tt.push(Token(_sp, token::Comma));

--- a/ipc/nano/src/lib.rs
+++ b/ipc/nano/src/lib.rs
@@ -116,6 +116,8 @@ impl<S> Worker<S> where S: IpcInterface<S> {
 
 	/// Polls all sockets, reads and dispatches method invocations
 	pub fn poll(&mut self) {
+		use std::io::Write;
+
 		let mut request = PollRequest::new(&mut self.polls[..]);
  		let _result_guard = Socket::poll(&mut request, POLL_TIMEOUT);
 
@@ -135,7 +137,7 @@ impl<S> Worker<S> where S: IpcInterface<S> {
 							// dispatching for ipc interface
 							let result = self.service.dispatch_buf(method_num, payload);
 
-							if let Err(e) = socket.nb_write(&result) {
+							if let Err(e) = socket.write(&result) {
 								warn!(target: "ipc", "Failed to write response: {:?}", e);
 							}
 						}

--- a/ipc/rpc/src/binary.rs
+++ b/ipc/rpc/src/binary.rs
@@ -581,3 +581,16 @@ fn serialize_opt_vec() {
 
 	assert_eq!(0, buff.get_ref()[2]);
 }
+
+#[test]
+fn deserialize_opt_vec() {
+	use std::io::Cursor;
+    let mut buff = Cursor::new(vec![
+		0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
+		0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8, 0u8,
+	]);
+
+	let vec = deserialize_from::<Option<Vec<u8>>, _>(&mut buff).unwrap();
+
+	assert!(vec.is_none());
+}

--- a/ipc/rpc/src/binary.rs
+++ b/ipc/rpc/src/binary.rs
@@ -104,8 +104,8 @@ impl<R: BinaryConvertable, E: BinaryConvertable> BinaryConvertable for Result<R,
 
 	fn to_bytes(&self, buffer: &mut [u8], length_stack: &mut VecDeque<usize>) -> Result<(), BinaryConvertError> {
 		match *self {
-			Ok(ref r) => Ok(try!(r.to_bytes(buffer, length_stack))),
-			Err(ref e) => Ok(try!(e.to_bytes(buffer, length_stack))),
+			Ok(ref r) => { buffer[0] = 0; Ok(try!(r.to_bytes(&mut buffer[1..], length_stack))) },
+			Err(ref e) => { buffer[1] = 1; Ok(try!(e.to_bytes(&mut buffer[1..], length_stack))) },
 		}
 	}
 

--- a/ipc/rpc/src/binary.rs
+++ b/ipc/rpc/src/binary.rs
@@ -594,3 +594,17 @@ fn deserialize_opt_vec() {
 
 	assert!(vec.is_none());
 }
+
+#[test]
+fn deserialize_opt_vec_in_out() {
+	use std::io::{Cursor, SeekFrom, Seek};
+
+	let mut buff = Cursor::new(vec![0; 128]);
+	let optional_vec: Option<Vec<u8>> = None;
+	serialize_into(&optional_vec, &mut buff).unwrap();
+
+	buff.seek(SeekFrom::Start(0)).unwrap();
+	let vec = deserialize_from::<Option<Vec<u8>>, _>(&mut buff).unwrap();
+
+	assert!(vec.is_none());
+}

--- a/ipc/tests/binary.rs.in
+++ b/ipc/tests/binary.rs.in
@@ -42,3 +42,17 @@ pub enum EnumWithStruct {
 	Left,
 	Right { how_much: u64 },
 }
+
+#[derive(Binary)]
+pub struct TwoVec {
+	v1: Vec<u8>,
+	v2: Vec<u8>,
+}
+
+#[test]
+fn opt_two_vec() {
+	let example: Option<TwoVec> = None;
+
+	let serialized = ::ipc::binary::serialize(&example).unwrap();
+	assert_eq!(serialized, vec![0u8; 16]);
+}

--- a/ipc/tests/nested.rs.in
+++ b/ipc/tests/nested.rs.in
@@ -30,6 +30,7 @@ pub struct DB<L: Sized> {
 
 pub trait DBWriter {
 	fn write(&self, data: Vec<u8>)  -> Result<(), DBError>;
+	fn write_slice(&self, data: &[u8]) -> Result<(), DBError>;
 }
 
 impl<L: Sized> IpcConfig for DB<L> {}
@@ -40,6 +41,12 @@ pub enum DBError { Write, Read }
 #[derive(Ipc)]
 impl<L: Sized> DBWriter for DB<L> {
 	fn write(&self, data: Vec<u8>) -> Result<(), DBError> {
+		let mut writes = self.writes.write().unwrap();
+		*writes = *writes + data.len() as u64;
+		Ok(())
+	}
+
+	fn write_slice(&self, data: &[u8]) -> Result<(), DBError> {
 		let mut writes = self.writes.write().unwrap();
 		*writes = *writes + data.len() as u64;
 		Ok(())

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -17,7 +17,7 @@ nix ="0.5.0"
 rand = "0.3.12"
 time = "0.1.34"
 tiny-keccak = "1.0"
-rocksdb = { git = "https://github.com/arkpar/rust-rocksdb.git" }
+rocksdb = { path = "../../rust-rocksdb" }
 lazy_static = "0.1"
 eth-secp256k1 = { git = "https://github.com/ethcore/rust-secp256k1" }
 rust-crypto = "0.2.34"

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -17,7 +17,7 @@ nix ="0.5.0"
 rand = "0.3.12"
 time = "0.1.34"
 tiny-keccak = "1.0"
-rocksdb = { path = "../../rust-rocksdb" }
+rocksdb = { git = "https://github.com/ethcore/rust-rocksdb" }
 lazy_static = "0.1"
 eth-secp256k1 = { git = "https://github.com/ethcore/rust-secp256k1" }
 rust-crypto = "0.2.34"

--- a/util/src/kvdb.rs
+++ b/util/src/kvdb.rs
@@ -55,11 +55,11 @@ pub struct DatabaseConfig {
 }
 
 /// Database iterator
-pub struct DatabaseIterator<'a> {
-	iter: DBIterator<'a>,
+pub struct DatabaseIterator {
+	iter: DBIterator,
 }
 
-impl<'a> Iterator for DatabaseIterator<'a> {
+impl<'a> Iterator for DatabaseIterator {
 	type Item = (Box<[u8]>, Box<[u8]>);
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -135,7 +135,7 @@ impl Database {
 
 	/// Get value by partial key. Prefix size should match configured prefix size.
 	pub fn get_by_prefix(&self, prefix: &[u8]) -> Option<Box<[u8]>> {
-		let mut iter = self.db.iterator(IteratorMode::From(prefix, Direction::forward));
+		let mut iter = self.db.iterator(IteratorMode::From(prefix, Direction::Forward));
 		match iter.next() {
 			// TODO: use prefix_same_as_start read option (not availabele in C API currently)
 			Some((k, v)) => if k[0 .. prefix.len()] == prefix[..] { Some(v) } else { None },


### PR DESCRIPTION
dedicated service for database exposed via ipc

client for database service (which is sharing `DatabaseService` trait for key-value operations) can be generated just like that:

```
let client = nanoipc::init_duplex_client::<DatabaseClient<_>>("~/.parity/db.ipc").unwrap();
client.open(DatabaseConfig { prefix_size: None }, "~/.parity/db").unwrap();
```

see `mod client_tests`

also contains some cryptic rpc codegen tricks to allow passing `&[u8]` in method signature