### PR TITLE
snappy and minor block compression

### DIFF
--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -777,11 +777,13 @@ impl<V> BlockChainClient for Client<V> where V: Verifier {
 		let best_hash = best_header.hash();
 		let genesis_hash = self.chain.genesis_hash();
 
-		let block_chunk_hashes = chunk_blocks(self, best_hash, genesis_hash, &path).unwrap();
+		let block_hashes = chunk_blocks(self, best_hash, genesis_hash, &path).unwrap();
+
+		trace!(target: "snapshot", "produced {} state chunks and {} block chunks.", state_hashes.len(), block_hashes.len());
 
 		let manifest_data = ManifestData {
 			state_hashes: state_hashes,
-			block_hashes: block_chunk_hashes,
+			block_hashes: block_hashes,
 			state_root: state_root,
 		};
 

--- a/ethcore/src/header.rs
+++ b/ethcore/src/header.rs
@@ -149,6 +149,16 @@ impl Header {
 
 	/// Set the number field of the header.
 	pub fn set_parent_hash(&mut self, a: H256) { self.parent_hash = a; self.note_dirty(); }
+	/// Set the uncles hash field of the header.
+	pub fn set_uncles_hash(&mut self, a: H256) { self.uncles_hash = a; self.note_dirty(); }
+	/// Set the state root field of the header.
+	pub fn set_state_root(&mut self, a: H256) { self.state_root = a; self.note_dirty(); }
+	/// Set the transactions root field of the header.
+	pub fn set_transactions_root(&mut self, a: H256) { self.transactions_root = a; self.note_dirty() }
+	/// Set the receipts root field of the header.
+	pub fn set_receipts_root(&mut self, a: H256) { self.receipts_root = a; self.note_dirty() }
+	/// Set the log bloom field of the header.
+	pub fn set_log_bloom(&mut self, a: LogBloom) { self.log_bloom = a; self.note_dirty() }
 	/// Set the timestamp field of the header.
 	pub fn set_timestamp(&mut self, a: u64) { self.timestamp = a; self.note_dirty(); }
 	/// Set the timestamp field of the header to the current time.

--- a/ethcore/src/snapshot/block.rs
+++ b/ethcore/src/snapshot/block.rs
@@ -20,7 +20,7 @@ use block::Block;
 use header::Header;
 
 use views::BlockView;
-use util::rlp::{Rlp, RlpStream, Stream, View};
+use util::rlp::{DecoderError, RlpStream, Stream, UntrustedRlp, View};
 use util::{Bytes, H256};
 
 const HEADER_FIELDS: usize = 11;
@@ -87,34 +87,34 @@ impl AbridgedBlock {
 	/// Flesh out an abridged block view with the provided parent hash and block number.
 	///
 	/// Will fail if contains invalid rlp.
-	pub fn to_block(&self, parent_hash: H256, number: u64) -> Block {
-		let rlp = Rlp::new(&self.rlp);
+	pub fn to_block(&self, parent_hash: H256, number: u64) -> Result<Block, DecoderError> {
+		let rlp = UntrustedRlp::new(&self.rlp);
 
 		let mut header = Header {
 			parent_hash: parent_hash,
-			uncles_hash: rlp.val_at(0),
-			author: rlp.val_at(1),
-			state_root: rlp.val_at(2),
-			transactions_root: rlp.val_at(3),
-			receipts_root: rlp.val_at(4),
-			log_bloom: rlp.val_at(5),
-			difficulty: rlp.val_at(6),
+			uncles_hash: try!(rlp.val_at(0)),
+			author: try!(rlp.val_at(1)),
+			state_root: try!(rlp.val_at(2)),
+			transactions_root: try!(rlp.val_at(3)),
+			receipts_root: try!(rlp.val_at(4)),
+			log_bloom: try!(rlp.val_at(5)),
+			difficulty: try!(rlp.val_at(6)),
 			number: number,
-			gas_limit: rlp.val_at(7),
-			gas_used: rlp.val_at(8),
-			timestamp: rlp.val_at(9),
-			extra_data: rlp.val_at(10),
+			gas_limit: try!(rlp.val_at(7)),
+			gas_used: try!(rlp.val_at(8)),
+			timestamp: try!(rlp.val_at(9)),
+			extra_data: try!(rlp.val_at(10)),
 			..Default::default()
 		};
 
-		let seal: Vec<Bytes> = rlp.val_at(11);
+		let seal: Vec<Bytes> = try!(rlp.val_at(11));
 
 		header.set_seal(seal);
 
-		Block {
+		Ok(Block {
 			header: header,
-			transactions: rlp.val_at(12),
-			uncles: rlp.val_at(13),
-		}
+			transactions: try!(rlp.val_at(12)),
+			uncles: try!(rlp.val_at(13)),
+		})
 	}
 }

--- a/ethcore/src/snapshot/block.rs
+++ b/ethcore/src/snapshot/block.rs
@@ -1,0 +1,120 @@
+// Copyright 2015, 2016 Ethcore (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Block RLP compression.
+
+use block::Block;
+use header::Header;
+
+use views::BlockView;
+use util::rlp::{Rlp, RlpStream, Stream, View};
+use util::{Bytes, H256};
+
+const HEADER_FIELDS: usize = 11;
+const BLOCK_FIELDS: usize = 2;
+
+pub struct AbridgedBlock {
+	rlp: Bytes,
+}
+
+impl AbridgedBlock {
+	/// Create from a vector of bytes. Does no verification.
+	pub fn from_raw(rlp: Bytes) -> Self {
+		AbridgedBlock {
+			rlp: rlp,
+		}
+	}
+
+	/// Return the inner bytes.
+	pub fn into_inner(self) -> Bytes {
+		self.rlp
+	}
+
+	/// Given a full block view, trim out the parent hash and block number,
+	/// producing new rlp.
+	pub fn from_block_view(block_view: &BlockView) -> Self {
+		let header = block_view.header_view();
+
+		let seal_fields = header.seal();
+
+		// 11 header fields, unknown amount of seal fields, and 2 block fields.
+		let mut stream = RlpStream::new_list(
+			HEADER_FIELDS +
+			seal_fields.len() +
+			BLOCK_FIELDS
+		);
+
+		// write header values.
+		stream
+			.append(&header.uncles_hash())
+			.append(&header.author())
+			.append(&header.state_root())
+			.append(&header.transactions_root())
+			.append(&header.receipts_root())
+			.append(&header.log_bloom())
+			.append(&header.difficulty())
+			.append(&header.gas_limit())
+			.append(&header.gas_used())
+			.append(&header.timestamp())
+			.append(&header.extra_data());
+
+		// write seal fields.
+		for field in seal_fields {
+			stream.append_raw(&field, 1);
+		}
+
+		// write block values.
+		stream.append(&block_view.transactions()).append(&block_view.uncles());
+
+		AbridgedBlock {
+			rlp: stream.out(),
+		}
+	}
+
+	/// Flesh out an abridged block view with the provided parent hash and block number.
+	///
+	/// Will fail if contains invalid rlp.
+	pub fn to_block(&self, parent_hash: H256, number: u64) -> Block {
+		let rlp = Rlp::new(&self.rlp);
+
+		let mut header = Header {
+			parent_hash: parent_hash,
+			uncles_hash: rlp.val_at(0),
+			author: rlp.val_at(1),
+			state_root: rlp.val_at(2),
+			transactions_root: rlp.val_at(3),
+			receipts_root: rlp.val_at(4),
+			log_bloom: rlp.val_at(5),
+			difficulty: rlp.val_at(6),
+			number: number,
+			gas_limit: rlp.val_at(7),
+			gas_used: rlp.val_at(8),
+			timestamp: rlp.val_at(9),
+			extra_data: rlp.val_at(10),
+			..Default::default()
+		};
+
+		let seal: Vec<Bytes> = rlp.val_at(11);
+
+		header.set_seal(seal);
+
+		Block {
+			header: header,
+			transactions: rlp.val_at(12),
+			uncles: rlp.val_at(13),
+		}
+	}
+}

--- a/ethcore/src/snapshot/mod.rs
+++ b/ethcore/src/snapshot/mod.rs
@@ -34,6 +34,7 @@ use util::{Bytes, Hashable, HashDB, TrieDB};
 use util::hash::{FixedHash, H256};
 use util::numbers::U256;
 use util::rlp::{DecoderError, Rlp, RlpStream, Stream, SHA3_NULL_RLP, UntrustedRlp, View};
+use util::snappy;
 /// Used to build block chunks.
 struct BlockChunker<'a> {
 	client: &'a BlockChainClient,
@@ -92,7 +93,7 @@ impl<'a> BlockChunker<'a> {
 			rlp_stream.append(&pair);
 		}
 
-		let raw_data = rlp_stream.out();
+		let raw_data = snappy::compress(&rlp_stream.out());
 		let hash = raw_data.sha3();
 
 		trace!(target: "snapshot", "writing block chunk. hash: {},  size: {} bytes", hash.hex(), raw_data.len());
@@ -169,7 +170,7 @@ impl<'a> StateChunker<'a> {
 		let bytes = {
 			let mut stream = RlpStream::new();
 			stream.append(&&self.rlps[..]);
-			stream.out()
+			snappy::compress(&stream.out())
 		};
 
 		self.rlps.clear();

--- a/ethcore/src/snapshot/mod.rs
+++ b/ethcore/src/snapshot/mod.rs
@@ -40,10 +40,6 @@ mod block;
 // Try to have chunks be around 16MB (before compression)
 const PREFERRED_CHUNK_SIZE: usize = 16 * 1024 * 1024;
 
-// use initially 20MB for the reusable snappy buffers.
-// should always be larger than PREFERRED_CHUNK_SIZE for fault tolerance.
-const SNAPPY_BUFFER_SIZE: usize = 20 * 1024 * 1024;
-
 // compresses the data into the buffer, resizing if necessary.
 fn compression_helper(input: &[u8], output: &mut Vec<u8>) -> usize {
 	let max_size = snappy::max_compressed_len(input.len());
@@ -159,7 +155,7 @@ pub fn chunk_blocks(client: &BlockChainClient, best_block_hash: H256, genesis_ha
 		rlps: VecDeque::new(),
 		current_hash: best_block_hash,
 		hashes: Vec::new(),
-		snappy_buffer: vec![0; SNAPPY_BUFFER_SIZE],
+		snappy_buffer: vec![0; snappy::max_compressed_len(PREFERRED_CHUNK_SIZE)],
 	};
 
 	try!(chunker.chunk_all(genesis_hash, path));
@@ -229,7 +225,7 @@ pub fn chunk_state(db: &HashDB, root: &H256, path: &Path) -> Result<Vec<H256>, E
 		rlps: Vec::new(),
 		cur_size: 0,
 		snapshot_path: path,
-		snappy_buffer: vec![0; SNAPPY_BUFFER_SIZE],
+		snappy_buffer: vec![0; snappy::max_compressed_len(PREFERRED_CHUNK_SIZE)],
 	};
 
 	trace!(target: "snapshot", "beginning state chunking");

--- a/ethcore/src/snapshot/mod.rs
+++ b/ethcore/src/snapshot/mod.rs
@@ -88,7 +88,7 @@ struct BlockChunker<'a> {
 }
 
 impl<'a> BlockChunker<'a> {
-	// Try to fill the buffers, moving backwards from current block hash.
+	// Repeatedly fill the buffers and writes out chunks, moving backwards from starting block hash.
 	// Loops until we reach the genesis, and writes out the remainder.
 	fn chunk_all(&mut self, genesis_hash: H256, path: &Path) -> Result<(), Error> {
 		let mut loaded_size = 0;
@@ -122,8 +122,8 @@ impl<'a> BlockChunker<'a> {
 		}
 
 		if loaded_size != 0 {
-			// we don't store the genesis hash, so once we get to this point,
-			// the "first" block will have number 1.
+			// we don't store the genesis block, so once we get to this point,
+			// the "first" block will be number 1.
 			try!(self.write_chunk(genesis_hash, 1, path));
 		}
 

--- a/util/src/error.rs
+++ b/util/src/error.rs
@@ -65,6 +65,8 @@ pub enum UtilError {
 	SimpleString(String),
 	/// Error from a bad input size being given for the needed output.
 	BadSize,
+	/// Error from snappy.
+	Snappy(::snappy::Error),
 }
 
 impl fmt::Display for UtilError {
@@ -82,6 +84,7 @@ impl fmt::Display for UtilError {
 			UtilError::Decoder(ref err) => f.write_fmt(format_args!("{}", err)),
 			UtilError::SimpleString(ref msg) => f.write_str(&msg),
 			UtilError::BadSize => f.write_str("Bad input size."),
+			UtilError::Snappy(ref err) => f.write_fmt(format_args!("{}", err)),
 		}
 	}
 }
@@ -176,6 +179,12 @@ impl From<::rlp::DecoderError> for UtilError {
 impl From<String> for UtilError {
 	fn from(err: String) -> UtilError {
 		UtilError::SimpleString(err)
+	}
+}
+
+impl From<::snappy::Error> for UtilError {
+	fn from(err: ::snappy::Error) -> UtilError {
+		UtilError::Snappy(err)
 	}
 }
 

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -155,6 +155,7 @@ pub mod keys;
 pub mod table;
 pub mod network_settings;
 pub mod path;
+pub mod snappy;
 
 pub use common::*;
 pub use misc::*;

--- a/util/src/snappy.rs
+++ b/util/src/snappy.rs
@@ -1,0 +1,140 @@
+// Copyright 2015, 2016 Ethcore (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Snappy compression bindings.
+
+use std::fmt;
+use libc::{c_char, c_int, size_t};
+
+const SNAPPY_OK: c_int = 0;
+const SNAPPY_INVALID_INPUT: c_int = 1;
+const SNAPPY_BUFFER_TOO_SMALL: c_int = 2;
+
+#[link(name = "snappy")]
+extern {
+	fn snappy_compress(
+		input: *const c_char,
+		input_len: size_t,
+		compressed: *mut c_char,
+		compressed_len: *mut size_t
+	) -> c_int;
+
+	fn snappy_max_compressed_length(source_len: size_t) -> size_t;
+
+	fn snappy_uncompress(
+		compressed: *const c_char,
+		compressed_len: size_t,
+		uncompressed: *mut c_char,
+		uncompressed_len: *mut size_t,
+	) -> c_int;
+
+	fn snappy_uncompressed_length(
+		compressed: *const c_char,
+		compressed_len: size_t,
+		result: *mut size_t,
+	) -> c_int;
+}
+
+/// Errors that can occur during usage of snappy.
+#[derive(Debug)]
+pub enum Error {
+	/// An invalid input was supplied. Usually means that you tried to decompress an uncompressed
+	/// buffer.
+	InvalidInput,
+	/// The output buffer supplied was too small. Make sure to provide buffers large enough to hold
+	/// all the output data.
+	BufferTooSmall,
+}
+
+impl fmt::Display for Error {
+	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+		match *self {
+			Error::InvalidInput => write!(f, "Snappy error (invalid input)"),
+			Error::BufferTooSmall => write!(f, "Snappy error (buffer too small)"),
+		}
+	}
+}
+
+/// Compress a buffer using snappy.
+pub fn compress(input: &[u8]) -> Vec<u8> {
+	let mut buf_size = unsafe { snappy_max_compressed_length(input.len() as size_t) };
+	let mut output = vec![0; buf_size as usize];
+
+	buf_size = compress_into(input, &mut output).expect("snappy compression failed with large enough buffer.");
+	output.truncate(buf_size);
+	output
+}
+
+/// Compress a buffer using snappy, writing the result into
+/// the given output buffer. Will error if the buffer is too small.
+/// Otherwise, returns the length of the compressed data.
+pub fn compress_into(input: &[u8], output: &mut [u8]) -> Result<usize, Error> {
+	let mut len = output.len() as size_t;
+	let status = unsafe {
+		snappy_compress(
+			input.as_ptr() as *const c_char,
+			input.len() as size_t,
+			output.as_mut_ptr() as *mut c_char,
+			&mut len,
+		)
+	};
+
+	match status {
+		SNAPPY_OK => Ok(len as usize),
+		SNAPPY_INVALID_INPUT => Err(Error::InvalidInput), // should never happen, but can't hurt!
+		SNAPPY_BUFFER_TOO_SMALL => Err(Error::BufferTooSmall),
+		_ => panic!("snappy returned unspecified status"),
+	}
+}
+
+/// Decompress a buffer using snappy. Will return an error if the buffer is not snappy-compressed.
+pub fn decompress(input: &[u8]) -> Result<Vec<u8>, Error> {
+	let mut buf_size: size_t = 0;
+
+	let status = unsafe { snappy_uncompressed_length(input.as_ptr() as *const c_char, input.len() as size_t, &mut buf_size) };
+	if status == SNAPPY_INVALID_INPUT {
+		return Err(Error::InvalidInput);
+	}
+
+	let mut output = vec![0; buf_size];
+
+	buf_size = try!(decompress_into(input, &mut output));
+	output.truncate(buf_size);
+	Ok(output)
+}
+
+/// Decompress a buffer using snappy, writing the result into
+/// the given output buffer. Will error if the input buffer is not snappy-compressed
+/// or the output buffer is too small.
+/// Otherwise, returns the length of the decompressed data.
+pub fn decompress_into(input: &[u8], output: &mut [u8]) -> Result<usize, Error> {
+	let mut len = output.len() as size_t;
+	let status = unsafe {
+		snappy_uncompress(
+			input.as_ptr() as *const c_char,
+			input.len() as size_t,
+			output.as_mut_ptr() as *mut c_char,
+			&mut len,
+		)
+	};
+
+	match status {
+		SNAPPY_OK => Ok(len as usize),
+		SNAPPY_INVALID_INPUT => Err(Error::InvalidInput),
+		SNAPPY_BUFFER_TOO_SMALL => Err(Error::BufferTooSmall),
+		_ => panic!("snappy returned unspecified status"),
+	}
+}

--- a/util/src/snappy.rs
+++ b/util/src/snappy.rs
@@ -68,9 +68,14 @@ impl fmt::Display for Error {
 	}
 }
 
+/// The maximum compressed length given a size.
+pub fn max_compressed_len(len: usize) -> usize {
+	unsafe { snappy_max_compressed_length(len as size_t) as usize }
+}
+
 /// Compress a buffer using snappy.
 pub fn compress(input: &[u8]) -> Vec<u8> {
-	let mut buf_size = unsafe { snappy_max_compressed_length(input.len() as size_t) };
+	let mut buf_size = max_compressed_len(input.len());
 	let mut output = vec![0; buf_size as usize];
 
 	buf_size = compress_into(input, &mut output).expect("snappy compression failed with large enough buffer.");
@@ -79,7 +84,7 @@ pub fn compress(input: &[u8]) -> Vec<u8> {
 }
 
 /// Compress a buffer using snappy, writing the result into
-/// the given output buffer. Will error if the buffer is too small.
+/// the given output buffer. Will error iff the buffer is too small.
 /// Otherwise, returns the length of the compressed data.
 pub fn compress_into(input: &[u8], output: &mut [u8]) -> Result<usize, Error> {
 	let mut len = output.len() as size_t;


### PR DESCRIPTION
adds some simple snappy bindings.

the blocks now don't contain any parent hash or number within them. Each chunk of blocks stores the parent hash and the number of the first contained within, and the rest can be recalculated.