### PR TITLE
simplified block opening

### DIFF
--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -481,7 +481,7 @@ impl<V> BlockChainClient for Client<V> where V: Verifier {
 		}
 		let options = TransactOptions { tracing: false, vm_tracing: analytics.vm_tracing, check_nonce: false };
 		let mut ret = Executive::new(&mut state, &env_info, self.engine.deref().deref(), &self.vm_factory).transact(t, options);
-		
+
 		// TODO gav move this into Executive.
 		if analytics.state_diffing {
 			if let Ok(ref mut x) = ret {
@@ -760,18 +760,16 @@ impl<V> BlockChainClient for Client<V> where V: Verifier {
 }
 
 impl<V> MiningBlockChainClient for Client<V> where V: Verifier {
-	fn prepare_sealing(&self, author: Address, gas_floor_target: U256, extra_data: Bytes, transactions: Vec<SignedTransaction>)
-		-> (Option<ClosedBlock>, HashSet<H256>) {
+	fn prepare_open_block(&self, author: Address, gas_floor_target: U256, extra_data: Bytes) -> OpenBlock {
 		let engine = self.engine.deref().deref();
 		let h = self.chain.best_block_hash();
-		let mut invalid_transactions = HashSet::new();
 
-		let mut b = OpenBlock::new(
+		let mut open_block = OpenBlock::new(
 			engine,
 			&self.vm_factory,
 			false,	// TODO: this will need to be parameterised once we want to do immediate mining insertion.
 			self.state_db.lock().unwrap().boxed_clone(),
-			match self.chain.block_header(&h) { Some(ref x) => x, None => { return (None, invalid_transactions) } },
+			&self.chain.block_header(&h).expect("h is best block hash: so it's header must exist: qed"),
 			self.build_last_hashes(h.clone()),
 			author,
 			gas_floor_target,
@@ -785,44 +783,10 @@ impl<V> MiningBlockChainClient for Client<V> where V: Verifier {
 			.into_iter()
 			.take(engine.maximum_uncle_count())
 			.foreach(|h| {
-				b.push_uncle(h).unwrap();
+				open_block.push_uncle(h).unwrap();
 			});
 
-		// Add transactions
-		let block_number = b.block().header().number();
-		let min_tx_gas = U256::from(self.engine.schedule(&b.env_info()).tx_gas);
-
-		for tx in transactions {
-			// Push transaction to block
-			let hash = tx.hash();
-			let import = b.push_transaction(tx, None);
-
-			match import {
-				Err(Error::Execution(ExecutionError::BlockGasLimitReached { gas_limit, gas_used, .. })) => {
-					trace!(target: "miner", "Skipping adding transaction to block because of gas limit: {:?}", hash);
-					// Exit early if gas left is smaller then min_tx_gas
-					if gas_limit - gas_used < min_tx_gas {
-						break;
-					}
-				},
-				Err(e) => {
-					invalid_transactions.insert(hash);
-					trace!(target: "miner",
-						   "Error adding transaction to block: number={}. transaction_hash={:?}, Error: {:?}",
-						   block_number, hash, e);
-				},
-				_ => {}
-			}
-		}
-
-		// And close
-		let b = b.close();
-		trace!(target: "miner", "Sealing: number={}, hash={}, diff={}",
-			   b.block().header().number(),
-			   b.hash(),
-			   b.block().header().difficulty()
-		);
-		(Some(b), invalid_transactions)
+		open_block
 	}
 
 	fn try_seal(&self, block: LockedBlock, seal: Vec<Bytes>) -> Result<SealedBlock, LockedBlock> {

--- a/ethcore/src/client/mod.rs
+++ b/ethcore/src/client/mod.rs
@@ -31,13 +31,12 @@ pub use self::trace::Filter as TraceFilter;
 pub use executive::{Executed, Executive, TransactOptions};
 pub use env_info::{LastHashes, EnvInfo};
 
-use std::collections::HashSet;
 use util::bytes::Bytes;
 use util::hash::{Address, H256, H2048};
 use util::numbers::U256;
 use blockchain::TreeRoute;
 use block_queue::BlockQueueInfo;
-use block::{ClosedBlock, LockedBlock, SealedBlock};
+use block::{LockedBlock, SealedBlock, OpenBlock};
 use header::{BlockNumber, Header};
 use transaction::{LocalizedTransaction, SignedTransaction};
 use log_entry::LocalizedLogEntry;
@@ -199,7 +198,7 @@ pub trait MiningBlockChainClient : BlockChainClient {
 	/// Attempts to seal given block. Returns `SealedBlock` on success and the same block in case of error.
 	fn try_seal(&self, block: LockedBlock, seal: Vec<Bytes>) -> Result<SealedBlock, LockedBlock>;
 
-	/// Returns ClosedBlock prepared for sealing.
-	fn prepare_sealing(&self, author: Address, gas_floor_target: U256, extra_data: Bytes, transactions: Vec<SignedTransaction>)
-		-> (Option<ClosedBlock>, HashSet<H256>);
+	/// Returns OpenBlock prepared for closing.
+	fn prepare_open_block(&self, author: Address, gas_floor_target: U256, extra_data: Bytes)
+		-> OpenBlock;
 }

--- a/ethcore/src/client/test_client.rs
+++ b/ethcore/src/client/test_client.rs
@@ -31,7 +31,7 @@ use evm::Factory as EvmFactory;
 use miner::{Miner, MinerService};
 
 use block_queue::BlockQueueInfo;
-use block::{SealedBlock, ClosedBlock, LockedBlock};
+use block::{SealedBlock, LockedBlock, OpenBlock};
 use executive::Executed;
 use error::{ExecutionError};
 use trace::LocalizedTrace;
@@ -245,8 +245,8 @@ impl MiningBlockChainClient for TestBlockChainClient {
 	}
 
 
-	fn prepare_sealing(&self, _author: Address, _gas_floor_target: U256, _extra_data: Bytes, _transactions: Vec<SignedTransaction>) -> (Option<ClosedBlock>, HashSet<H256>) {
-		(None, HashSet::new())
+	fn prepare_open_block(&self, _author: Address, _gas_floor_target: U256, _extra_data: Bytes) -> OpenBlock {
+		unimplemented!();
 	}
 }
 

--- a/ethcore/src/tests/client.rs
+++ b/ethcore/src/tests/client.rs
@@ -137,7 +137,7 @@ fn can_mine() {
 	let client_result = get_test_client_with_blocks(vec![dummy_blocks[0].clone()]);
 	let client = client_result.reference();
 
-	let b = client.prepare_sealing(Address::default(), 31415926.into(), vec![], vec![]).0.unwrap();
+	let b = client.prepare_open_block(Address::default(), 31415926.into(), vec![]).close();
 
 	assert_eq!(*b.block().header().parent_hash(), BlockView::new(&dummy_blocks[0]).header_view().sha3());
 	assert!(client.try_seal(b.lock(), vec![]).is_ok());


### PR DESCRIPTION
- removed code duplicated in client's and miner's `prepare_sealing`.
- renamed client `prepare_sealing` to `prepare_open_block`
- `prepare_open_block` creates `OpenBlock` based on data available in blockchain. It does not push transactions