### PR TITLE
small cleanup

### DIFF
--- a/ethcore/src/block.rs
+++ b/ethcore/src/block.rs
@@ -260,8 +260,8 @@ impl<'x> OpenBlock<'x> {
 
 	/// Alter the extra_data for the block.
 	pub fn set_extra_data(&mut self, extra_data: Bytes) -> Result<(), BlockError> {
-		if extra_data.len() > self.engine.maximum_extra_data_size() {
-			Err(BlockError::ExtraDataOutOfBounds(OutOfBounds{min: None, max: Some(self.engine.maximum_extra_data_size()), found: extra_data.len()}))
+		if extra_data.len() > self.engine.params().maximum_extra_data_size {
+			Err(BlockError::ExtraDataOutOfBounds(OutOfBounds{min: None, max: Some(self.engine.params().maximum_extra_data_size), found: extra_data.len()}))
 		} else {
 			self.block.base.header.set_extra_data(extra_data);
 			Ok(())

--- a/ethcore/src/engine.rs
+++ b/ethcore/src/engine.rs
@@ -46,8 +46,6 @@ pub trait Engine : Sync + Send {
 	/// (In principle these are just hints for the engine since that has the last word on them.)
 	fn builtins(&self) -> &BTreeMap<Address, Builtin>;
 
-	/// Some intrinsic operation parameters; by default they take their value from the `spec()`'s `engine_params`.
-	fn maximum_extra_data_size(&self) -> usize { self.params().maximum_extra_data_size }
 	/// Maximum number of uncles a block is allowed to declare.
 	fn maximum_uncle_count(&self) -> usize { 2 }
 	/// The number of generations back that uncles can be.
@@ -68,17 +66,17 @@ pub trait Engine : Sync + Send {
 	/// be returned.
 	fn generate_seal(&self, _block: &ExecutedBlock, _accounts: Option<&AccountProvider>) -> Option<Vec<Bytes>> { None }
 
-	/// Phase 1 quick block verification. Only does checks that are cheap. `block` (the header's full block)
+	/// Phase 1 quick block verification. Only does checks that are cheap.
 	/// may be provided for additional checks. Returns either a null `Ok` or a general error detailing the problem with import.
-	fn verify_block_basic(&self, _header: &Header,  _block: Option<&[u8]>) -> Result<(), Error> { Ok(()) }
+	fn verify_header_basic(&self, _header: &Header) -> Result<(), Error> { Ok(()) }
 
-	/// Phase 2 verification. Perform costly checks such as transaction signatures. `block` (the header's full block)
+	/// Phase 2 verification. Perform costly checks such as transaction signatures.
 	/// may be provided for additional checks. Returns either a null `Ok` or a general error detailing the problem with import.
-	fn verify_block_unordered(&self, _header: &Header, _block: Option<&[u8]>) -> Result<(), Error> { Ok(()) }
+	fn verify_header_unordered(&self, _header: &Header) -> Result<(), Error> { Ok(()) }
 
-	/// Phase 3 verification. Check block information against parent and uncles. `block` (the header's full block)
+	/// Phase 3 verification. Check block information against parent and uncles.
 	/// may be provided for additional checks. Returns either a null `Ok` or a general error detailing the problem with import.
-	fn verify_block_family(&self, _header: &Header, _parent: &Header, _block: Option<&[u8]>) -> Result<(), Error> { Ok(()) }
+	fn verify_header_family(&self, _header: &Header, _parent: &Header) -> Result<(), Error> { Ok(()) }
 
 	/// Additional verification for transactions in blocks.
 	// TODO: Add flags for which bits of the transaction to check.
@@ -91,7 +89,7 @@ pub trait Engine : Sync + Send {
 	/// to get the job done. By default it must pass `verify_basic` and `verify_block_unordered`. If more or fewer
 	/// methods are needed for an Engine, this may be overridden.
 	fn verify_block_seal(&self, header: &Header) -> Result<(), Error> {
-		self.verify_block_basic(header, None).and_then(|_| self.verify_block_unordered(header, None))
+		self.verify_header_basic(header).and_then(|_| self.verify_header_unordered(header))
 	}
 
 	/// Don't forget to call Super::populate_from_parent when subclassing & overriding.


### PR DESCRIPTION
a few small changes:

- removed usages of hardcoded uncles position

  ```diff 
-for u in Rlp::new(bytes).at(2).iter().map(|rlp| rlp.as_val::<Header>())
+for u in &BlockView::new(&bytes).uncles()

-let uncles_count = Rlp::new(bytes).at(2).item_count();
+let uncles_count = BlockView::new(bytes).uncles_count();
  ```

- simplified engine interface, removed unused params
  ```diff
-fn verify_block_basic(&self, header: &Header, _block: Option<&[u8]>)
+fn verify_header_basic(&self, header: &Header)

-fn verify_block_unordered(&self, header: &Header, _block: Option<&[u8]>)
+fn verify_header_unordered(&self, header: &Header)

-fn verify_block_family(&self, header: &Header, parent: &Header, _block: Option<&[u8]>)
+fn verify_header_family(&self, header: &Header, parent: &Header)
  ```

- simplified one of the methods in `verification.rs`
  ```diff
-fn verify_header(header: &Header, engine: &Engine) -> Result<(), Error>
+fn verify_header(header: &Header, params: &CommonParams) -> Result<(), Error>
  ```