### PR TITLE
--geth prevent getTransactionReceipt from using pending.

### DIFF
--- a/ethcore/src/miner/miner.rs
+++ b/ethcore/src/miner/miner.rs
@@ -384,9 +384,13 @@ impl MinerService for Miner {
 			.collect()
 	}
 
-	fn import_own_transaction<T>(&self, chain: &MiningBlockChainClient, transaction: SignedTransaction, fetch_account: T) ->
-		Result<TransactionImportResult, Error>
-		where T: Fn(&Address) -> AccountDetails {
+	fn import_own_transaction<T>(
+		&self,
+		chain: &MiningBlockChainClient,
+		transaction: SignedTransaction,
+		fetch_account: T
+	) -> Result<TransactionImportResult, Error> where T: Fn(&Address) -> AccountDetails {
+
 		let hash = transaction.hash();
 		trace!(target: "own_tx", "Importing transaction: {:?}", transaction);
 

--- a/ethcore/src/miner/transaction_queue.rs
+++ b/ethcore/src/miner/transaction_queue.rs
@@ -425,7 +425,7 @@ impl TransactionQueue {
 
 	/// Add signed transaction to queue to be verified and imported
 	pub fn add<T>(&mut self, tx: SignedTransaction, fetch_account: &T, origin: TransactionOrigin) -> Result<TransactionImportResult, Error>
-		where T: Fn(&Address) -> AccountDetails {
+	where T: Fn(&Address) -> AccountDetails {
 
 		trace!(target: "miner", "Importing: {:?}", tx.hash());
 

--- a/parity/cli.rs
+++ b/parity/cli.rs
@@ -168,9 +168,10 @@ Virtual Machine Options:
   --jitvm                  Enable the JIT VM.
 
 Legacy Options:
-  --geth                   Run in Geth-compatibility mode. Currently just sets
-                           the IPC path to be the same as Geth's. Overrides
-                           the --ipc-path/--ipcpath options.
+  --geth                   Run in Geth-compatibility mode. Sets the IPC path
+                           to be the same as Geth's. Overrides the --ipc-path
+                           and --ipcpath options. Alters RPCs to reflect Geth
+                           bugs.
   --testnet                Geth-compatible testnet mode. Equivalent to --chain
                            testnet --keys-path $HOME/parity/testnet-keys.
                            Overrides the --keys-path option.

--- a/parity/main.rs
+++ b/parity/main.rs
@@ -222,6 +222,7 @@ fn execute_client(conf: Configuration, spec: Spec, client_config: ClientConfig) 
 		external_miner: external_miner.clone(),
 		logger: logger.clone(),
 		settings: network_settings.clone(),
+		allow_pending_receipt_query: !conf.args.flag_geth,
 	});
 
 	let dependencies = rpc::Dependencies {

--- a/parity/rpc_apis.rs
+++ b/parity/rpc_apis.rs
@@ -88,6 +88,7 @@ pub struct Dependencies {
 	pub external_miner: Arc<ExternalMiner>,
 	pub logger: Arc<RotatingLogger>,
 	pub settings: Arc<NetworkSettings>,
+	pub allow_pending_receipt_query: bool,
 }
 
 fn to_modules(apis: &[Api]) -> BTreeMap<String, String> {
@@ -143,7 +144,7 @@ pub fn setup_rpc<T: Extendable>(server: T, deps: Arc<Dependencies>, apis: ApiSet
 				server.add_delegate(NetClient::new(&deps.sync).to_delegate());
 			},
 			Api::Eth => {
-				server.add_delegate(EthClient::new(&deps.client, &deps.sync, &deps.secret_store, &deps.miner, &deps.external_miner).to_delegate());
+				server.add_delegate(EthClient::new(&deps.client, &deps.sync, &deps.secret_store, &deps.miner, &deps.external_miner, deps.allow_pending_receipt_query).to_delegate());
 				server.add_delegate(EthFilterClient::new(&deps.client, &deps.miner).to_delegate());
 
 				if deps.signer_port.is_some() {

--- a/rpc/rpctest/src/main.rs
+++ b/rpc/rpctest/src/main.rs
@@ -123,7 +123,7 @@ impl Configuration {
 			accs.insert(Address::from(1), TestAccount::new("test"));
 			let accounts = Arc::new(TestAccountProvider::new(accs));
 			let server = rpc::RpcServer::new();
-			server.add_delegate(EthClient::new(&client, &sync, &accounts, &miner).to_delegate());
+			server.add_delegate(EthClient::new(&client, &sync, &accounts, &miner, true).to_delegate());
 			server.add_delegate(EthFilterClient::new(&client, &miner).to_delegate());
 
 			let url = format!("{}:{}", self.args.flag_jsonrpc_addr, self.args.flag_jsonrpc_port);

--- a/rpc/src/v1/impls/eth.rs
+++ b/rpc/src/v1/impls/eth.rs
@@ -54,6 +54,7 @@ pub struct EthClient<C, S, A, M, EM> where
 	miner: Weak<M>,
 	external_miner: Arc<EM>,
 	seed_compute: Mutex<SeedHashCompute>,
+	allow_pending_receipt_query: bool,
 }
 
 impl<C, S, A, M, EM> EthClient<C, S, A, M, EM> where
@@ -64,7 +65,7 @@ impl<C, S, A, M, EM> EthClient<C, S, A, M, EM> where
 	EM: ExternalMinerService {
 
 	/// Creates new EthClient.
-	pub fn new(client: &Arc<C>, sync: &Arc<S>, accounts: &Arc<A>, miner: &Arc<M>, em: &Arc<EM>)
+	pub fn new(client: &Arc<C>, sync: &Arc<S>, accounts: &Arc<A>, miner: &Arc<M>, em: &Arc<EM>, allow_pending_receipt_query: bool)
 		-> EthClient<C, S, A, M, EM> {
 		EthClient {
 			client: Arc::downgrade(client),
@@ -73,6 +74,7 @@ impl<C, S, A, M, EM> EthClient<C, S, A, M, EM> where
 			accounts: Arc::downgrade(accounts),
 			external_miner: em.clone(),
 			seed_compute: Mutex::new(SeedHashCompute::new()),
+			allow_pending_receipt_query: allow_pending_receipt_query,
 		}
 	}
 
@@ -423,8 +425,8 @@ impl<C, S, A, M, EM> Eth for EthClient<C, S, A, M, EM> where
 			.and_then(|(hash,)| {
 				let miner = take_weak!(self.miner);
 				match miner.pending_receipts().get(&hash) {
-					Some(receipt) => to_value(&Receipt::from(receipt.clone())),
-					None => {
+					Some(receipt) if self.allow_pending_receipt_query => to_value(&Receipt::from(receipt.clone())),
+					_ => {
 						let client = take_weak!(self.client);
 						let receipt = client.transaction_receipt(TransactionID::Hash(hash));
 						to_value(&receipt.map(Receipt::from))

--- a/rpc/src/v1/tests/eth.rs
+++ b/rpc/src/v1/tests/eth.rs
@@ -107,7 +107,8 @@ impl EthTester {
 			&sync_provider,
 			&account_provider,
 			&miner_service,
-			&external_miner
+			&external_miner,
+			true
 		);
 		let eth_sign = EthSigningUnsafeClient::new(
 			&client,

--- a/rpc/src/v1/tests/mocked/eth.rs
+++ b/rpc/src/v1/tests/mocked/eth.rs
@@ -71,7 +71,7 @@ impl Default for EthTester {
 		let miner = miner_service();
 		let hashrates = Arc::new(RwLock::new(HashMap::new()));
 		let external_miner = Arc::new(ExternalMiner::new(hashrates.clone()));
-		let eth = EthClient::new(&client, &sync, &ap, &miner, &external_miner).to_delegate();
+		let eth = EthClient::new(&client, &sync, &ap, &miner, &external_miner, true).to_delegate();
 		let sign = EthSigningUnsafeClient::new(&client, &ap, &miner).to_delegate();
 		let io = IoHandler::new();
 		io.add_delegate(eth);


### PR DESCRIPTION
This mimics the fucntionality of Geth and the current unratified
JSONRPC spec (but not the functionality of eth and the ratified
spec).