### PR TITLE
Set default database file size large enough

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1105,7 +1105,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "rocksdb"
 version = "0.4.5"
-source = "git+https://github.com/ethcore/rust-rocksdb#8f6e43b2d8799578a378648bcb17c01fb431dbec"
+source = "git+https://github.com/ethcore/rust-rocksdb#e0e6c099d8cd156fe446009fce241d57b00cd8f4"
 dependencies = [
  "libc 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocksdb-sys 0.3.0 (git+https://github.com/ethcore/rust-rocksdb)",
@@ -1114,7 +1114,7 @@ dependencies = [
 [[package]]
 name = "rocksdb-sys"
 version = "0.3.0"
-source = "git+https://github.com/ethcore/rust-rocksdb#8f6e43b2d8799578a378648bcb17c01fb431dbec"
+source = "git+https://github.com/ethcore/rust-rocksdb#e0e6c099d8cd156fe446009fce241d57b00cd8f4"
 dependencies = [
  "gcc 0.3.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1105,7 +1105,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "rocksdb"
 version = "0.4.5"
-source = "git+https://github.com/ethcore/rust-rocksdb#9140e37ce0fdb748097f85653c01b0f7e3736ea9"
+source = "git+https://github.com/ethcore/rust-rocksdb#8f6e43b2d8799578a378648bcb17c01fb431dbec"
 dependencies = [
  "libc 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",
  "rocksdb-sys 0.3.0 (git+https://github.com/ethcore/rust-rocksdb)",
@@ -1114,7 +1114,7 @@ dependencies = [
 [[package]]
 name = "rocksdb-sys"
 version = "0.3.0"
-source = "git+https://github.com/ethcore/rust-rocksdb#9140e37ce0fdb748097f85653c01b0f7e3736ea9"
+source = "git+https://github.com/ethcore/rust-rocksdb#8f6e43b2d8799578a378648bcb17c01fb431dbec"
 dependencies = [
  "gcc 0.3.28 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.12 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/util/src/kvdb.rs
+++ b/util/src/kvdb.rs
@@ -20,8 +20,8 @@ use std::default::Default;
 use rocksdb::{DB, Writable, WriteBatch, IteratorMode, DBVector, DBIterator,
 	IndexType, Options, DBCompactionStyle, BlockBasedOptions, Direction};
 
-const DB_FILE_SIZE_BASE: u64 = 100 * 1024 * 1024;
-const DB_FILE_SIZE_MULTIPLIER: i32 = 10;
+const DB_FILE_SIZE_BASE: u64 = 10 * 1024 * 1024;
+const DB_FILE_SIZE_MULTIPLIER: i32 = 5;
 
 /// Write transaction. Batches a sequence of put/delete operations for efficiency.
 pub struct DBTransaction {
@@ -67,7 +67,7 @@ impl DatabaseConfig {
 		DatabaseConfig {
 			cache_size: Some(cache_size),
 			prefix_size: None,
-			max_open_files: 256
+			max_open_files: -1,
 		}
 	}
 }
@@ -77,7 +77,7 @@ impl Default for DatabaseConfig {
 		DatabaseConfig {
 			cache_size: None,
 			prefix_size: None,
-			max_open_files: 256
+			max_open_files: -1,
 		}
 	}
 }

--- a/util/src/kvdb.rs
+++ b/util/src/kvdb.rs
@@ -20,6 +20,9 @@ use std::default::Default;
 use rocksdb::{DB, Writable, WriteBatch, IteratorMode, DBVector, DBIterator,
 	IndexType, Options, DBCompactionStyle, BlockBasedOptions, Direction};
 
+const DB_FILE_SIZE_BASE: u64 = 100 * 1024 * 1024;
+const DB_FILE_SIZE_MULTIPLIER: usize = 10;
+
 /// Write transaction. Batches a sequence of put/delete operations for efficiency.
 pub struct DBTransaction {
 	batch: WriteBatch,
@@ -110,6 +113,8 @@ impl Database {
 		opts.create_if_missing(true);
 		opts.set_use_fsync(false);
 		opts.set_compaction_style(DBCompactionStyle::DBUniversalCompaction);
+		opts.set_target_file_size_base(DB_FILE_SIZE_BASE);
+		opts.set_target_file_size_multiplier(DB_FILE_SIZE_MULTIPLIER);
 		if let Some(cache_size) = config.cache_size {
 			// half goes to read cache
 			opts.set_block_cache_size_mb(cache_size as u64 / 2);

--- a/util/src/kvdb.rs
+++ b/util/src/kvdb.rs
@@ -21,7 +21,7 @@ use rocksdb::{DB, Writable, WriteBatch, IteratorMode, DBVector, DBIterator,
 	IndexType, Options, DBCompactionStyle, BlockBasedOptions, Direction};
 
 const DB_FILE_SIZE_BASE: u64 = 100 * 1024 * 1024;
-const DB_FILE_SIZE_MULTIPLIER: usize = 10;
+const DB_FILE_SIZE_MULTIPLIER: i32 = 10;
 
 /// Write transaction. Batches a sequence of put/delete operations for efficiency.
 pub struct DBTransaction {


### PR DESCRIPTION
Prevents performance degradation of large databases stored on hdd

Still have to strictly confirm that it fixes hdd sync issues

but state db with `pruning=archieve` is currently consists of over the 9000 (nuturally) files, given only 256 allowed to be open at once, and taking in account recommended rocksdb maximum file amount of 50, this still worth fixing anyway