### PR TITLE
Configurable gas limit cap.

### DIFF
--- a/ethcore/src/basic_authority.rs
+++ b/ethcore/src/basic_authority.rs
@@ -254,7 +254,7 @@ mod tests {
 		spec.ensure_db_good(db.as_hashdb_mut());
 		let last_hashes = vec![genesis_header.hash()];
 		let vm_factory = Default::default();
-		let b = OpenBlock::new(engine.deref(), &vm_factory, false, db, &genesis_header, last_hashes, None, addr, 3141562.into(), vec![]).unwrap();
+		let b = OpenBlock::new(engine.deref(), &vm_factory, false, db, &genesis_header, last_hashes, None, addr, (3141562.into(), 31415620.into()), vec![]).unwrap();
 		let b = b.close_and_lock();
 		let seal = engine.generate_seal(b.block(), Some(&tap)).unwrap();
 		assert!(b.try_seal(engine.deref(), seal).is_ok());

--- a/ethcore/src/basic_authority.rs
+++ b/ethcore/src/basic_authority.rs
@@ -80,7 +80,7 @@ impl Engine for BasicAuthority {
 		Schedule::new_homestead()
 	}
 
-	fn populate_from_parent(&self, header: &mut Header, parent: &Header, gas_floor_target: U256) {
+	fn populate_from_parent(&self, header: &mut Header, parent: &Header, gas_floor_target: U256, _gas_ceil_target: U256) {
 		header.difficulty = parent.difficulty;
 		header.gas_limit = {
 			let gas_limit = parent.gas_limit;

--- a/ethcore/src/block.rs
+++ b/ethcore/src/block.rs
@@ -222,7 +222,7 @@ impl<'x> OpenBlock<'x> {
 		last_hashes: LastHashes,
 		dao_rescue_block_gas_limit: Option<U256>,
 		author: Address,
-		gas_floor_target: U256,
+		gas_range_target: (U256, U256),
 		extra_data: Bytes,
 	) -> Result<Self, Error> {
 		let state = try!(State::from_existing(db, parent.state_root().clone(), engine.account_start_nonce()));
@@ -241,7 +241,7 @@ impl<'x> OpenBlock<'x> {
 		r.block.base.header.extra_data = extra_data;
 		r.block.base.header.note_dirty();
 
-		engine.populate_from_parent(&mut r.block.base.header, parent, gas_floor_target);
+		engine.populate_from_parent(&mut r.block.base.header, parent, gas_range_target.0, gas_range_target.1);
 		engine.on_new_block(&mut r.block);
 		Ok(r)
 	}
@@ -480,7 +480,7 @@ pub fn enact(
 		}
 	}
 
-	let mut b = try!(OpenBlock::new(engine, vm_factory, tracing, db, parent, last_hashes, dao_rescue_block_gas_limit, header.author().clone(), 3141562.into(), header.extra_data().clone()));
+	let mut b = try!(OpenBlock::new(engine, vm_factory, tracing, db, parent, last_hashes, dao_rescue_block_gas_limit, header.author().clone(), (3141562.into(), 31415620.into()), header.extra_data().clone()));
 	b.set_difficulty(*header.difficulty());
 	b.set_gas_limit(*header.gas_limit());
 	b.set_timestamp(header.timestamp());

--- a/ethcore/src/block.rs
+++ b/ethcore/src/block.rs
@@ -552,7 +552,7 @@ mod tests {
 		spec.ensure_db_good(db.as_hashdb_mut());
 		let last_hashes = vec![genesis_header.hash()];
 		let vm_factory = Default::default();
-		let b = OpenBlock::new(engine.deref(), &vm_factory, false, db, &genesis_header, last_hashes, None, Address::zero(), 3141562.into(), vec![]).unwrap();
+		let b = OpenBlock::new(engine.deref(), &vm_factory, false, db, &genesis_header, last_hashes, None, Address::zero(), (3141562.into(), 31415620.into()), vec![]).unwrap();
 		let b = b.close_and_lock();
 		let _ = b.seal(engine.deref(), vec![]);
 	}
@@ -568,7 +568,7 @@ mod tests {
 		let mut db = db_result.take();
 		spec.ensure_db_good(db.as_hashdb_mut());
 		let vm_factory = Default::default();
-		let b = OpenBlock::new(engine.deref(), &vm_factory, false, db, &genesis_header, vec![genesis_header.hash()], None, Address::zero(), 3141562.into(), vec![]).unwrap()
+		let b = OpenBlock::new(engine.deref(), &vm_factory, false, db, &genesis_header, vec![genesis_header.hash()], None, Address::zero(), (3141562.into(), 31415620.into()), vec![]).unwrap()
 			.close_and_lock().seal(engine.deref(), vec![]).unwrap();
 		let orig_bytes = b.rlp_bytes();
 		let orig_db = b.drain();
@@ -596,7 +596,7 @@ mod tests {
 		let mut db = db_result.take();
 		spec.ensure_db_good(db.as_hashdb_mut());
 		let vm_factory = Default::default();
-		let mut open_block = OpenBlock::new(engine.deref(), &vm_factory, false, db, &genesis_header, vec![genesis_header.hash()], None, Address::zero(), 3141562.into(), vec![]).unwrap();
+		let mut open_block = OpenBlock::new(engine.deref(), &vm_factory, false, db, &genesis_header, vec![genesis_header.hash()], None, Address::zero(), (3141562.into(), 31415620.into()), vec![]).unwrap();
 		let mut uncle1_header = Header::new();
 		uncle1_header.extra_data = b"uncle1".to_vec();
 		let mut uncle2_header = Header::new();

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -797,7 +797,7 @@ impl<V> BlockChainClient for Client<V> where V: Verifier {
 }
 
 impl<V> MiningBlockChainClient for Client<V> where V: Verifier {
-	fn prepare_open_block(&self, author: Address, gas_floor_target: U256, extra_data: Bytes) -> OpenBlock {
+	fn prepare_open_block(&self, author: Address, gas_range_target: (U256, U256), extra_data: Bytes) -> OpenBlock {
 		let engine = self.engine.deref().deref();
 		let h = self.chain.best_block_hash();
 
@@ -810,7 +810,7 @@ impl<V> MiningBlockChainClient for Client<V> where V: Verifier {
 			self.build_last_hashes(h.clone()),
 			self.dao_rescue_block_gas_limit(h.clone()),
 			author,
-			gas_floor_target,
+			gas_range_target,
 			extra_data,
 		).expect("OpenBlock::new only fails if parent state root invalid; state root of best block's header is never invalid; qed");
 

--- a/ethcore/src/client/mod.rs
+++ b/ethcore/src/client/mod.rs
@@ -251,6 +251,6 @@ pub trait BlockChainClient : Sync + Send {
 /// Extended client interface used for mining
 pub trait MiningBlockChainClient : BlockChainClient {
 	/// Returns OpenBlock prepared for closing.
-	fn prepare_open_block(&self, author: Address, gas_floor_target: U256, extra_data: Bytes)
+	fn prepare_open_block(&self, author: Address, gas_range_target: (U256, U256), extra_data: Bytes)
 		-> OpenBlock;
 }

--- a/ethcore/src/client/test_client.rs
+++ b/ethcore/src/client/test_client.rs
@@ -240,7 +240,7 @@ impl TestBlockChainClient {
 }
 
 impl MiningBlockChainClient for TestBlockChainClient {
-	fn prepare_open_block(&self, _author: Address, _gas_floor_target: U256, _extra_data: Bytes) -> OpenBlock {
+	fn prepare_open_block(&self, _author: Address, _gas_range_target: (U256, U256), _extra_data: Bytes) -> OpenBlock {
 		unimplemented!();
 	}
 }

--- a/ethcore/src/engine.rs
+++ b/ethcore/src/engine.rs
@@ -96,7 +96,7 @@ pub trait Engine : Sync + Send {
 
 	/// Don't forget to call Super::populate_from_parent when subclassing & overriding.
 	// TODO: consider including State in the params.
-	fn populate_from_parent(&self, header: &mut Header, parent: &Header, _gas_floor_target: U256) {
+	fn populate_from_parent(&self, header: &mut Header, parent: &Header, _gas_floor_target: U256, _gas_ceil_target: U256) {
 		header.difficulty = parent.difficulty;
 		header.gas_limit = parent.gas_limit;
 		header.note_dirty();

--- a/ethcore/src/ethereum/ethash.rs
+++ b/ethcore/src/ethereum/ethash.rs
@@ -112,15 +112,20 @@ impl Engine for Ethash {
 		}
 	}
 
-	fn populate_from_parent(&self, header: &mut Header, parent: &Header, gas_floor_target: U256) {
+	fn populate_from_parent(&self, header: &mut Header, parent: &Header, gas_floor_target: U256, gas_ceil_target: U256) {
 		header.difficulty = self.calculate_difficuty(header, parent);
 		header.gas_limit = {
 			let gas_limit = parent.gas_limit;
 			let bound_divisor = self.ethash_params.gas_limit_bound_divisor;
 			if gas_limit < gas_floor_target {
 				min(gas_floor_target, gas_limit + gas_limit / bound_divisor - 1.into())
+			} else if gas_limit > gas_ceil_target {
+				max(gas_ceil_target, gas_limit - gas_limit / bound_divisor + 1.into())
 			} else {
-				max(gas_floor_target, gas_limit - gas_limit / bound_divisor + 1.into() + (header.gas_used * 6.into() / 5.into()) / bound_divisor)
+				max(gas_ceil_target,
+					max(gas_floor_target,
+						gas_limit - gas_limit / bound_divisor + 1.into() +
+							(header.gas_used * 6.into() / 5.into()) / bound_divisor))
 			}
 		};
 		header.note_dirty();
@@ -237,8 +242,7 @@ impl Ethash {
 		let mut target = if header.number < frontier_limit {
 			if header.timestamp >= parent.timestamp + duration_limit {
 				parent.difficulty - (parent.difficulty / difficulty_bound_divisor)
-			}
-			else {
+			} else {
 				parent.difficulty + (parent.difficulty / difficulty_bound_divisor)
 			}
 		}

--- a/ethcore/src/ethereum/ethash.rs
+++ b/ethcore/src/ethereum/ethash.rs
@@ -327,7 +327,7 @@ mod tests {
 		spec.ensure_db_good(db.as_hashdb_mut());
 		let last_hashes = vec![genesis_header.hash()];
 		let vm_factory = Default::default();
-		let b = OpenBlock::new(engine.deref(), &vm_factory, false, db, &genesis_header, last_hashes, None, Address::zero(), 3141562.into(), vec![]).unwrap();
+		let b = OpenBlock::new(engine.deref(), &vm_factory, false, db, &genesis_header, last_hashes, None, Address::zero(), (3141562.into(), 31415620.into()), vec![]).unwrap();
 		let b = b.close();
 		assert_eq!(b.state().balance(&Address::zero()), U256::from_str("4563918244f40000").unwrap());
 	}
@@ -342,7 +342,7 @@ mod tests {
 		spec.ensure_db_good(db.as_hashdb_mut());
 		let last_hashes = vec![genesis_header.hash()];
 		let vm_factory = Default::default();
-		let mut b = OpenBlock::new(engine.deref(), &vm_factory, false, db, &genesis_header, last_hashes, None, Address::zero(), 3141562.into(), vec![]).unwrap();
+		let mut b = OpenBlock::new(engine.deref(), &vm_factory, false, db, &genesis_header, last_hashes, None, Address::zero(), (3141562.into(), 31415620.into()), vec![]).unwrap();
 		let mut uncle = Header::new();
 		let uncle_author = address_from_hex("ef2d6d194084c2de36e0dabfce45d046b37d1106");
 		uncle.author = uncle_author.clone();

--- a/ethcore/src/ethereum/ethash.rs
+++ b/ethcore/src/ethereum/ethash.rs
@@ -122,7 +122,7 @@ impl Engine for Ethash {
 			} else if gas_limit > gas_ceil_target {
 				max(gas_ceil_target, gas_limit - gas_limit / bound_divisor + 1.into())
 			} else {
-				max(gas_ceil_target,
+				min(gas_ceil_target,
 					max(gas_floor_target,
 						gas_limit - gas_limit / bound_divisor + 1.into() +
 							(header.gas_used * 6.into() / 5.into()) / bound_divisor))

--- a/ethcore/src/miner/mod.rs
+++ b/ethcore/src/miner/mod.rs
@@ -81,11 +81,18 @@ pub trait MinerService : Send + Sync {
 	/// Set minimal gas price of transaction to be accepted for mining.
 	fn set_minimal_gas_price(&self, min_gas_price: U256);
 
-	/// Get the gas limit we wish to target when sealing a new block.
+	/// Get the lower bound of the gas limit we wish to target when sealing a new block.
 	fn gas_floor_target(&self) -> U256;
 
-	/// Set the gas limit we wish to target when sealing a new block.
+	/// Get the upper bound of the gas limit we wish to target when sealing a new block.
+	fn gas_ceil_target(&self) -> U256;
+
+	// TODO: coalesce into single set_range function.
+	/// Set the lower bound of gas limit we wish to target when sealing a new block.
 	fn set_gas_floor_target(&self, target: U256);
+
+	/// Set the upper bound of gas limit we wish to target when sealing a new block.
+	fn set_gas_ceil_target(&self, target: U256);
 
 	/// Get current transactions limit in queue.
 	fn transactions_limit(&self) -> usize;

--- a/ethcore/src/tests/client.rs
+++ b/ethcore/src/tests/client.rs
@@ -150,7 +150,7 @@ fn can_mine() {
 	let client_result = get_test_client_with_blocks(vec![dummy_blocks[0].clone()]);
 	let client = client_result.reference();
 
-	let b = client.prepare_open_block(Address::default(), 31415926.into(), vec![]).close();
+	let b = client.prepare_open_block(Address::default(), (3141562.into(), 31415620.into()), vec![]).close();
 
 	assert_eq!(*b.block().header().parent_hash(), BlockView::new(&dummy_blocks[0]).header_view().sha3());
 }

--- a/ethcore/src/tests/helpers.rs
+++ b/ethcore/src/tests/helpers.rs
@@ -181,7 +181,7 @@ pub fn generate_dummy_client_with_spec_and_data<F>(get_test_spec: F, block_numbe
 			last_hashes.clone(),
 			None,
 			author.clone(),
-			3141562.into(),
+			(3141562.into(), 31415620.into()),
 			vec![]
 		).unwrap();
 		b.set_difficulty(U256::from(0x20000));

--- a/parity/cli.rs
+++ b/parity/cli.rs
@@ -137,6 +137,8 @@ Sealing/Mining Options:
                            good value [default: auto].
   --gas-floor-target GAS   Amount of gas per block to target when sealing a new
                            block [default: 3141592].
+  --gas-cap GAS            A cap on how large we will raise the gas limit per
+                           block due to transaction volume [default: 3141592].
   --author ADDRESS         Specify the block author (aka "coinbase") address
                            for sending block rewards from sealed blocks
                            [default: 0037a6b811ffeb6e072da21179d11b1406371c63].
@@ -283,6 +285,7 @@ pub struct Args {
 	pub flag_usd_per_tx: String,
 	pub flag_usd_per_eth: String,
 	pub flag_gas_floor_target: String,
+	pub flag_gas_cap: String,
 	pub flag_extra_data: Option<String>,
 	pub flag_tx_limit: usize,
 	pub flag_logging: Option<String>,

--- a/parity/configuration.rs
+++ b/parity/configuration.rs
@@ -85,7 +85,16 @@ impl Configuration {
 		}
 	}
 
-
+	pub fn gas_ceil_target(&self) -> U256 {
+		if self.args.flag_dont_help_rescue_dao || self.args.flag_dogmatic {
+			10_000_000.into()
+		} else {
+			let d = &self.args.flag_gas_cap;
+			U256::from_dec_str(d).unwrap_or_else(|_| {
+				die!("{}: Invalid target gas ceiling given. Must be a decimal unsigned 256-bit number.", d)
+			})
+		}
+	}
 
 	pub fn gas_price(&self) -> U256 {
 		match self.args.flag_gasprice.as_ref() {

--- a/parity/main.rs
+++ b/parity/main.rs
@@ -211,6 +211,7 @@ fn execute_client(conf: Configuration, spec: Spec, client_config: ClientConfig) 
 	let miner = Miner::with_accounts(conf.args.flag_force_sealing, conf.spec(), account_service.clone());
 	miner.set_author(conf.author());
 	miner.set_gas_floor_target(conf.gas_floor_target());
+	miner.set_gas_ceil_target(conf.gas_ceil_target());
 	miner.set_extra_data(conf.extra_data());
 	miner.set_minimal_gas_price(conf.gas_price());
 	miner.set_transactions_limit(conf.args.flag_tx_limit);

--- a/rpc/src/v1/impls/ethcore.rs
+++ b/rpc/src/v1/impls/ethcore.rs
@@ -72,6 +72,10 @@ impl<C, M> Ethcore for EthcoreClient<C, M> where M: MinerService + 'static, C: M
 		to_value(&take_weak!(self.miner).gas_floor_target())
 	}
 
+	fn gas_ceil_target(&self, _: Params) -> Result<Value, Error> {
+		to_value(&take_weak!(self.miner).gas_ceil_target())
+	}
+
 	fn dev_logs(&self, _params: Params) -> Result<Value, Error> {
 		let logs = self.logger.logs();
 		to_value(&logs.deref().as_slice())

--- a/rpc/src/v1/impls/ethcore_set.rs
+++ b/rpc/src/v1/impls/ethcore_set.rs
@@ -52,8 +52,15 @@ impl<M> EthcoreSet for EthcoreSetClient<M> where M: MinerService + 'static {
 	}
 
 	fn set_gas_floor_target(&self, params: Params) -> Result<Value, Error> {
-		from_params::<(U256,)>(params).and_then(|(gas_floor_target,)| {
-			take_weak!(self.miner).set_gas_floor_target(gas_floor_target);
+		from_params::<(U256,)>(params).and_then(|(target,)| {
+			take_weak!(self.miner).set_gas_floor_target(target);
+			to_value(&true)
+		})
+	}
+
+	fn set_gas_ceil_target(&self, params: Params) -> Result<Value, Error> {
+		from_params::<(U256,)>(params).and_then(|(target,)| {
+			take_weak!(self.miner).set_gas_ceil_target(target);
 			to_value(&true)
 		})
 	}

--- a/rpc/src/v1/traits/ethcore.rs
+++ b/rpc/src/v1/traits/ethcore.rs
@@ -30,6 +30,9 @@ pub trait Ethcore: Sized + Send + Sync + 'static {
 	/// Returns mining gas floor target.
 	fn gas_floor_target(&self, _: Params) -> Result<Value, Error>;
 
+	/// Returns mining gas floor cap.
+	fn gas_ceil_target(&self, _: Params) -> Result<Value, Error>;
+
 	/// Returns minimal gas price for transaction to be included in queue.
 	fn min_gas_price(&self, _: Params) -> Result<Value, Error>;
 
@@ -70,6 +73,7 @@ pub trait Ethcore: Sized + Send + Sync + 'static {
 
 		delegate.add_method("ethcore_extraData", Ethcore::extra_data);
 		delegate.add_method("ethcore_gasFloorTarget", Ethcore::gas_floor_target);
+		delegate.add_method("ethcore_gasCeilTarget", Ethcore::gas_ceil_target);
 		delegate.add_method("ethcore_minGasPrice", Ethcore::min_gas_price);
 		delegate.add_method("ethcore_transactionsLimit", Ethcore::transactions_limit);
 		delegate.add_method("ethcore_devLogs", Ethcore::dev_logs);

--- a/rpc/src/v1/traits/ethcore_set.rs
+++ b/rpc/src/v1/traits/ethcore_set.rs
@@ -28,6 +28,9 @@ pub trait EthcoreSet: Sized + Send + Sync + 'static {
 	/// Sets new gas floor target for mined blocks.
 	fn set_gas_floor_target(&self, _: Params) -> Result<Value, Error>;
 
+	/// Sets new gas ceiling target for mined blocks.
+	fn set_gas_ceil_target(&self, _: Params) -> Result<Value, Error>;
+
 	/// Sets new extra data for mined blocks.
 	fn set_extra_data(&self, _: Params) -> Result<Value, Error>;
 
@@ -54,6 +57,7 @@ pub trait EthcoreSet: Sized + Send + Sync + 'static {
 		let mut delegate = IoDelegate::new(Arc::new(self));
 		delegate.add_method("ethcore_setMinGasPrice", EthcoreSet::set_min_gas_price);
 		delegate.add_method("ethcore_setGasFloorTarget", EthcoreSet::set_gas_floor_target);
+		delegate.add_method("ethcore_setGasCeilTarget", EthcoreSet::set_gas_ceil_target);
 		delegate.add_method("ethcore_setExtraData", EthcoreSet::set_extra_data);
 		delegate.add_method("ethcore_setAuthor", EthcoreSet::set_author);
 		delegate.add_method("ethcore_setTransactionsLimit", EthcoreSet::set_transactions_limit);


### PR DESCRIPTION
The point of this is to provide an option to the user so they can cap the rise of gas limit. Gas limit strategy is to increase as long as there is significant gas usage in the block. For fork voting, this means a miner taking a large amount of transaction spam could accidentally keep their gas limit substantially above the target floor. This prevents that situation by allowing a cap, beyond which no amount of transaction volume could push the gas limit.