### PR TITLE
Snapshot state restoration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1079,7 +1079,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "rocksdb"
 version = "0.4.5"
-source = "git+https://github.com/ethcore/rust-rocksdb#9140e37ce0fdb748097f85653c01b0f7e3736ea9"
+source = "git+https://github.com/ethcore/rust-rocksdb#8f6e43b2d8799578a378648bcb17c01fb431dbec"
 dependencies = [
  "libc 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocksdb-sys 0.3.0 (git+https://github.com/ethcore/rust-rocksdb)",
@@ -1088,7 +1088,7 @@ dependencies = [
 [[package]]
 name = "rocksdb-sys"
 version = "0.3.0"
-source = "git+https://github.com/ethcore/rust-rocksdb#9140e37ce0fdb748097f85653c01b0f7e3736ea9"
+source = "git+https://github.com/ethcore/rust-rocksdb#8f6e43b2d8799578a378648bcb17c01fb431dbec"
 dependencies = [
  "gcc 0.3.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ethcore/src/error.rs
+++ b/ethcore/src/error.rs
@@ -229,7 +229,7 @@ pub enum Error {
 	/// Io error.
 	Io(::std::io::Error),
 	/// Snappy error.
-	Snappy(::util::snappy::Error),
+	Snappy(::util::snappy::InvalidInput),
 }
 
 impl fmt::Display for Error {
@@ -321,8 +321,8 @@ impl From<::std::io::Error> for Error {
 	}
 }
 
-impl From<::util::snappy::Error> for Error {
-	fn from(err: ::util::snappy::Error) -> Error {
+impl From<::util::snappy::InvalidInput> for Error {
+	fn from(err: ::util::snappy::InvalidInput) -> Error {
 		Error::Snappy(err)
 	}
 }

--- a/ethcore/src/error.rs
+++ b/ethcore/src/error.rs
@@ -228,6 +228,8 @@ pub enum Error {
 	Trie(TrieError),
 	/// Io error.
 	Io(::std::io::Error),
+	/// Snappy error.
+	Snappy(::util::snappy::Error),
 }
 
 impl fmt::Display for Error {
@@ -245,6 +247,7 @@ impl fmt::Display for Error {
 			Error::PowInvalid => f.write_str("Invalid nonce or mishash"),
 			Error::Trie(ref err) => f.write_fmt(format_args!("{}", err)),
 			Error::Io(ref err) => f.write_fmt(format_args!("{}", err)),
+			Error::Snappy(ref err) => f.write_fmt(format_args!("{}", err)),
 		}
 	}
 }
@@ -315,6 +318,12 @@ impl From<TrieError> for Error {
 impl From<::std::io::Error> for Error {
 	fn from(err: ::std::io::Error) -> Error {
 		Error::Io(err)
+	}
+}
+
+impl From<::util::snappy::Error> for Error {
+	fn from(err: ::util::snappy::Error) -> Error {
+		Error::Snappy(err)
 	}
 }
 

--- a/ethcore/src/snapshot/account.rs
+++ b/ethcore/src/snapshot/account.rs
@@ -96,7 +96,7 @@ impl Account {
 			}
 		}
 
-		account_stream.append(&pairs_rlp);
+		account_stream.append_raw(&pairs_rlp, 1);
 
 		Ok(account_stream.out())
 	}
@@ -126,7 +126,6 @@ impl Account {
 				storage_trie.insert(&k, &v);
 			}
 		}
-
 		Ok(Account {
 			nonce: nonce,
 			balance: balance,

--- a/ethcore/src/snapshot/account.rs
+++ b/ethcore/src/snapshot/account.rs
@@ -102,10 +102,8 @@ impl Account {
 	}
 
 	// decode a fat rlp, and rebuild the storage trie as we go.
-	pub fn from_fat_rlp(acct_db: &mut AccountDBMut, rlp: Bytes) -> Result<Self, DecoderError> {
+	pub fn from_fat_rlp(acct_db: &mut AccountDBMut, rlp: UntrustedRlp) -> Result<Self, DecoderError> {
 		use util::{TrieDBMut, TrieMut};
-
-		let rlp = UntrustedRlp::new(&rlp);
 
 		let nonce = try!(rlp.val_at(0));
 		let balance = try!(rlp.val_at(1));

--- a/ethcore/src/snapshot/account.rs
+++ b/ethcore/src/snapshot/account.rs
@@ -1,0 +1,139 @@
+// Copyright 2015, 2016 Ethcore (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Account state encoding and decoding
+
+use account_db::{AccountDB, AccountDBMut};
+use client::BlockChainClient;
+use error::Error;
+
+use util::{Bytes, HashDB, SHA3_EMPTY, TrieDB};
+use util::hash::{FixedHash, H256};
+use util::numbers::U256;
+use util::rlp::{DecoderError, Rlp, RlpStream, Stream, UntrustedRlp, View};
+
+// An alternate account structure from ::account::Account.
+pub struct Account {
+	nonce: U256,
+	balance: U256,
+	storage_root: H256,
+	code_hash: H256,
+}
+
+impl Account {
+	// decode the account from rlp.
+	pub fn from_thin_rlp(rlp: &[u8]) -> Self {
+		let r: Rlp = Rlp::new(rlp);
+
+		Account {
+			nonce: r.val_at(0),
+			balance: r.val_at(1),
+			storage_root: r.val_at(2),
+			code_hash: r.val_at(3),
+		}
+	}
+
+	// encode the account to a standard rlp.
+	pub fn to_thin_rlp(&self) -> Bytes {
+		let mut stream = RlpStream::new_list(4);
+		stream
+			.append(&self.nonce)
+			.append(&self.balance)
+			.append(&self.storage_root)
+			.append(&self.code_hash);
+
+		stream.out()
+	}
+
+	// walk the account's storage trie, returning an RLP item containing the
+	// account properties and the storage.
+	pub fn to_fat_rlp(&self, acct_db: &AccountDB, addr_hash: H256) -> Result<Bytes, Error> {
+		let db = try!(TrieDB::new(acct_db, &self.storage_root));
+
+		let mut pairs = Vec::new();
+
+		for (k, v) in db.iter() {
+			pairs.push((k, v));
+		}
+
+		let mut stream = RlpStream::new_list(pairs.len());
+
+		for (k, v) in pairs {
+			stream.begin_list(2).append(&k).append(&v);
+		}
+
+		let pairs_rlp = stream.out();
+
+		let mut account_stream = RlpStream::new_list(5);
+		account_stream.append(&self.nonce)
+					  .append(&self.balance);
+
+		// [has_code, code_hash].
+		if self.code_hash == SHA3_EMPTY {
+			account_stream.append(&false).append_empty_data();
+		} else {
+			match acct_db.lookup(&self.code_hash) {
+				Some(c) => {
+					account_stream.append(&true).append(&c);
+				}
+				None => {
+					warn!("code lookup failed for account with address hash {}, code hash {}", addr_hash, self.code_hash);
+					account_stream.append(&false).append_empty_data();
+				}
+			}
+		}
+
+		account_stream.append(&pairs_rlp);
+
+		Ok(account_stream.out())
+	}
+
+	// decode a fat rlp, and rebuild the storage trie as we go.
+	pub fn from_fat_rlp(acct_db: &mut AccountDBMut, rlp: Bytes) -> Result<Self, DecoderError> {
+		use util::{TrieDBMut, TrieMut};
+
+		let rlp = UntrustedRlp::new(&rlp);
+
+		let nonce = try!(rlp.val_at(0));
+		let balance = try!(rlp.val_at(1));
+		let code_hash = if try!(rlp.val_at(2)) {
+			let code: Bytes = try!(rlp.val_at(3));
+			acct_db.insert(&code)
+		} else {
+			SHA3_EMPTY
+		};
+
+		let mut storage_root = H256::zero();
+
+		{
+			let mut storage_trie = TrieDBMut::new(acct_db, &mut storage_root);
+			let pairs = try!(rlp.at(4));
+			for pair_rlp in pairs.iter() {
+				let k: Bytes  = try!(pair_rlp.val_at(0));
+				let v: Bytes = try!(pair_rlp.val_at(1));
+
+				storage_trie.insert(&k, &v);
+			}
+		}
+
+		Ok(Account {
+			nonce: nonce,
+			balance: balance,
+			storage_root: storage_root,
+			code_hash: code_hash,
+		})
+	}
+}

--- a/ethcore/src/snapshot/mod.rs
+++ b/ethcore/src/snapshot/mod.rs
@@ -78,6 +78,8 @@ fn write_chunk(raw_data: &[u8], compression_buffer: &mut Vec<u8>, path: &Path) -
 	let compressed = &compression_buffer[..compressed_size];
 	let hash = compressed.sha3();
 
+	assert!(snappy::validate_compressed_buffer(compressed));
+
 	let mut file_path = path.to_owned();
 	file_path.push(hash.hex());
 

--- a/ethcore/src/snapshot/mod.rs
+++ b/ethcore/src/snapshot/mod.rs
@@ -322,8 +322,8 @@ impl<'a> StateRebuilder<'a> {
 		let rlp = UntrustedRlp::new(&self.snappy_buffer[..len]);
 
 		for account_pair in rlp.iter() {
-			let hash: H256 = try!(rlp.val_at(0));
-			let fat_rlp = try!(rlp.at(1));
+			let hash: H256 = try!(account_pair.val_at(0));
+			let fat_rlp = try!(account_pair.at(1));
 
 			let thin_rlp = {
 				let mut acct_db = AccountDBMut::from_hash(self.db, hash);

--- a/util/src/error.rs
+++ b/util/src/error.rs
@@ -66,7 +66,7 @@ pub enum UtilError {
 	/// Error from a bad input size being given for the needed output.
 	BadSize,
 	/// Error from snappy.
-	Snappy(::snappy::Error),
+	Snappy(::snappy::InvalidInput),
 }
 
 impl fmt::Display for UtilError {
@@ -182,8 +182,8 @@ impl From<String> for UtilError {
 	}
 }
 
-impl From<::snappy::Error> for UtilError {
-	fn from(err: ::snappy::Error) -> UtilError {
+impl From<::snappy::InvalidInput> for UtilError {
+	fn from(err: ::snappy::InvalidInput) -> UtilError {
 		UtilError::Snappy(err)
 	}
 }

--- a/util/src/snappy.rs
+++ b/util/src/snappy.rs
@@ -46,6 +46,11 @@ extern {
 		compressed_len: size_t,
 		result: *mut size_t,
 	) -> c_int;
+
+	fn snappy_validate_compressed_buffer(
+		compressed: *const c_char,
+		compressed_len: size_t,
+	) -> c_int;
 }
 
 /// Errors that can occur during usage of snappy.
@@ -151,4 +156,10 @@ pub fn decompress_into(input: &[u8], output: &mut [u8]) -> Result<usize, Error> 
 		SNAPPY_BUFFER_TOO_SMALL => Err(Error::BufferTooSmall),
 		_ => panic!("snappy returned unspecified status"),
 	}
+}
+
+/// Validate a compressed buffer. True if valid, false if not.
+pub fn validate_compressed_buffer(input: &[u8]) -> bool {
+	let status = unsafe { snappy_validate_compressed_buffer(input.as_ptr() as *const c_char, input.len() as size_t )};
+	status == SNAPPY_OK
 }


### PR DESCRIPTION
Restoring from a snapshot at block ~1.7m and new db:
```bash
robert@habermeier-laptop-zenbook303:~/projects/eth/parity$ RUST_LOG="snapshot=trace" target/release/parity -- snapshot restore
Migrating database /home/robert/.parity/906a34e69aec8c0d/v5.3-sec-archive/extras from version 5 to 6
Migration finished
2016-06-17 13:05:22 INFO:parity::configuration: Using a conversion rate of Ξ1 = US$15.26 (15602571000 wei/gas)
2016-06-17 13:05:22 INFO:ethcore::service: Starting Parity/v1.2.0-unstable-7e56a5f-20160616/x86_64-linux-gnu/rustc1.9.0
2016-06-17 13:05:22 INFO:ethcore::service: Configured for Frontier/Homestead using "Ethash" engine
2016-06-17 13:05:22 INFO:ethcore_util::network::host: Public node URL: enode://498814f7f3fc05cdfe850a47fd019004c0171aef9bfbf375e484af7b554ed105bc9119a21c25d87b812012bbb4d7affd9d841e1fc4e34dbee541c48d86caaaaf@0.0.0.0:30303
2016-06-17 13:05:22 TRACE:snapshot: loading snapshot from "/home/robert/.parity/snapshot"
2016-06-17 13:05:22 TRACE:snapshot: feeding state chunk 5bab4fdd04fbb05804a4fbe67a21444bfa43a39b4ecbe74a556f8805455fb667, compressed size 9932087
2016-06-17 13:05:28 TRACE:snapshot: feeding state chunk cd4fe9726c8ff73fab5290a439596744021e03548f3768ec8185aa725172dc7b, compressed size 8330857
2016-06-17 13:05:31 TRACE:snapshot: feeding state chunk 5abb81938e8e0691f99434f7f66314f08b08e63aaa612c62f71dbdf4764c4d79, compressed size 8727748
2016-06-17 13:05:36 TRACE:snapshot: feeding state chunk cea8534404119dcbf30b341b928a09334ade70604ee5f649e653c5f4afdbe783, compressed size 9836558
2016-06-17 13:05:40 TRACE:snapshot: feeding state chunk c05801f07d625436fc26f2d510d43b3bbe53fabf1ac29b5975c94c85eb6a40a2, compressed size 7952591
2016-06-17 13:05:43 TRACE:snapshot: feeding state chunk 1a41e7d8afb3244b572d95f2866c488362f98a357abf5e8c9a4c9202b39ca76f, compressed size 7392796
2016-06-17 13:05:46 TRACE:snapshot: feeding state chunk f95183ab3d4805511e8d1491f1ae14eb6d4ed332a7f3992716a3fac1e6663dfa, compressed size 4794858
2016-06-17 13:05:48 TRACE:snapshot: feeding state chunk 2e9d97710a86f012e07198345bcdb7088e9e241fd14cc6aed603e5d2582ee8f5, compressed size 12189254
2016-06-17 13:05:56 TRACE:snapshot: feeding state chunk e5a1e524fa018407e0d9f3c2e838786042afd566fc6acb34ff77c3a1b7f6fe8d, compressed size 6503616
```

db usage after:
```bash
robert@habermeier-laptop-zenbook303:~/projects/eth/parity$ du -h ~/.parity/906a34e69aec8c0d/
96K	/home/robert/.parity/906a34e69aec8c0d/v5.3-sec-refcounted/state
100K	/home/robert/.parity/906a34e69aec8c0d/v5.3-sec-refcounted
96K	/home/robert/.parity/906a34e69aec8c0d/v5.3-sec-archive/tracedb
269M	/home/robert/.parity/906a34e69aec8c0d/v5.3-sec-archive/state
132K	/home/robert/.parity/906a34e69aec8c0d/v5.3-sec-archive/extras
96K	/home/robert/.parity/906a34e69aec8c0d/v5.3-sec-archive/blocks
270M	/home/robert/.parity/906a34e69aec8c0d/v5.3-sec-archive
96K	/home/robert/.parity/906a34e69aec8c0d/v5.3-sec-overlayrecent/state
100K	/home/robert/.parity/906a34e69aec8c0d/v5.3-sec-overlayrecent
96K	/home/robert/.parity/906a34e69aec8c0d/v5.3-sec-earlymerge/state
100K	/home/robert/.parity/906a34e69aec8c0d/v5.3-sec-earlymerge
270M	/home/robert/.parity/906a34e69aec8c0d/
```