### PR TITLE
Disabling `ethcore` by default, adding x-frame-options header to dapps.

### DIFF
--- a/dapps/src/apps.rs
+++ b/dapps/src/apps.rs
@@ -40,6 +40,9 @@ pub fn all_endpoints() -> Endpoints {
 	let mut pages = Endpoints::new();
 	pages.insert("proxy".into(), ProxyPac::boxed());
 
+	// Home page needs to be safe embed
+	// because we use Cross-Origin LocalStorage.
+	// TODO [ToDr] Account naming should be moved to parity.
 	pages.insert("home".into(), Box::new(
 		PageEndpoint::new_safe_to_embed(parity_dapps_builtins::App::default())
 	));

--- a/dapps/src/apps.rs
+++ b/dapps/src/apps.rs
@@ -38,11 +38,13 @@ pub fn utils() -> Box<Endpoint> {
 
 pub fn all_endpoints() -> Endpoints {
 	let mut pages = Endpoints::new();
-	pages.insert("proxy".to_owned(), ProxyPac::boxed());
+	pages.insert("proxy".into(), ProxyPac::boxed());
 
+	pages.insert("home".into(), Box::new(
+		PageEndpoint::new_safe_to_embed(parity_dapps_builtins::App::default())
+	));
 	insert::<parity_dapps_status::App>(&mut pages, "status");
 	insert::<parity_dapps_status::App>(&mut pages, "parity");
-	insert::<parity_dapps_builtins::App>(&mut pages, "home");
 
 	wallet_page(&mut pages);
 	daodapp_page(&mut pages);

--- a/dapps/src/page/mod.rs
+++ b/dapps/src/page/mod.rs
@@ -212,6 +212,7 @@ fn should_extract_path_with_appid() {
 		},
 		file: None,
 		write_pos: 0,
+		safe_to_embed: true,
 	};
 
 	// when

--- a/dapps/src/page/mod.rs
+++ b/dapps/src/page/mod.rs
@@ -30,6 +30,8 @@ pub struct PageEndpoint<T : WebApp + 'static> {
 	pub app: Arc<T>,
 	/// Prefix to strip from the path (when `None` deducted from `app_id`)
 	pub prefix: Option<String>,
+	/// Safe to be loaded in frame by other origin. (use wisely!)
+	safe_to_embed: bool,
 }
 
 impl<T: WebApp + 'static> PageEndpoint<T> {
@@ -37,6 +39,7 @@ impl<T: WebApp + 'static> PageEndpoint<T> {
 		PageEndpoint {
 			app: Arc::new(app),
 			prefix: None,
+			safe_to_embed: false,
 		}
 	}
 
@@ -44,6 +47,18 @@ impl<T: WebApp + 'static> PageEndpoint<T> {
 		PageEndpoint {
 			app: Arc::new(app),
 			prefix: Some(prefix),
+			safe_to_embed: false,
+		}
+	}
+
+	/// Creates new `PageEndpoint` which can be safely used in iframe
+	/// even from different origin. It might be dangerous (clickjacking).
+	/// Use wisely!
+	pub fn new_safe_to_embed(app: T) -> Self {
+		PageEndpoint {
+			app: Arc::new(app),
+			prefix: None,
+			safe_to_embed: true,
 		}
 	}
 }
@@ -61,6 +76,7 @@ impl<T: WebApp> Endpoint for PageEndpoint<T> {
 			path: path,
 			file: None,
 			write_pos: 0,
+			safe_to_embed: self.safe_to_embed,
 		})
 	}
 }
@@ -83,6 +99,7 @@ struct PageHandler<T: WebApp + 'static> {
 	path: EndpointPath,
 	file: Option<String>,
 	write_pos: usize,
+	safe_to_embed: bool,
 }
 
 impl<T: WebApp + 'static> PageHandler<T> {
@@ -128,6 +145,9 @@ impl<T: WebApp + 'static> server::Handler<HttpStream> for PageHandler<T> {
 		if let Some(f) = self.file.as_ref().and_then(|f| self.app.file(f)) {
 			res.set_status(StatusCode::Ok);
 			res.headers_mut().set(header::ContentType(f.content_type.parse().unwrap()));
+			if !self.safe_to_embed {
+				res.headers_mut().set_raw("X-Frame-Options", vec![b"SAMEORIGIN".to_vec()]);
+			}
 			Next::write()
 		} else {
 			res.set_status(StatusCode::NotFound);

--- a/parity/cli.rs
+++ b/parity/cli.rs
@@ -76,13 +76,13 @@ API and Console Options:
                            interface. APIS is a comma-delimited list of API
                            name. Possible name are web3, eth, net, personal,
                            ethcore, traces.
-                           [default: web3,eth,net,personal,ethcore,traces].
+                           [default: web3,eth,net,personal,traces].
 
   --ipc-off                Disable JSON-RPC over IPC service.
   --ipc-path PATH          Specify custom path for JSON-RPC over IPC service
                            [default: $HOME/.parity/jsonrpc.ipc].
   --ipc-apis APIS          Specify custom API set available via JSON-RPC over
-                           IPC [default: web3,eth,net,personal,ethcore].
+                           IPC [default: web3,eth,net,personal,traces].
 
   --dapps-off              Disable the Dapps server (e.g. status page).
   --dapps-port PORT        Specify the port portion of the Dapps server


### PR DESCRIPTION
Related: #1194
Related: #1193 
