### PR TITLE
Fixing replacing transaction with lower gas_price result.

### DIFF
--- a/ethcore/src/miner/transaction_queue.rs
+++ b/ethcore/src/miner/transaction_queue.rs
@@ -688,14 +688,15 @@ impl TransactionQueue {
 		if let Some(order) = self.future.drop(&address, &nonce) {
 			// Let's insert that transaction to current (if it has higher gas_price)
 			let future_tx = self.by_hash.remove(&order.hash).unwrap();
-			try!(check_too_cheap(Self::replace_transaction(future_tx, state_nonce, &mut self.current, &mut self.by_hash)));
+			// if transaction in `current` (then one we are importing) is replaced it means that it has to low gas_price
+			try!(check_too_cheap(!Self::replace_transaction(future_tx, state_nonce, &mut self.current, &mut self.by_hash)));
 		}
 
 		// Also enforce the limit
 		let removed = self.current.enforce_limit(&mut self.by_hash);
 		// If some transaction were removed because of limit we need to update last_nonces also.
 		self.update_last_nonces(&removed);
-		// Trigger error if we were removed.
+		// Trigger error if the transaction we are importing was removed.
 		try!(check_if_removed(&address, &nonce, removed));
 
 		trace!(target: "miner", "status: {:?}", self.status());
@@ -939,7 +940,7 @@ mod test {
 		let res = txq.add(tx2.clone(), &default_nonce, TransactionOrigin::External);
 
 		// and then there should be only one transaction in current (the one with higher gas_price)
-		assert_eq!(unwrap_tx_err(res), TransactionError::TooCheapToReplace);
+		assert_eq!(res.unwrap(), TransactionImportResult::Current);
 		assert_eq!(txq.status().pending, 1);
 		assert_eq!(txq.status().future, 0);
 		assert_eq!(txq.current.by_priority.len(), 1);


### PR DESCRIPTION
1. Transaction `tx=(sender1, nonce, gas_price)` in future.
2. Importing transaction `tx2=(sender1, nonce, gas_price+k)` to current (state nonce changed in the meantime)
3. `tx2` should be imported to current (and it was) but error was returned (which was incorrect)