### PR TITLE
Removing signer connection limit

### DIFF
--- a/signer/src/ws_server/mod.rs
+++ b/signer/src/ws_server/mod.rs
@@ -93,7 +93,6 @@ impl Server {
 		let config = {
 			let mut config = ws::Settings::default();
 			// It's also used for handling min-sysui requests (browser can make many of them in paralel)
-			config.max_connections = 15;
 			config.method_strict = true;
 			// Was shutting down server when suspending on linux:
 			config.shutdown_on_interrupt = false;


### PR DESCRIPTION
Solves #1382 

Opening many tabs with signer UI was hitting the limit, causing some of the connections to be open which wouldn't let the server close.