### PR TITLE
Don't mine without --author

### DIFF
--- a/parity/cli.rs
+++ b/parity/cli.rs
@@ -128,6 +128,9 @@ API and Console Options:
                            output on start up. This will prevent it.
 
 Sealing/Mining Options:
+  --author ADDRESS         Specify the block author (aka "coinbase") address
+                           for sending block rewards from sealed blocks.
+                           NOTE: MINING WILL NOT WORK WITHOUT THIS OPTION.
   --force-sealing          Force the node to author new blocks as if it were
                            always sealing/mining.
   --usd-per-tx USD         Amount of USD to be paid for a basic transaction
@@ -141,9 +144,6 @@ Sealing/Mining Options:
                            block [default: 3141592].
   --gas-cap GAS            A cap on how large we will raise the gas limit per
                            block due to transaction volume [default: 3141592].
-  --author ADDRESS         Specify the block author (aka "coinbase") address
-                           for sending block rewards from sealed blocks
-                           [default: 0037a6b811ffeb6e072da21179d11b1406371c63].
   --extra-data STRING      Specify a custom extra-data for authored blocks, no
                            more than 32 characters.
   --tx-limit LIMIT         Limit of transactions kept in the queue (waiting to
@@ -283,7 +283,7 @@ pub struct Args {
 	pub flag_signer_path: String,
 	pub flag_no_token: bool,
 	pub flag_force_sealing: bool,
-	pub flag_author: String,
+	pub flag_author: Option<String>,
 	pub flag_usd_per_tx: String,
 	pub flag_usd_per_eth: String,
 	pub flag_gas_floor_target: String,

--- a/parity/configuration.rs
+++ b/parity/configuration.rs
@@ -67,11 +67,12 @@ impl Configuration {
 		self.args.flag_maxpeers.unwrap_or(self.args.flag_peers) as u32
 	}
 
-	pub fn author(&self) -> Address {
-		let d = self.args.flag_etherbase.as_ref().unwrap_or(&self.args.flag_author);
-		Address::from_str(clean_0x(d)).unwrap_or_else(|_| {
-			die!("{}: Invalid address for --author. Must be 40 hex characters, with or without the 0x at the beginning.", d)
-		})
+	pub fn author(&self) -> Option<Address> {
+		self.args.flag_etherbase.as_ref()
+			.or(self.args.flag_author.as_ref())
+			.map(|d| Address::from_str(clean_0x(d)).unwrap_or_else(|_| {
+				die!("{}: Invalid address for --author. Must be 40 hex characters, with or without the 0x at the beginning.", d)
+			}))
 	}
 
 	pub fn gas_floor_target(&self) -> U256 {

--- a/parity/main.rs
+++ b/parity/main.rs
@@ -209,7 +209,7 @@ fn execute_client(conf: Configuration, spec: Spec, client_config: ClientConfig) 
 
 	// Miner
 	let miner = Miner::with_accounts(conf.args.flag_force_sealing, conf.spec(), account_service.clone());
-	miner.set_author(conf.author());
+	miner.set_author(conf.author().unwrap_or(Default::default()));
 	miner.set_gas_floor_target(conf.gas_floor_target());
 	miner.set_gas_ceil_target(conf.gas_ceil_target());
 	miner.set_extra_data(conf.extra_data());

--- a/rpc/src/v1/impls/mod.rs
+++ b/rpc/src/v1/impls/mod.rs
@@ -68,7 +68,8 @@ mod error_codes {
 	// NOTE [ToDr] Codes from [-32099, -32000]
 	pub const UNSUPPORTED_REQUEST_CODE: i64 = -32000;
 	pub const NO_WORK_CODE: i64 = -32001;
-	pub const UNKNOWN_ERROR: i64 = -32002;
+	pub const NO_AUTHOR_CODE: i64 = -32002;
+	pub const UNKNOWN_ERROR: i64 = -32009;
 	pub const TRANSACTION_ERROR: i64 = -32010;
 	pub const ACCOUNT_LOCKED: i64 = -32020;
 	pub const SIGNER_DISABLED: i64 = -32030;


### PR DESCRIPTION
Requires --author to be set before mining is allowed to happen.