### PR TITLE
Support "earliest" and specific block parameters in RPC where possible

### DIFF
--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -348,7 +348,8 @@ impl<V> Client<V> where V: Verifier {
 
 	/// Attempt to get a copy of a specific block's state.
 	///
-	/// This can fail (but may not) if the DB prunes state.
+	/// This will not fail if given BlockID::Latest.
+	/// Otherwise, this can fail (but may not) if the DB prunes state.
 	pub fn state_at(&self, id: BlockID) -> Option<State> {
 		// fast path for latest state.
 		if let BlockID::Latest = id.clone() {
@@ -556,9 +557,10 @@ impl<V> BlockChainClient for Client<V> where V: Verifier {
 		Self::block_hash(&self.chain, id).and_then(|hash| self.chain.block_details(&hash)).map(|d| d.total_difficulty)
 	}
 
-	fn nonce(&self, address: &Address) -> U256 {
-		self.state().nonce(address)
+	fn nonce(&self, address: &Address, id: BlockID) -> Option<U256> {
+		self.state_at(id).map(|s| s.nonce(address))
 	}
+
 
 	fn block_hash(&self, id: BlockID) -> Option<H256> {
 		Self::block_hash(&self.chain, id)

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -578,6 +578,13 @@ impl<V> BlockChainClient for Client<V> where V: Verifier {
 		self.state().storage_at(address, position)
 	}
 
+	fn storage_at_id(&self, address: &Address, position: &H256, id: BlockID) -> Option<H256> {
+		match id {
+			BlockID::Latest => Some(self.storage_at(address, position)),
+			id => self.state_at_id(id).map(|s| s.storage_at(address, position)),
+		}
+	}
+
 	fn transaction(&self, id: TransactionID) -> Option<LocalizedTransaction> {
 		self.transaction_address(id).and_then(|address| self.chain.transaction(&address))
 	}

--- a/ethcore/src/client/mod.rs
+++ b/ethcore/src/client/mod.rs
@@ -74,8 +74,20 @@ pub trait BlockChainClient : Sync + Send {
 	/// Get address code.
 	fn code(&self, address: &Address) -> Option<Bytes>;
 
-	/// Get address balance.
+	/// Get address balance at latest state.
 	fn balance(&self, address: &Address) -> U256;
+
+	/// Account balance at a specific block ID.
+	///
+	/// Will fail if the block is not valid or the block's root hash has been
+	/// pruned from the DB.
+	fn balance_at_id(&self, address: &Address, id: BlockID) -> Option<U256> {
+		if let BlockID::Latest = id {
+			Some(self.balance(address))
+		} else {
+			None
+		}
+	}
 
 	/// Get value of the storage at given position.
 	fn storage_at(&self, address: &Address, position: &H256) -> H256;

--- a/ethcore/src/client/mod.rs
+++ b/ethcore/src/client/mod.rs
@@ -70,7 +70,7 @@ pub trait BlockChainClient : Sync + Send {
 	fn nonce(&self, address: &Address, id: BlockID) -> Option<U256>;
 
 	/// Get address nonce at the latest block's state.
-	fn nonce_latest(&self, address: &Address) -> U256 {
+	fn latest_nonce(&self, address: &Address) -> U256 {
 		self.nonce(address, BlockID::Latest)
 			.expect("nonce will return Some when given BlockID::Latest. nonce was given BlockID::Latest. \
 			Therefore nonce has returned Some; qed")
@@ -89,7 +89,7 @@ pub trait BlockChainClient : Sync + Send {
 	fn balance(&self, address: &Address, id: BlockID) -> Option<U256>;
 
 	/// Get address balance at the latest block's state.
-	fn balance_latest(&self, address: &Address) -> U256 {
+	fn latest_balance(&self, address: &Address) -> U256 {
 		self.balance(address, BlockID::Latest)
 			.expect("balance will return Some if given BlockID::Latest. balance was given BlockID::Latest \
 			Therefore balance has returned Some; qed")
@@ -102,7 +102,7 @@ pub trait BlockChainClient : Sync + Send {
 	fn storage_at(&self, address: &Address, position: &H256, id: BlockID) -> Option<H256>;
 
 	/// Get value of the storage at given position at the latest block's state.
-	fn storage_at_latest(&self, address: &Address, position: &H256) -> H256 {
+	fn latest_storage_at(&self, address: &Address, position: &H256) -> H256 {
 		self.storage_at(address, position, BlockID::Latest)
 			.expect("storage_at will return Some if given BlockID::Latest. storage_at was given BlockID::Latest. \
 			Therefore storage_at has returned Some; qed")

--- a/ethcore/src/client/mod.rs
+++ b/ethcore/src/client/mod.rs
@@ -69,6 +69,7 @@ pub trait BlockChainClient : Sync + Send {
 	/// May not fail on BlockID::Latest.
 	fn nonce(&self, address: &Address, id: BlockID) -> Option<U256>;
 
+	/// Get address nonce at the latest block's state.
 	fn nonce_latest(&self, address: &Address) -> U256 {
 		self.nonce(address, BlockID::Latest)
 			.expect("nonce will return Some when given BlockID::Latest. nonce was given BlockID::Latest. \

--- a/ethcore/src/client/mod.rs
+++ b/ethcore/src/client/mod.rs
@@ -79,6 +79,7 @@ pub trait BlockChainClient : Sync + Send {
 
 	/// Account balance at a specific block ID.
 	///
+	/// Must not fail if `id` is `BlockID::Latest`.
 	/// Will fail if the block is not valid or the block's root hash has been
 	/// pruned from the DB.
 	fn balance_at_id(&self, address: &Address, id: BlockID) -> Option<U256> {
@@ -89,8 +90,17 @@ pub trait BlockChainClient : Sync + Send {
 		}
 	}
 
-	/// Get value of the storage at given position.
+	/// Get value of the storage at given position from the latest state.
 	fn storage_at(&self, address: &Address, position: &H256) -> H256;
+
+	/// Get value of the storage at given position form the latest state.
+	fn storage_at_id(&self, address: &Address, position: &H256, id: BlockID) -> Option<H256> {
+		if let BlockID::Latest = id {
+			Some(self.storage_at(address, position))
+		} else {
+			None
+		}
+	}
 
 	/// Get transaction with given hash.
 	fn transaction(&self, id: TransactionID) -> Option<LocalizedTransaction>;

--- a/ethcore/src/client/mod.rs
+++ b/ethcore/src/client/mod.rs
@@ -74,33 +74,15 @@ pub trait BlockChainClient : Sync + Send {
 	/// Get address code.
 	fn code(&self, address: &Address) -> Option<Bytes>;
 
-	/// Get address balance at latest state.
-	fn balance(&self, address: &Address) -> U256;
-
-	/// Account balance at a specific block ID.
+	/// Get address balance at the given block's state.
 	///
-	/// Must not fail if `id` is `BlockID::Latest`.
-	/// Will fail if the block is not valid or the block's root hash has been
-	/// pruned from the DB.
-	fn balance_at_id(&self, address: &Address, id: BlockID) -> Option<U256> {
-		if let BlockID::Latest = id {
-			Some(self.balance(address))
-		} else {
-			None
-		}
-	}
+	/// Returns None if and only if the block's root hash has been pruned from the DB.
+	fn balance(&self, address: &Address, id: BlockID) -> Option<U256>;
 
-	/// Get value of the storage at given position from the latest state.
-	fn storage_at(&self, address: &Address, position: &H256) -> H256;
-
-	/// Get value of the storage at given position form the latest state.
-	fn storage_at_id(&self, address: &Address, position: &H256, id: BlockID) -> Option<H256> {
-		if let BlockID::Latest = id {
-			Some(self.storage_at(address, position))
-		} else {
-			None
-		}
-	}
+	/// Get value of the storage at given position at the given block.
+	///
+	/// Returns None if and only if the block's root hash has been pruned from the DB.
+	fn storage_at(&self, address: &Address, position: &H256, id: BlockID) -> Option<H256>;
 
 	/// Get transaction with given hash.
 	fn transaction(&self, id: TransactionID) -> Option<LocalizedTransaction>;

--- a/ethcore/src/client/mod.rs
+++ b/ethcore/src/client/mod.rs
@@ -65,8 +65,15 @@ pub trait BlockChainClient : Sync + Send {
 	/// Get block total difficulty.
 	fn block_total_difficulty(&self, id: BlockID) -> Option<U256>;
 
-	/// Get address nonce.
-	fn nonce(&self, address: &Address) -> U256;
+	/// Attempt to get address nonce at given block.
+	/// May not fail on BlockID::Latest.
+	fn nonce(&self, address: &Address, id: BlockID) -> Option<U256>;
+
+	fn nonce_latest(&self, address: &Address) -> U256 {
+		self.nonce(address, BlockID::Latest)
+			.expect("nonce will return Some when given BlockID::Latest. nonce was given BlockID::Latest. \
+			Therefore nonce has returned Some; qed")
+	}
 
 	/// Get block hash.
 	fn block_hash(&self, id: BlockID) -> Option<H256>;

--- a/ethcore/src/client/mod.rs
+++ b/ethcore/src/client/mod.rs
@@ -83,13 +83,29 @@ pub trait BlockChainClient : Sync + Send {
 
 	/// Get address balance at the given block's state.
 	///
+	/// May not return None if given BlockID::Latest.
 	/// Returns None if and only if the block's root hash has been pruned from the DB.
 	fn balance(&self, address: &Address, id: BlockID) -> Option<U256>;
 
-	/// Get value of the storage at given position at the given block.
+	/// Get address balance at the latest block's state.
+	fn balance_latest(&self, address: &Address) -> U256 {
+		self.balance(address, BlockID::Latest)
+			.expect("balance will return Some if given BlockID::Latest. balance was given BlockID::Latest \
+			Therefore balance has returned Some; qed")
+	}
+
+	/// Get value of the storage at given position at the given block's state.
 	///
+	/// May not return None if given BlockID::Latest.
 	/// Returns None if and only if the block's root hash has been pruned from the DB.
 	fn storage_at(&self, address: &Address, position: &H256, id: BlockID) -> Option<H256>;
+
+	/// Get value of the storage at given position at the latest block's state.
+	fn storage_at_latest(&self, address: &Address, position: &H256) -> H256 {
+		self.storage_at(address, position, BlockID::Latest)
+			.expect("storage_at will return Some if given BlockID::Latest. storage_at was given BlockID::Latest. \
+			Therefore storage_at has returned Some; qed")
+	}
 
 	/// Get transaction with given hash.
 	fn transaction(&self, id: TransactionID) -> Option<LocalizedTransaction>;

--- a/ethcore/src/client/test_client.rs
+++ b/ethcore/src/client/test_client.rs
@@ -253,12 +253,20 @@ impl BlockChainClient for TestBlockChainClient {
 		self.code.read().unwrap().get(address).cloned()
 	}
 
-	fn balance(&self, address: &Address) -> U256 {
-		self.balances.read().unwrap().get(address).cloned().unwrap_or_else(U256::zero)
+	fn balance(&self, address: &Address, id: BlockID) -> Option<U256> {
+		if let BlockID::Latest = id {
+			Some(self.balances.read().unwrap().get(address).cloned().unwrap_or_else(U256::zero))
+		} else {
+			None
+		}
 	}
 
-	fn storage_at(&self, address: &Address, position: &H256) -> H256 {
-		self.storage.read().unwrap().get(&(address.clone(), position.clone())).cloned().unwrap_or_else(H256::new)
+	fn storage_at(&self, address: &Address, position: &H256, id: BlockID) -> Option<H256> {
+		if let BlockID::Latest = id {
+			Some(self.storage.read().unwrap().get(&(address.clone(), position.clone())).cloned().unwrap_or_else(H256::new))
+		} else {
+			None
+		}
 	}
 
 	fn transaction(&self, _id: TransactionID) -> Option<LocalizedTransaction> {

--- a/ethcore/src/client/test_client.rs
+++ b/ethcore/src/client/test_client.rs
@@ -245,8 +245,11 @@ impl BlockChainClient for TestBlockChainClient {
 		Self::block_hash(self, id)
 	}
 
-	fn nonce(&self, address: &Address) -> U256 {
-		self.nonces.read().unwrap().get(address).cloned().unwrap_or_else(U256::zero)
+	fn nonce(&self, address: &Address, id: BlockID) -> Option<U256> {
+		match id {
+			BlockID::Latest => Some(self.nonces.read().unwrap().get(address).cloned().unwrap_or_else(U256::zero)),
+			_ => None,
+		}
 	}
 
 	fn code(&self, address: &Address) -> Option<Bytes> {

--- a/miner/src/lib.rs
+++ b/miner/src/lib.rs
@@ -63,8 +63,8 @@ pub use external::{ExternalMiner, ExternalMinerService};
 use std::collections::BTreeMap;
 use util::{H256, U256, Address, Bytes};
 use ethcore::client::{BlockChainClient, Executed};
-use ethcore::block::{ClosedBlock};
-use ethcore::receipt::{Receipt};
+use ethcore::block::ClosedBlock;
+use ethcore::receipt::Receipt;
 use ethcore::error::{Error, ExecutionError};
 use ethcore::transaction::SignedTransaction;
 
@@ -154,7 +154,7 @@ pub trait MinerService : Send + Sync {
 	/// Suggested gas limit.
 	fn sensible_gas_limit(&self) -> U256 { x!(21000) }
 
-	/// Account balance
+	/// Latest account balance in pending state.
 	fn balance(&self, chain: &BlockChainClient, address: &Address) -> U256;
 
 	/// Call into contract code using pending state.

--- a/miner/src/miner.rs
+++ b/miner/src/miner.rs
@@ -167,8 +167,8 @@ impl Miner {
 		};
 		let mut queue = self.transaction_queue.lock().unwrap();
 		let fetch_account = |a: &Address| AccountDetails {
-			nonce: chain.nonce_latest(a),
-			balance: chain.balance_latest(a),
+			nonce: chain.latest_nonce(a),
+			balance: chain.latest_balance(a),
 		};
 		for hash in invalid_transactions.into_iter() {
 			queue.remove_invalid(&hash, &fetch_account);
@@ -291,7 +291,7 @@ impl MinerService for Miner {
 	fn balance(&self, chain: &BlockChainClient, address: &Address) -> U256 {
 		let sealing_work = self.sealing_work.lock().unwrap();
 		sealing_work.peek_last_ref().map_or_else(
-			|| chain.balance_latest(address),
+			|| chain.latest_balance(address),
 			|b| b.block().fields().state.balance(address)
 		)
 	}
@@ -299,14 +299,14 @@ impl MinerService for Miner {
 	fn storage_at(&self, chain: &BlockChainClient, address: &Address, position: &H256) -> H256 {
 		let sealing_work = self.sealing_work.lock().unwrap();
 		sealing_work.peek_last_ref().map_or_else(
-			|| chain.storage_at_latest(address, position),
+			|| chain.latest_storage_at(address, position),
 			|b| b.block().fields().state.storage_at(address, position)
 		)
 	}
 
 	fn nonce(&self, chain: &BlockChainClient, address: &Address) -> U256 {
 		let sealing_work = self.sealing_work.lock().unwrap();
-		sealing_work.peek_last_ref().map_or_else(|| chain.nonce_latest(address), |b| b.block().fields().state.nonce(address))
+		sealing_work.peek_last_ref().map_or_else(|| chain.latest_nonce(address), |b| b.block().fields().state.nonce(address))
 	}
 
 	fn code(&self, chain: &BlockChainClient, address: &Address) -> Option<Bytes> {
@@ -551,8 +551,8 @@ impl MinerService for Miner {
 					let _sender = tx.sender();
 				}
 				let _ = self.import_transactions(txs, |a| AccountDetails {
-					nonce: chain.nonce_latest(a),
-					balance: chain.balance_latest(a),
+					nonce: chain.latest_nonce(a),
+					balance: chain.latest_balance(a),
 				});
 			});
 		}
@@ -572,7 +572,7 @@ impl MinerService for Miner {
 						})
 						.collect::<HashSet<Address>>();
 				for sender in to_remove.into_iter() {
-					transaction_queue.remove_all(sender, chain.nonce_latest(&sender));
+					transaction_queue.remove_all(sender, chain.latest_nonce(&sender));
 				}
 			});
 		}

--- a/miner/src/miner.rs
+++ b/miner/src/miner.rs
@@ -167,8 +167,8 @@ impl Miner {
 		};
 		let mut queue = self.transaction_queue.lock().unwrap();
 		let fetch_account = |a: &Address| AccountDetails {
-			nonce: chain.nonce(a),
-			balance: chain.balance(a, BlockID::Latest).unwrap(),
+			nonce: chain.nonce_latest(a),
+			balance: chain.balance_latest(a),
 		};
 		for hash in invalid_transactions.into_iter() {
 			queue.remove_invalid(&hash, &fetch_account);
@@ -291,7 +291,7 @@ impl MinerService for Miner {
 	fn balance(&self, chain: &BlockChainClient, address: &Address) -> U256 {
 		let sealing_work = self.sealing_work.lock().unwrap();
 		sealing_work.peek_last_ref().map_or_else(
-			|| chain.balance(address, BlockID::Latest).unwrap(),
+			|| chain.balance_latest(address),
 			|b| b.block().fields().state.balance(address)
 		)
 	}
@@ -299,14 +299,14 @@ impl MinerService for Miner {
 	fn storage_at(&self, chain: &BlockChainClient, address: &Address, position: &H256) -> H256 {
 		let sealing_work = self.sealing_work.lock().unwrap();
 		sealing_work.peek_last_ref().map_or_else(
-			|| chain.storage_at(address, position, BlockID::Latest).unwrap(),
+			|| chain.storage_at_latest(address, position),
 			|b| b.block().fields().state.storage_at(address, position)
 		)
 	}
 
 	fn nonce(&self, chain: &BlockChainClient, address: &Address) -> U256 {
 		let sealing_work = self.sealing_work.lock().unwrap();
-		sealing_work.peek_last_ref().map_or_else(|| chain.nonce(address), |b| b.block().fields().state.nonce(address))
+		sealing_work.peek_last_ref().map_or_else(|| chain.nonce_latest(address), |b| b.block().fields().state.nonce(address))
 	}
 
 	fn code(&self, chain: &BlockChainClient, address: &Address) -> Option<Bytes> {
@@ -551,8 +551,8 @@ impl MinerService for Miner {
 					let _sender = tx.sender();
 				}
 				let _ = self.import_transactions(txs, |a| AccountDetails {
-					nonce: chain.nonce(a),
-					balance: chain.balance(a, BlockID::Latest).unwrap(),
+					nonce: chain.nonce_latest(a),
+					balance: chain.balance_latest(a),
 				});
 			});
 		}
@@ -572,7 +572,7 @@ impl MinerService for Miner {
 						})
 						.collect::<HashSet<Address>>();
 				for sender in to_remove.into_iter() {
-					transaction_queue.remove_all(sender, chain.nonce(&sender));
+					transaction_queue.remove_all(sender, chain.nonce_latest(&sender));
 				}
 			});
 		}

--- a/rpc/src/v1/impls/eth.rs
+++ b/rpc/src/v1/impls/eth.rs
@@ -164,7 +164,7 @@ impl<C, S, A, M, EM> EthClient<C, S, A, M, EM> where
 					.or_else(|| miner
 							 .last_nonce(&request.from)
 							 .map(|nonce| nonce + U256::one()))
-					.unwrap_or_else(|| client.nonce_latest(&request.from)),
+					.unwrap_or_else(|| client.latest_nonce(&request.from)),
 					action: request.to.map_or(Action::Create, Action::Call),
 					gas: request.gas.unwrap_or_else(|| miner.sensible_gas_limit()),
 					gas_price: request.gas_price.unwrap_or_else(|| miner.sensible_gas_price()),
@@ -181,7 +181,7 @@ impl<C, S, A, M, EM> EthClient<C, S, A, M, EM> where
 		let miner = take_weak!(self.miner);
 		let from = request.from.unwrap_or(Address::zero());
 		Ok(EthTransaction {
-			nonce: request.nonce.unwrap_or_else(|| client.nonce_latest(&from)),
+			nonce: request.nonce.unwrap_or_else(|| client.latest_nonce(&from)),
 			action: request.to.map_or(Action::Create, Action::Call),
 			gas: request.gas.unwrap_or(U256::from(50_000_000)),
 			gas_price: request.gas_price.unwrap_or_else(|| miner.sensible_gas_price()),
@@ -199,8 +199,8 @@ impl<C, S, A, M, EM> EthClient<C, S, A, M, EM> where
 
 			miner.import_own_transaction(client.deref(), signed_transaction, |a: &Address| {
 				AccountDetails {
-					nonce: client.nonce_latest(&a),
-					balance: client.balance_latest(&a),
+					nonce: client.latest_nonce(&a),
+					balance: client.latest_balance(&a),
 				}
 			})
 		};

--- a/rpc/src/v1/impls/eth.rs
+++ b/rpc/src/v1/impls/eth.rs
@@ -262,9 +262,9 @@ const UNSUPPORTED_REQUEST_CODE: i64 = -32000;
 
 fn make_unsupported_err() -> Error {
 	Error {
-			code: ErrorCode::ServerError(UNSUPPORTED_REQUEST_CODE),
-			message: "Unsupported request.".into(),
-			data: None
+		code: ErrorCode::ServerError(UNSUPPORTED_REQUEST_CODE),
+		message: "Unsupported request.".into(),
+		data: None
 	}
 }
 
@@ -362,8 +362,8 @@ impl<C, S, A, M, EM> Eth for EthClient<C, S, A, M, EM> where
 			.and_then(|(address, position, block_number,)| match block_number {
 				BlockNumber::Pending => to_value(&U256::from(take_weak!(self.miner).storage_at(&*take_weak!(self.client), &address, &H256::from(position)))),
 				id => match take_weak!(self.client).storage_at(&address, &H256::from(position), id.into()) {
-						Some(s) => to_value(&U256::from(s)),
-						None => Err(make_unsupported_err()), // None is only returned on unsupported requests.
+					Some(s) => to_value(&U256::from(s)),
+					None => Err(make_unsupported_err()), // None is only returned on unsupported requests.
 				}
 			})
 	}

--- a/rpc/src/v1/impls/eth.rs
+++ b/rpc/src/v1/impls/eth.rs
@@ -361,9 +361,9 @@ impl<C, S, A, M, EM> Eth for EthClient<C, S, A, M, EM> where
 	fn storage_at(&self, params: Params) -> Result<Value, Error> {
 		from_params_default_third::<Address, U256>(params)
 			.and_then(|(address, position, block_number,)| match block_number {
-				BlockNumber::Pending => to_value(&U256::from(take_weak!(self.miner).storage_at(take_weak!(self.client).deref(), &address, &H256::from(position)))),
+				BlockNumber::Pending => to_value(&U256::from(take_weak!(self.miner).storage_at(&*take_weak!(self.client), &address, &H256::from(position)))),
 				BlockNumber::Latest => to_value(&U256::from(take_weak!(self.client).storage_at(&address, &H256::from(position)))),
-				_ => Err(Error::invalid_params()),
+				id => to_value(&try!(take_weak!(self.client).storage_at_id(&address, &H256::from(position), id.into()).ok_or_else(make_unsupported_err))),
 			})
 	}
 

--- a/sync/src/chain.rs
+++ b/sync/src/chain.rs
@@ -901,7 +901,7 @@ impl ChainSync {
 		let chain = io.chain();
 		let fetch_account = |a: &Address| AccountDetails {
 			nonce: chain.nonce(a),
-			balance: chain.balance(a),
+			balance: chain.balance(a, BlockID::Latest).unwrap(),
 		};
 		let _ = self.miner.import_transactions(transactions, fetch_account);
 		Ok(())

--- a/sync/src/chain.rs
+++ b/sync/src/chain.rs
@@ -900,8 +900,8 @@ impl ChainSync {
 		}
 		let chain = io.chain();
 		let fetch_account = |a: &Address| AccountDetails {
-			nonce: chain.nonce(a),
-			balance: chain.balance(a, BlockID::Latest).unwrap(),
+			nonce: chain.nonce_latest(a),
+			balance: chain.balance_latest(a),
 		};
 		let _ = self.miner.import_transactions(transactions, fetch_account);
 		Ok(())

--- a/sync/src/chain.rs
+++ b/sync/src/chain.rs
@@ -900,8 +900,8 @@ impl ChainSync {
 		}
 		let chain = io.chain();
 		let fetch_account = |a: &Address| AccountDetails {
-			nonce: chain.nonce_latest(a),
-			balance: chain.balance_latest(a),
+			nonce: chain.latest_nonce(a),
+			balance: chain.latest_balance(a),
 		};
 		let _ = self.miner.import_transactions(transactions, fetch_account);
 		Ok(())


### PR DESCRIPTION
It may not be possible whenever the database does any kind of pruning.