### PR TITLE
Fixed loosing peers on incoming connections.

### DIFF
--- a/sync/src/chain.rs
+++ b/sync/src/chain.rs
@@ -405,6 +405,7 @@ impl ChainSync {
 		}
 		if item_count == 0 && (self.state == SyncState::Blocks || self.state == SyncState::NewBlocks) {
 			self.deactivate_peer(io, peer_id); //TODO: is this too harsh?
+			self.continue_sync(io);
 			return Ok(());
 		}
 
@@ -452,7 +453,11 @@ impl ChainSync {
 
 		// Disable the peer for this syncing round if it gives invalid chain
 		if !valid_response {
-			trace!(target: "sync", "{} Disabled for invalid headers response", peer_id);
+			trace!(target: "sync", "{} Deactivated for invalid headers response", peer_id);
+			self.deactivate_peer(io, peer_id); 
+		}
+		if headers.is_empty() {
+			trace!(target: "sync", "{} Deactivated for no data", peer_id);
 			self.deactivate_peer(io, peer_id); 
 		}
 		match self.state {

--- a/sync/src/chain.rs
+++ b/sync/src/chain.rs
@@ -456,7 +456,8 @@ impl ChainSync {
 			trace!(target: "sync", "{} Deactivated for invalid headers response", peer_id);
 			self.deactivate_peer(io, peer_id); 
 		}
-		if headers.is_empty() {
+		if headers.is_empty() && self.state == SyncState::ChainHead {
+			// Peer does not have any new subchain heads, deactivate it nd try with another
 			trace!(target: "sync", "{} Deactivated for no data", peer_id);
 			self.deactivate_peer(io, peer_id); 
 		}

--- a/util/src/network/handshake.rs
+++ b/util/src/network/handshake.rs
@@ -128,7 +128,6 @@ impl Handshake {
 	/// Readable IO handler. Drives the state change.
 	pub fn readable<Message>(&mut self, io: &IoContext<Message>, host: &HostInfo) -> Result<(), UtilError> where Message: Send + Clone {
 		if !self.expired() {
-			io.clear_timer(self.connection.token).ok();
 			match self.state {
 				HandshakeState::New => {}
 				HandshakeState::ReadingAuth => {
@@ -151,7 +150,9 @@ impl Handshake {
 						try!(self.read_ack_eip8(host.secret(), &data));
 					};
 				},
-				HandshakeState::StartSession => {},
+				HandshakeState::StartSession => {
+					io.clear_timer(self.connection.token).ok();
+				},
 			}
 		}
 		Ok(())

--- a/util/src/network/host.rs
+++ b/util/src/network/host.rs
@@ -829,6 +829,7 @@ impl<Message> IoHandler<NetworkIoMessage<Message>> for Host<Message> where Messa
 				io.update_registration(DISCOVERY).expect("Error updating discovery registration");
 			},
 			NODE_TABLE => {
+				trace!(target: "network", "Refreshing node table");
 				self.nodes.write().unwrap().clear_useless();
 				io.update_registration(NODE_TABLE).expect("Error updating node table timer registration");
 			},

--- a/util/src/network/host.rs
+++ b/util/src/network/host.rs
@@ -651,6 +651,7 @@ impl<Message> Host<Message> where Message: Send + Sync + Clone {
 						break;
 					},
 					Ok(SessionData::Ready) => {
+						self.num_sessions.fetch_add(1, AtomicOrdering::SeqCst);
 						if !s.info.originated {
 							let session_count = self.session_count();
 							let ideal_peers = { self.info.read().unwrap().deref().config.ideal_peers };
@@ -668,7 +669,6 @@ impl<Message> Host<Message> where Message: Send + Sync + Clone {
 								}
 							}
 						}
-						self.num_sessions.fetch_add(1, AtomicOrdering::SeqCst);
 						for (p, _) in self.handlers.read().unwrap().iter() {
 							if s.have_capability(p)  {
 								ready_data.push(p);

--- a/util/src/network/host.rs
+++ b/util/src/network/host.rs
@@ -522,11 +522,13 @@ impl<Message> Host<Message> where Message: Send + Sync + Clone {
 		}
 
 		let nodes = if pin { self.pinned_nodes.clone() } else { self.nodes.read().unwrap().nodes() };
+		let mut started: usize = 0;
 		for id in nodes.iter().filter(|ref id| !self.have_session(id) && !self.connecting_to(id))
 			.take(min(MAX_HANDSHAKES_PER_ROUND, handshake_limit - handshake_count)) {
 			self.connect_peer(&id, io);
+			started += 1;
 		}
-		debug!(target: "network", "Connecting peers: {} sessions, {} pending", self.session_count(), self.handshake_count());
+		debug!(target: "network", "Connecting peers: {} sessions, {} pending, {} started", self.session_count(), self.handshake_count(), started);
 	}
 
 	#[cfg_attr(feature="dev", allow(single_match))]

--- a/util/src/network/host.rs
+++ b/util/src/network/host.rs
@@ -828,6 +828,7 @@ impl<Message> IoHandler<NetworkIoMessage<Message>> for Host<Message> where Messa
 			},
 			NODE_TABLE => {
 				self.nodes.write().unwrap().clear_useless();
+				io.update_registration(NODE_TABLE).expect("Error updating node table timer registration");
 			},
 			_ => match self.timers.read().unwrap().get(&token).cloned() {
 				Some(timer) => match self.handlers.read().unwrap().get(timer.protocol).cloned() {

--- a/util/src/network/host.rs
+++ b/util/src/network/host.rs
@@ -831,7 +831,6 @@ impl<Message> IoHandler<NetworkIoMessage<Message>> for Host<Message> where Messa
 			NODE_TABLE => {
 				trace!(target: "network", "Refreshing node table");
 				self.nodes.write().unwrap().clear_useless();
-				io.update_registration(NODE_TABLE).expect("Error updating node table timer registration");
 			},
 			_ => match self.timers.read().unwrap().get(&token).cloned() {
 				Some(timer) => match self.handlers.read().unwrap().get(timer.protocol).cloned() {


### PR DESCRIPTION
Session count was updated incorrectly when an incoming connection is rejected, which resulted on halting connection attempts on machines that can accept incoming connections.
Includes other minor fixes.
#1271 