### PR TITLE
rpc api by default for ipc

### DIFF
--- a/parity/cli.rs
+++ b/parity/cli.rs
@@ -55,7 +55,7 @@ Account Options:
                            ACCOUNTS is a comma-delimited list of addresses.
   --password FILE          Provide a file containing a password for unlocking
                            an account.
-  --keys-iterations NUM    Specify the number of iterations to use when 
+  --keys-iterations NUM    Specify the number of iterations to use when
                            deriving key from the password (bigger is more
                            secure) [default: 10240].
   --no-import-keys         Do not import keys from legacy clients.
@@ -98,7 +98,7 @@ API and Console Options:
   --ipc-path PATH          Specify custom path for JSON-RPC over IPC service
                            [default: $HOME/.parity/jsonrpc.ipc].
   --ipc-apis APIS          Specify custom API set available via JSON-RPC over
-                           IPC [default: web3,eth,net,ethcore,personal,traces].
+                           IPC [default: web3,eth,net,ethcore,personal,traces,rpc].
 
   --dapps-off              Disable the Dapps server (e.g. status page).
   --dapps-port PORT        Specify the port portion of the Dapps server


### PR DESCRIPTION
fixes #1391 

bug was introduced by not listing rpc api (which is requested by geth for anything it is attaching to)