### PR TITLE
Fixing signer behaviour when confirming transaction with wrong password.

### DIFF
--- a/dapps/src/apps/mod.rs
+++ b/dapps/src/apps/mod.rs
@@ -47,8 +47,8 @@ pub fn all_endpoints(dapps_path: String) -> Endpoints {
 		PageEndpoint::new_safe_to_embed(parity_dapps_builtins::App::default())
 	));
 	pages.insert("proxy".into(), ProxyPac::boxed());
-	insert::<parity_dapps_status::App>(&mut pages, "status");
 	insert::<parity_dapps_status::App>(&mut pages, "parity");
+	insert::<parity_dapps_status::App>(&mut pages, "status");
 
 	// Optional dapps
 	wallet_page(&mut pages);

--- a/rpc/src/v1/impls/personal_signer.rs
+++ b/rpc/src/v1/impls/personal_signer.rs
@@ -81,8 +81,7 @@ impl<A: 'static, C: 'static, M: 'static> PersonalSigner for SignerClient<A, C, M
 						}
 					})
 					.unwrap_or_else(|| {
-						queue.request_rejected(id);
-						to_value(&H256::zero())
+						to_value(&false)
 					})
 			}
 		)

--- a/rpc/src/v1/tests/mocked/personal_signer.rs
+++ b/rpc/src/v1/tests/mocked/personal_signer.rs
@@ -121,6 +121,30 @@ fn should_reject_transaction_from_queue_without_dispatching() {
 }
 
 #[test]
+fn should_not_remove_transaction_if_password_is_invalid() {
+	// given
+	let tester = signer_tester();
+	tester.queue.add_request(TransactionRequest {
+		from: Address::from(1),
+		to: Some(Address::from_str("d46e8dd67c5d32be8058bb8eb970870f07244567").unwrap()),
+		gas_price: Some(U256::from(10_000)),
+		gas: Some(U256::from(10_000_000)),
+		value: Some(U256::from(1)),
+		data: None,
+		nonce: None,
+	});
+	assert_eq!(tester.queue.requests().len(), 1);
+
+	// when
+	let request = r#"{"jsonrpc":"2.0","method":"personal_confirmTransaction","params":["0x01",{},"xxx"],"id":1}"#;
+	let response = r#"{"jsonrpc":"2.0","result":false,"id":1}"#;
+
+	// then
+	assert_eq!(tester.io.handle_request(&request), Some(response.to_owned()));
+	assert_eq!(tester.queue.requests().len(), 1);
+}
+
+#[test]
 fn should_confirm_transaction_and_dispatch() {
 	// given
 	let tester = signer_tester();


### PR DESCRIPTION
Previously it was removing the transaction. Now it returns false and keeps the transaction untouched. 
(see test case for details)

+
Small quick fix for the order of dapps. (currently on home screen status page is displayed as "parity.parity", after fix it will be "status.parity")