### PR TITLE
remove unsafety from util/hash.rs and util/bigint/uint.rs

### DIFF
--- a/util/bigint/src/uint.rs
+++ b/util/bigint/src/uint.rs
@@ -92,8 +92,8 @@ macro_rules! uint_overflowing_add_reg {
 macro_rules! uint_overflowing_add {
 	(U256, $n_words: expr, $self_expr: expr, $other: expr) => ({
 		let mut result: [u64; 4] = unsafe { mem::uninitialized() };
-		let self_t: &[u64; 4] = unsafe { &mem::transmute($self_expr) };
-		let other_t: &[u64; 4] = unsafe { &mem::transmute($other) };
+		let self_t: &[u64; 4] = &self.0;
+		let other_t: &[u64; 4] = &other.0;
 
 		let overflow: u8;
 		unsafe {
@@ -115,8 +115,8 @@ macro_rules! uint_overflowing_add {
 	});
 	(U512, $n_words: expr, $self_expr: expr, $other: expr) => ({
 		let mut result: [u64; 8] = unsafe { mem::uninitialized() };
-		let self_t: &[u64; 8] = unsafe { &mem::transmute($self_expr) };
-		let other_t: &[u64; 8] = unsafe { &mem::transmute($other) };
+		let self_t: &[u64; 8] = &self.0;
+		let other_t: &[u64; 8] = &other.0;
 
 		let overflow: u8;
 
@@ -196,8 +196,8 @@ macro_rules! uint_overflowing_sub_reg {
 macro_rules! uint_overflowing_sub {
 	(U256, $n_words: expr, $self_expr: expr, $other: expr) => ({
 		let mut result: [u64; 4] = unsafe { mem::uninitialized() };
-		let self_t: &[u64; 4] = unsafe { &mem::transmute($self_expr) };
-		let other_t: &[u64; 4] = unsafe { &mem::transmute($other) };
+		let self_t: &[u64; 4] = &self.0;
+		let other_t: &[u64; 4] = &other.0;
 
 		let overflow: u8;
 		unsafe {
@@ -218,8 +218,8 @@ macro_rules! uint_overflowing_sub {
 	});
 	(U512, $n_words: expr, $self_expr: expr, $other: expr) => ({
 		let mut result: [u64; 8] = unsafe { mem::uninitialized() };
-		let self_t: &[u64; 8] = unsafe { &mem::transmute($self_expr) };
-		let other_t: &[u64; 8] = unsafe { &mem::transmute($other) };
+		let self_t: &[u64; 8] = &self.0;
+		let other_t: &[u64; 8] = &other.0;
 
 		let overflow: u8;
 
@@ -270,8 +270,8 @@ macro_rules! uint_overflowing_sub {
 macro_rules! uint_overflowing_mul {
 	(U256, $n_words: expr, $self_expr: expr, $other: expr) => ({
 		let mut result: [u64; 4] = unsafe { mem::uninitialized() };
-		let self_t: &[u64; 4] = unsafe { &mem::transmute($self_expr) };
-		let other_t: &[u64; 4] = unsafe { &mem::transmute($other) };
+		let self_t: &[u64; 4] = &self.0;
+		let other_t: &[u64; 4] = &self.0;
 
 		let overflow: u64;
 		unsafe {
@@ -548,6 +548,7 @@ pub trait Uint: Sized + Default + FromStr + From<u64> + fmt::Debug + fmt::Displa
 macro_rules! construct_uint {
 	($name:ident, $n_words:expr) => (
 		/// Little-endian large integer type
+		#[repr(C)]
 		#[derive(Copy, Clone, Eq, PartialEq)]
 		pub struct $name(pub [u64; $n_words]);
 
@@ -1132,8 +1133,8 @@ impl U256 {
 	/// No overflow possible
 	#[cfg(all(asm_available, target_arch="x86_64"))]
 	pub fn full_mul(self, other: U256) -> U512 {
-		let self_t: &[u64; 4] = unsafe { &mem::transmute(self) };
-		let other_t: &[u64; 4] = unsafe { &mem::transmute(other) };
+		let self_t: &[u64; 4] = &self.0;
+		let other_t: &[u64; 4] = &other.0;
 		let mut result: [u64; 8] = unsafe { mem::uninitialized() };
 		unsafe {
 			asm!("

--- a/util/src/hash.rs
+++ b/util/src/hash.rs
@@ -559,7 +559,7 @@ impl From<Address> for H256 {
 impl<'a> From<&'a Address> for H256 {
 	fn from(value: &'a Address) -> H256 {
 		let mut ret = H256::new();
-		ret.0[12..32].copy_from_slice(&value);
+		ret.0[12..32].copy_from_slice(value);
 		ret
 	}
 }

--- a/util/src/hash.rs
+++ b/util/src/hash.rs
@@ -150,8 +150,8 @@ macro_rules! impl_hash {
 			}
 
 			fn copy_to(&self, dest: &mut[u8]) {
-					let min = ::std::cmp::min($size, dest.len());
-					dest[..min].copy_from_slice(&self.0[..min]);
+				let min = ::std::cmp::min($size, dest.len());
+				dest[..min].copy_from_slice(&self.0[..min]);
 			}
 
 			fn shift_bloomed<'a, T>(&'a mut self, b: &T) -> &'a mut Self where T: FixedHash {

--- a/util/src/hash.rs
+++ b/util/src/hash.rs
@@ -143,6 +143,7 @@ macro_rules! impl_hash {
 				}
 				min
 			}
+
 			fn from_slice(src: &[u8]) -> Self {
 				let mut r = Self::new();
 				r.clone_from_slice(src);
@@ -158,11 +159,7 @@ macro_rules! impl_hash {
 				let bp: Self = b.bloom_part($size);
 				let new_self = &bp | self;
 
-				// impl |= instead
-				// TODO: that's done now!
-
 				self.0 = new_self.0;
-
 				self
 			}
 
@@ -174,7 +171,6 @@ macro_rules! impl_hash {
 				let bloom_bits = m * 8;
 				let mask = bloom_bits - 1;
 				let bloom_bytes = (log2(bloom_bits) + 7) / 8;
-				//println!("bb: {}", bloom_bytes);
 
 				// must be a power of 2
 				assert_eq!(m & (m - 1), 0);


### PR DESCRIPTION
the copy stuff was fine, but some of the uses of `mem::uninitialized` were dubious.