### PR TITLE
Client interface refactoring (split to two traits)

### DIFF
--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -37,7 +37,7 @@ use filter::Filter;
 use log_entry::LocalizedLogEntry;
 use block_queue::{BlockQueue, BlockQueueInfo};
 use blockchain::{BlockChain, BlockProvider, TreeRoute, ImportRoute};
-use client::{BlockID, TransactionID, UncleID, TraceId, ClientConfig, BlockChainClient, TraceFilter};
+use client::{BlockID, TransactionID, UncleID, TraceId, ClientConfig, BlockChainClient, ExtendedBlockChainClient, TraceFilter};
 use client::Error as ClientError;
 use env_info::EnvInfo;
 use executive::{Executive, Executed, TransactOptions, contract_address};
@@ -448,79 +448,8 @@ impl<V> BlockChainClient for Client<V> where V: Verifier {
 		Executive::new(&mut state, &env_info, self.engine.deref().deref(), &self.vm_factory).transact(t, options)
 	}
 
-	// TODO [todr] Should be moved to miner crate eventually.
-	fn try_seal(&self, block: LockedBlock, seal: Vec<Bytes>) -> Result<SealedBlock, LockedBlock> {
-		block.try_seal(self.engine.deref().deref(), seal)
-	}
-
 	fn vm_factory(&self) -> &EvmFactory {
 		&self.vm_factory
-	}
-
-	// TODO [todr] Should be moved to miner crate eventually.
-	fn prepare_sealing(&self, author: Address, gas_floor_target: U256, extra_data: Bytes, transactions: Vec<SignedTransaction>)
-		-> (Option<ClosedBlock>, HashSet<H256>) {
-		let engine = self.engine.deref().deref();
-		let h = self.chain.best_block_hash();
-		let mut invalid_transactions = HashSet::new();
-
-		let mut b = OpenBlock::new(
-			engine,
-			&self.vm_factory,
-			false,	// TODO: this will need to be parameterised once we want to do immediate mining insertion.
-			self.state_db.lock().unwrap().boxed_clone(),
-			match self.chain.block_header(&h) { Some(ref x) => x, None => { return (None, invalid_transactions) } },
-			self.build_last_hashes(h.clone()),
-			author,
-			gas_floor_target,
-			extra_data,
-		);
-
-		// Add uncles
-		self.chain
-			.find_uncle_headers(&h, engine.maximum_uncle_age())
-			.unwrap()
-			.into_iter()
-			.take(engine.maximum_uncle_count())
-			.foreach(|h| {
-				b.push_uncle(h).unwrap();
-			});
-
-		// Add transactions
-		let block_number = b.block().header().number();
-		let min_tx_gas = U256::from(self.engine.schedule(&b.env_info()).tx_gas);
-
-		for tx in transactions {
-			// Push transaction to block
-			let hash = tx.hash();
-			let import = b.push_transaction(tx, None);
-
-			match import {
-				Err(Error::Execution(ExecutionError::BlockGasLimitReached { gas_limit, gas_used, .. })) => {
-					trace!(target: "miner", "Skipping adding transaction to block because of gas limit: {:?}", hash);
-					// Exit early if gas left is smaller then min_tx_gas
-					if gas_limit - gas_used < min_tx_gas {
-						break;
-					}
-				},
-				Err(e) => {
-					invalid_transactions.insert(hash);
-					trace!(target: "miner",
-						   "Error adding transaction to block: number={}. transaction_hash={:?}, Error: {:?}",
-						   block_number, hash, e);
-				},
-				_ => {}
-			}
-		}
-
-		// And close
-		let b = b.close();
-		trace!(target: "miner", "Sealing: number={}, hash={}, diff={}",
-			   b.block().header().number(),
-			   b.hash(),
-			   b.block().header().difficulty()
-		);
-		(Some(b), invalid_transactions)
 	}
 
 	fn block_header(&self, id: BlockID) -> Option<Bytes> {
@@ -773,6 +702,79 @@ impl<V> BlockChainClient for Client<V> where V: Verifier {
 
 	fn last_hashes(&self) -> LastHashes {
 		self.build_last_hashes(self.chain.best_block_hash())
+	}
+}
+
+impl<V> ExtendedBlockChainClient for Client<V> where V: Verifier {
+		// TODO [todr] Should be moved to miner crate eventually.
+	fn prepare_sealing(&self, author: Address, gas_floor_target: U256, extra_data: Bytes, transactions: Vec<SignedTransaction>)
+		-> (Option<ClosedBlock>, HashSet<H256>) {
+		let engine = self.engine.deref().deref();
+		let h = self.chain.best_block_hash();
+		let mut invalid_transactions = HashSet::new();
+
+		let mut b = OpenBlock::new(
+			engine,
+			&self.vm_factory,
+			false,	// TODO: this will need to be parameterised once we want to do immediate mining insertion.
+			self.state_db.lock().unwrap().boxed_clone(),
+			match self.chain.block_header(&h) { Some(ref x) => x, None => { return (None, invalid_transactions) } },
+			self.build_last_hashes(h.clone()),
+			author,
+			gas_floor_target,
+			extra_data,
+		);
+
+		// Add uncles
+		self.chain
+			.find_uncle_headers(&h, engine.maximum_uncle_age())
+			.unwrap()
+			.into_iter()
+			.take(engine.maximum_uncle_count())
+			.foreach(|h| {
+				b.push_uncle(h).unwrap();
+			});
+
+		// Add transactions
+		let block_number = b.block().header().number();
+		let min_tx_gas = U256::from(self.engine.schedule(&b.env_info()).tx_gas);
+
+		for tx in transactions {
+			// Push transaction to block
+			let hash = tx.hash();
+			let import = b.push_transaction(tx, None);
+
+			match import {
+				Err(Error::Execution(ExecutionError::BlockGasLimitReached { gas_limit, gas_used, .. })) => {
+					trace!(target: "miner", "Skipping adding transaction to block because of gas limit: {:?}", hash);
+					// Exit early if gas left is smaller then min_tx_gas
+					if gas_limit - gas_used < min_tx_gas {
+						break;
+					}
+				},
+				Err(e) => {
+					invalid_transactions.insert(hash);
+					trace!(target: "miner",
+						   "Error adding transaction to block: number={}. transaction_hash={:?}, Error: {:?}",
+						   block_number, hash, e);
+				},
+				_ => {}
+			}
+		}
+
+		// And close
+		let b = b.close();
+		trace!(target: "miner", "Sealing: number={}, hash={}, diff={}",
+			   b.block().header().number(),
+			   b.hash(),
+			   b.block().header().difficulty()
+		);
+		(Some(b), invalid_transactions)
+	}
+
+	// TODO [todr] Should be moved to miner crate eventually.
+	fn try_seal(&self, block: LockedBlock, seal: Vec<Bytes>) -> Result<SealedBlock, LockedBlock> {
+		block.try_seal(self.engine.deref().deref(), seal)
 	}
 }
 

--- a/ethcore/src/client/mod.rs
+++ b/ethcore/src/client/mod.rs
@@ -154,15 +154,6 @@ pub trait BlockChainClient : Sync + Send {
 	/// Returns logs matching given filter.
 	fn logs(&self, filter: Filter) -> Vec<LocalizedLogEntry>;
 
-	// TODO [todr] Should be moved to miner crate eventually.
-	/// Returns ClosedBlock prepared for sealing.
-	fn prepare_sealing(&self, author: Address, gas_floor_target: U256, extra_data: Bytes, transactions: Vec<SignedTransaction>)
-		-> (Option<ClosedBlock>, HashSet<H256>);
-
-	// TODO [todr] Should be moved to miner crate eventually.
-	/// Attempts to seal given block. Returns `SealedBlock` on success and the same block in case of error.
-	fn try_seal(&self, block: LockedBlock, seal: Vec<Bytes>) -> Result<SealedBlock, LockedBlock>;
-
 	/// Makes a non-persistent transaction call.
 	fn call(&self, t: &SignedTransaction) -> Result<Executed, ExecutionError>;
 
@@ -185,3 +176,14 @@ pub trait BlockChainClient : Sync + Send {
 	fn last_hashes(&self) -> LastHashes;
 }
 
+/// Extended client interface used for mining
+pub trait ExtendedBlockChainClient : BlockChainClient {
+	// TODO [todr] Should be moved to miner crate eventually.
+	/// Attempts to seal given block. Returns `SealedBlock` on success and the same block in case of error.
+	fn try_seal(&self, block: LockedBlock, seal: Vec<Bytes>) -> Result<SealedBlock, LockedBlock>;
+
+	// TODO [todr] Should be moved to miner crate eventually.
+	/// Returns ClosedBlock prepared for sealing.
+	fn prepare_sealing(&self, author: Address, gas_floor_target: U256, extra_data: Bytes, transactions: Vec<SignedTransaction>)
+		-> (Option<ClosedBlock>, HashSet<H256>);
+}

--- a/ethcore/src/client/test_client.rs
+++ b/ethcore/src/client/test_client.rs
@@ -20,7 +20,7 @@ use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrder};
 use util::*;
 use transaction::{Transaction, LocalizedTransaction, SignedTransaction, Action};
 use blockchain::TreeRoute;
-use client::{BlockChainClient, BlockChainInfo, BlockStatus, BlockID, TransactionID, UncleID, TraceId, TraceFilter, LastHashes};
+use client::{BlockChainClient, ExtendedBlockChainClient, BlockChainInfo, BlockStatus, BlockID, TransactionID, UncleID, TraceId, TraceFilter, LastHashes};
 use header::{Header as BlockHeader, BlockNumber};
 use filter::Filter;
 use log_entry::LocalizedLogEntry;
@@ -232,6 +232,17 @@ impl TestBlockChainClient {
 	}
 }
 
+impl ExtendedBlockChainClient for TestBlockChainClient {
+	fn try_seal(&self, block: LockedBlock, _seal: Vec<Bytes>) -> Result<SealedBlock, LockedBlock> {
+		Err(block)
+	}
+
+
+	fn prepare_sealing(&self, _author: Address, _gas_floor_target: U256, _extra_data: Bytes, _transactions: Vec<SignedTransaction>) -> (Option<ClosedBlock>, HashSet<H256>) {
+		(None, HashSet::new())
+	}
+}
+
 impl BlockChainClient for TestBlockChainClient {
 	fn call(&self, _t: &SignedTransaction) -> Result<Executed, ExecutionError> {
 		Ok(self.execution_result.read().unwrap().clone().unwrap())
@@ -294,14 +305,6 @@ impl BlockChainClient for TestBlockChainClient {
 
 	fn last_hashes(&self) -> LastHashes {
 		unimplemented!();
-	}
-
-	fn prepare_sealing(&self, _author: Address, _gas_floor_target: U256, _extra_data: Bytes, _transactions: Vec<SignedTransaction>) -> (Option<ClosedBlock>, HashSet<H256>) {
-		(None, HashSet::new())
-	}
-
-	fn try_seal(&self, block: LockedBlock, _seal: Vec<Bytes>) -> Result<SealedBlock, LockedBlock> {
-		Err(block)
 	}
 
 	fn block_header(&self, id: BlockID) -> Option<Bytes> {

--- a/miner/src/lib.rs
+++ b/miner/src/lib.rs
@@ -62,7 +62,7 @@ pub use external::{ExternalMiner, ExternalMinerService};
 
 use std::collections::BTreeMap;
 use util::{H256, U256, Address, Bytes};
-use ethcore::client::{BlockChainClient, Executed};
+use ethcore::client::{ExtendedBlockChainClient, Executed};
 use ethcore::block::ClosedBlock;
 use ethcore::receipt::Receipt;
 use ethcore::error::{Error, ExecutionError};
@@ -110,7 +110,7 @@ pub trait MinerService : Send + Sync {
 		where T: Fn(&Address) -> AccountDetails, Self: Sized;
 
 	/// Imports own (node owner) transaction to queue.
-	fn import_own_transaction<T>(&self, chain: &BlockChainClient, transaction: SignedTransaction, fetch_account: T) ->
+	fn import_own_transaction<T>(&self, chain: &ExtendedBlockChainClient, transaction: SignedTransaction, fetch_account: T) ->
 		Result<TransactionImportResult, Error>
 		where T: Fn(&Address) -> AccountDetails, Self: Sized;
 
@@ -118,20 +118,20 @@ pub trait MinerService : Send + Sync {
 	fn pending_transactions_hashes(&self) -> Vec<H256>;
 
 	/// Removes all transactions from the queue and restart mining operation.
-	fn clear_and_reset(&self, chain: &BlockChainClient);
+	fn clear_and_reset(&self, chain: &ExtendedBlockChainClient);
 
 	/// Called when blocks are imported to chain, updates transactions queue.
-	fn chain_new_blocks(&self, chain: &BlockChainClient, imported: &[H256], invalid: &[H256], enacted: &[H256], retracted: &[H256]);
+	fn chain_new_blocks(&self, chain: &ExtendedBlockChainClient, imported: &[H256], invalid: &[H256], enacted: &[H256], retracted: &[H256]);
 
 	/// New chain head event. Restart mining operation.
-	fn update_sealing(&self, chain: &BlockChainClient);
+	fn update_sealing(&self, chain: &ExtendedBlockChainClient);
 
 	/// Submit `seal` as a valid solution for the header of `pow_hash`.
 	/// Will check the seal, but not actually insert the block into the chain.
-	fn submit_seal(&self, chain: &BlockChainClient, pow_hash: H256, seal: Vec<Bytes>) -> Result<(), Error>;
+	fn submit_seal(&self, chain: &ExtendedBlockChainClient, pow_hash: H256, seal: Vec<Bytes>) -> Result<(), Error>;
 
 	/// Get the sealing work package and if `Some`, apply some transform.
-	fn map_sealing_work<F, T>(&self, chain: &BlockChainClient, f: F) -> Option<T>
+	fn map_sealing_work<F, T>(&self, chain: &ExtendedBlockChainClient, f: F) -> Option<T>
 		where F: FnOnce(&ClosedBlock) -> T, Self: Sized;
 
 	/// Query pending transactions for hash.
@@ -156,19 +156,19 @@ pub trait MinerService : Send + Sync {
 	fn sensible_gas_limit(&self) -> U256 { x!(21000) }
 
 	/// Latest account balance in pending state.
-	fn balance(&self, chain: &BlockChainClient, address: &Address) -> U256;
+	fn balance(&self, chain: &ExtendedBlockChainClient, address: &Address) -> U256;
 
 	/// Call into contract code using pending state.
-	fn call(&self, chain: &BlockChainClient, t: &SignedTransaction) -> Result<Executed, ExecutionError>;
+	fn call(&self, chain: &ExtendedBlockChainClient, t: &SignedTransaction) -> Result<Executed, ExecutionError>;
 
 	/// Get storage value in pending state.
-	fn storage_at(&self, chain: &BlockChainClient, address: &Address, position: &H256) -> H256;
+	fn storage_at(&self, chain: &ExtendedBlockChainClient, address: &Address, position: &H256) -> H256;
 
 	/// Get account nonce in pending state.
-	fn nonce(&self, chain: &BlockChainClient, address: &Address) -> U256;
+	fn nonce(&self, chain: &ExtendedBlockChainClient, address: &Address) -> U256;
 
 	/// Get contract code in pending state.
-	fn code(&self, chain: &BlockChainClient, address: &Address) -> Option<Bytes>;
+	fn code(&self, chain: &ExtendedBlockChainClient, address: &Address) -> Option<Bytes>;
 }
 
 /// Mining status

--- a/miner/src/miner.rs
+++ b/miner/src/miner.rs
@@ -20,7 +20,7 @@ use std::sync::atomic::AtomicBool;
 use util::*;
 use util::keys::store::{AccountService, AccountProvider};
 use ethcore::views::{BlockView, HeaderView};
-use ethcore::client::{BlockChainClient, BlockID};
+use ethcore::client::{ExtendedBlockChainClient, BlockID};
 use ethcore::block::{ClosedBlock, IsBlock};
 use ethcore::error::*;
 use ethcore::client::{Executive, Executed, EnvInfo, TransactOptions};
@@ -104,7 +104,7 @@ impl Miner {
 	/// Prepares new block for sealing including top transactions from queue.
 	#[cfg_attr(feature="dev", allow(match_same_arms))]
 	#[cfg_attr(feature="dev", allow(cyclomatic_complexity))]
-	fn prepare_sealing(&self, chain: &BlockChainClient) {
+	fn prepare_sealing(&self, chain: &ExtendedBlockChainClient) {
 		trace!(target: "miner", "prepare_sealing: entering");
 		let transactions = self.transaction_queue.lock().unwrap().top_transactions();
 		let mut sealing_work = self.sealing_work.lock().unwrap();
@@ -206,14 +206,14 @@ impl Miner {
 		trace!(target: "miner", "prepare_sealing: leaving (last={:?})", sealing_work.peek_last_ref().map(|b| b.block().fields().header.hash()));
 	}
 
-	fn update_gas_limit(&self, chain: &BlockChainClient) {
+	fn update_gas_limit(&self, chain: &ExtendedBlockChainClient) {
 		let gas_limit = HeaderView::new(&chain.best_block_header()).gas_limit();
 		let mut queue = self.transaction_queue.lock().unwrap();
 		queue.set_gas_limit(gas_limit);
 	}
 
 	/// Returns true if we had to prepare new pending block
-	fn enable_and_prepare_sealing(&self, chain: &BlockChainClient) -> bool {
+	fn enable_and_prepare_sealing(&self, chain: &ExtendedBlockChainClient) -> bool {
 		trace!(target: "miner", "enable_and_prepare_sealing: entering");
 		let have_work = self.sealing_work.lock().unwrap().peek_last_ref().is_some();
 		trace!(target: "miner", "enable_and_prepare_sealing: have_work={}", have_work);
@@ -237,7 +237,7 @@ const SEALING_TIMEOUT_IN_BLOCKS : u64 = 5;
 
 impl MinerService for Miner {
 
-	fn clear_and_reset(&self, chain: &BlockChainClient) {
+	fn clear_and_reset(&self, chain: &ExtendedBlockChainClient) {
 		self.transaction_queue.lock().unwrap().clear();
 		self.update_sealing(chain);
 	}
@@ -252,7 +252,7 @@ impl MinerService for Miner {
 		}
 	}
 
-	fn call(&self, chain: &BlockChainClient, t: &SignedTransaction) -> Result<Executed, ExecutionError> {
+	fn call(&self, chain: &ExtendedBlockChainClient, t: &SignedTransaction) -> Result<Executed, ExecutionError> {
 		let sealing_work = self.sealing_work.lock().unwrap();
 		match sealing_work.peek_last_ref() {
 			Some(work) => {
@@ -288,7 +288,7 @@ impl MinerService for Miner {
 		}
 	}
 
-	fn balance(&self, chain: &BlockChainClient, address: &Address) -> U256 {
+	fn balance(&self, chain: &ExtendedBlockChainClient, address: &Address) -> U256 {
 		let sealing_work = self.sealing_work.lock().unwrap();
 		sealing_work.peek_last_ref().map_or_else(
 			|| chain.latest_balance(address),
@@ -296,7 +296,7 @@ impl MinerService for Miner {
 		)
 	}
 
-	fn storage_at(&self, chain: &BlockChainClient, address: &Address, position: &H256) -> H256 {
+	fn storage_at(&self, chain: &ExtendedBlockChainClient, address: &Address, position: &H256) -> H256 {
 		let sealing_work = self.sealing_work.lock().unwrap();
 		sealing_work.peek_last_ref().map_or_else(
 			|| chain.latest_storage_at(address, position),
@@ -304,12 +304,12 @@ impl MinerService for Miner {
 		)
 	}
 
-	fn nonce(&self, chain: &BlockChainClient, address: &Address) -> U256 {
+	fn nonce(&self, chain: &ExtendedBlockChainClient, address: &Address) -> U256 {
 		let sealing_work = self.sealing_work.lock().unwrap();
 		sealing_work.peek_last_ref().map_or_else(|| chain.latest_nonce(address), |b| b.block().fields().state.nonce(address))
 	}
 
-	fn code(&self, chain: &BlockChainClient, address: &Address) -> Option<Bytes> {
+	fn code(&self, chain: &ExtendedBlockChainClient, address: &Address) -> Option<Bytes> {
 		let sealing_work = self.sealing_work.lock().unwrap();
 		sealing_work.peek_last_ref().map_or_else(|| chain.code(address), |b| b.block().fields().state.code(address))
 	}
@@ -376,7 +376,7 @@ impl MinerService for Miner {
 			.collect()
 	}
 
-	fn import_own_transaction<T>(&self, chain: &BlockChainClient, transaction: SignedTransaction, fetch_account: T) ->
+	fn import_own_transaction<T>(&self, chain: &ExtendedBlockChainClient, transaction: SignedTransaction, fetch_account: T) ->
 		Result<TransactionImportResult, Error>
 		where T: Fn(&Address) -> AccountDetails {
 		let hash = transaction.hash();
@@ -470,7 +470,7 @@ impl MinerService for Miner {
 		self.transaction_queue.lock().unwrap().last_nonce(address)
 	}
 
-	fn update_sealing(&self, chain: &BlockChainClient) {
+	fn update_sealing(&self, chain: &ExtendedBlockChainClient) {
 		if self.sealing_enabled.load(atomic::Ordering::Relaxed) {
 			let current_no = chain.chain_info().best_block_number;
 			let has_local_transactions = self.transaction_queue.lock().unwrap().has_local_pending_transactions();
@@ -490,7 +490,7 @@ impl MinerService for Miner {
 		}
 	}
 
-	fn map_sealing_work<F, T>(&self, chain: &BlockChainClient, f: F) -> Option<T> where F: FnOnce(&ClosedBlock) -> T {
+	fn map_sealing_work<F, T>(&self, chain: &ExtendedBlockChainClient, f: F) -> Option<T> where F: FnOnce(&ClosedBlock) -> T {
 		trace!(target: "miner", "map_sealing_work: entering");
 		self.enable_and_prepare_sealing(chain);
 		trace!(target: "miner", "map_sealing_work: sealing prepared");
@@ -500,7 +500,7 @@ impl MinerService for Miner {
 		ret.map(f)
 	}
 
-	fn submit_seal(&self, chain: &BlockChainClient, pow_hash: H256, seal: Vec<Bytes>) -> Result<(), Error> {
+	fn submit_seal(&self, chain: &ExtendedBlockChainClient, pow_hash: H256, seal: Vec<Bytes>) -> Result<(), Error> {
 		if let Some(b) = self.sealing_work.lock().unwrap().take_used_if(|b| &b.hash() == &pow_hash) {
 			match chain.try_seal(b.lock(), seal) {
 				Err(_) => {
@@ -523,8 +523,8 @@ impl MinerService for Miner {
 		}
 	}
 
-	fn chain_new_blocks(&self, chain: &BlockChainClient, _imported: &[H256], _invalid: &[H256], enacted: &[H256], retracted: &[H256]) {
-		fn fetch_transactions(chain: &BlockChainClient, hash: &H256) -> Vec<SignedTransaction> {
+	fn chain_new_blocks(&self, chain: &ExtendedBlockChainClient, _imported: &[H256], _invalid: &[H256], enacted: &[H256], retracted: &[H256]) {
+		fn fetch_transactions(chain: &ExtendedBlockChainClient, hash: &H256) -> Vec<SignedTransaction> {
 			let block = chain
 				.block(BlockID::Hash(*hash))
 				// Client should send message after commit to db and inserting to chain.
@@ -591,7 +591,7 @@ mod tests {
 	use ethcore::client::{TestBlockChainClient, EachBlockWith};
 	use ethcore::block::*;
 
-	// TODO [ToDr] To uncomment when TestBlockChainClient can actually return a ClosedBlock.
+	// TODO [ToDr] To uncomment` when TestBlockChainClient can actually return a ClosedBlock.
 	#[ignore]
 	#[test]
 	fn should_prepare_block_to_seal() {


### PR DESCRIPTION
You still have some time to introduce more descriptive name for it (instead of `ExtendedBlockChainClient`)