### PR TITLE
Updating parity-dapps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -926,7 +926,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "parity-dapps"
 version = "0.3.0"
-source = "git+https://github.com/ethcore/parity-dapps-rs.git#1f065d93aa49338e4a453c77c839957f2db78895"
+source = "git+https://github.com/ethcore/parity-dapps-rs.git#8cc812c26c903cf5764ce0f4cc3f2a7c3ddb0dc2"
 dependencies = [
  "aster 0.17.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "glob 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
to fix compilation of dapps on latest nightly.

Changes:
https://github.com/ethcore/parity-dapps-rs/commit/8cc812c26c903cf5764ce0f4cc3f2a7c3ddb0dc2