### PR TITLE
Signer with unlocked account working as expected.

### DIFF
--- a/ethcore/src/account_provider.rs
+++ b/ethcore/src/account_provider.rs
@@ -205,6 +205,13 @@ impl AccountProvider {
 		self.unlock_account(account, password, Unlock::Temp)
 	}
 
+	/// Checks if given account is unlocked
+	pub fn is_unlocked<A>(&self, account: A) -> bool where Address: From<A> {
+		let account = Address::from(account).into();
+		let unlocked = self.unlocked.read().unwrap();
+		unlocked.get(&account).is_some()
+	}
+
 	/// Signs the message. Account must be unlocked.
 	pub fn sign<A, M>(&self, account: A, message: M) -> Result<H520, Error> where Address: From<A>, Message: From<M> {
 		let account = Address::from(account).into();

--- a/parity/main.rs
+++ b/parity/main.rs
@@ -193,6 +193,12 @@ fn execute_client(conf: Configuration, spec: Spec, client_config: ClientConfig) 
 		});
 	}
 
+	// Display warning about using unlock with signer
+	if conf.args.flag_signer && conf.args.flag_unlock.is_some() {
+		warn!("Using Trusted Signer and --unlock is not recommended!");
+		warn!("NOTE that Signer will not ask you to confirm transactions from unlocked account.");
+	}
+
 	// Secret Store
 	let account_service = Arc::new(conf.account_service());
 

--- a/parity/rpc_apis.rs
+++ b/parity/rpc_apis.rs
@@ -150,7 +150,7 @@ pub fn setup_rpc<T: Extendable>(server: T, deps: Arc<Dependencies>, apis: ApiSet
 				server.add_delegate(EthFilterClient::new(&deps.client, &deps.miner).to_delegate());
 
 				if deps.signer_port.is_some() {
-					server.add_delegate(EthSigningQueueClient::new(&deps.signer_queue, &deps.client, &deps.miner).to_delegate());
+					server.add_delegate(EthSigningQueueClient::new(&deps.signer_queue, &deps.client, &deps.miner, &deps.secret_store).to_delegate());
 				} else {
 					server.add_delegate(EthSigningUnsafeClient::new(&deps.client, &deps.secret_store, &deps.miner).to_delegate());
 				}


### PR DESCRIPTION
Transactions coming from unlocked account does not require confirmations.

Closes: #1326 (when signer is disabled the UI will still ask you for password, though)