### PR TITLE
correct signature of SecTrieDB::raw_mut

### DIFF
--- a/util/src/trie/sectriedb.rs
+++ b/util/src/trie/sectriedb.rs
@@ -41,7 +41,7 @@ impl<'db> SecTrieDB<'db> {
 	}
 
 	/// Get a mutable reference to the underlying raw `TrieDB` struct.
-	pub fn raw_mut(&mut self) -> &TrieDB {
+	pub fn raw_mut(&mut self) -> &mut TrieDB<'db> {
 		&mut self.raw
 	}
 }


### PR DESCRIPTION
&mut T is invariant over its type parameter, so we need to specify the trait's lifetime explicitly rather than coerce it to the elided lifetime