### PR TITLE
change IPC codegen to allow attributes

### DIFF
--- a/ipc/codegen/Cargo.toml
+++ b/ipc/codegen/Cargo.toml
@@ -22,5 +22,5 @@ aster = { version = "0.17", default-features = false }
 clippy = { version = "^0.*", optional = true }
 quasi = { version = "0.11", default-features = false }
 quasi_macros = { version = "0.11", optional = true }
-syntex = { version = "*", optional = true }
-syntex_syntax = { version = "*", optional = true }
+syntex = { version = "0.33", optional = true }
+syntex_syntax = { version = "0.33", optional = true }

--- a/ipc/codegen/src/lib.rs
+++ b/ipc/codegen/src/lib.rs
@@ -50,12 +50,11 @@ include!("lib.rs.in");
 
 #[cfg(feature = "with-syntex")]
 pub fn register(reg: &mut syntex::Registry) {
-	/// Strip the serde attributes from the crate.
+	use syntax::{ast, fold};
+
 	#[cfg(feature = "with-syntex")]
 	fn strip_attributes(krate: ast::Crate) -> ast::Crate {
-		/// Helper folder that strips the serde attributes after the extensions have been expanded.
 		struct StripAttributeFolder;
-
 		impl fold::Folder for StripAttributeFolder {
 			fn fold_attribute(&mut self, attr: ast::Attribute) -> Option<ast::Attribute> {
 				match attr.node.value.node {

--- a/ipc/codegen/src/lib.rs
+++ b/ipc/codegen/src/lib.rs
@@ -50,11 +50,37 @@ include!("lib.rs.in");
 
 #[cfg(feature = "with-syntex")]
 pub fn register(reg: &mut syntex::Registry) {
+	/// Strip the serde attributes from the crate.
+	#[cfg(feature = "with-syntex")]
+	fn strip_attributes(krate: ast::Crate) -> ast::Crate {
+		/// Helper folder that strips the serde attributes after the extensions have been expanded.
+		struct StripAttributeFolder;
+
+		impl fold::Folder for StripAttributeFolder {
+			fn fold_attribute(&mut self, attr: ast::Attribute) -> Option<ast::Attribute> {
+				match attr.node.value.node {
+					ast::MetaItemKind::List(ref n, _) if n == &"ipc" => { return None; }
+					_ => {}
+				}
+
+				Some(attr)
+			}
+
+			fn fold_mac(&mut self, mac: ast::Mac) -> ast::Mac {
+				fold::noop_fold_mac(mac, self)
+			}
+		}
+
+		fold::Folder::fold_crate(&mut StripAttributeFolder, krate)
+	}
+
 	reg.add_attr("feature(custom_derive)");
 	reg.add_attr("feature(custom_attribute)");
 
 	reg.add_decorator("derive_Ipc", codegen::expand_ipc_implementation);
 	reg.add_decorator("derive_Binary", serialization::expand_serialization_implementation);
+
+	reg.add_post_expansion_pass(strip_attributes);
 }
 
 #[cfg(not(feature = "with-syntex"))]
@@ -67,4 +93,6 @@ pub fn register(reg: &mut rustc_plugin::Registry) {
 		syntax::parse::token::intern("derive_Binary"),
 		syntax::ext::base::MultiDecorator(
 			Box::new(serialization::expand_serialization_implementation)));
+
+	reg.register_attribute("ipc".to_owned(), AttributeType::Normal);
 }

--- a/ipc/tests/Cargo.toml
+++ b/ipc/tests/Cargo.toml
@@ -16,5 +16,5 @@ ethcore-ipc-nano = { path = "../nano" }
 ethcore-util = { path = "../../util" }
 
 [build-dependencies]
-syntex = "*"
+syntex = "0.33"
 ethcore-ipc-codegen = { path = "../codegen" }

--- a/ipc/tests/build.rs
+++ b/ipc/tests/build.rs
@@ -59,6 +59,23 @@ pub fn main() {
 	}
 
 	// rpc pass
+	if {
+		let src = Path::new("with_attrs.rs.in");
+		let dst = Path::new(&out_dir).join("with_attrs_ipc.rs");
+		let mut registry = syntex::Registry::new();
+		codegen::register(&mut registry);
+		registry.expand("", &src, &dst).is_ok()
+	}
+	// serialization pass
+	{
+		let src = Path::new(&out_dir).join("with_attrs_ipc.rs");
+		let dst = Path::new(&out_dir).join("with_attrs_cg.rs");
+		let mut registry = syntex::Registry::new();
+		codegen::register(&mut registry);
+		registry.expand("", &src, &dst).unwrap();
+	}
+
+	// rpc pass
 	{
 		let src = Path::new("binary.rs.in");
 		let dst = Path::new(&out_dir).join("binary.rs");

--- a/ipc/tests/examples.rs
+++ b/ipc/tests/examples.rs
@@ -86,7 +86,7 @@ mod tests {
 				0, 0, 0, 0, 0, 0, 0, 0,
 				4, 0, 0, 0, 0, 0, 0, 0,
 				5, 0, 0, 0],
-			service_client.socket().borrow().write_buffer.clone());
+			service_client.socket().write().unwrap().write_buffer.clone());
 		assert_eq!(10, result);
 	}
 
@@ -103,7 +103,7 @@ mod tests {
 			1, 0, 0, 0, 0, 0, 0, 0,
 			4, 0, 0, 0, 0, 0, 0, 0,
 			8, 0, 0, 0, 0, 0, 0, 0,
-			5, 0, 0, 0, 10, 0, 0, 0], service_client.socket().borrow().write_buffer.clone());
+			5, 0, 0, 0, 10, 0, 0, 0], service_client.socket().write().unwrap().write_buffer.clone());
 		assert_eq!(10, result);
 	}
 
@@ -145,7 +145,7 @@ mod tests {
 			// items
 			3, 0, 0, 0, 0, 0, 0, 0,
 			11, 0, 0, 0, 0, 0, 0, 0],
-			service_client.socket().borrow().write_buffer.clone());
+			service_client.socket().write().unwrap().write_buffer.clone());
 		assert_eq!(true, result);
 	}
 

--- a/ipc/tests/over_nano.rs
+++ b/ipc/tests/over_nano.rs
@@ -18,6 +18,7 @@
 mod tests {
 
 	use super::super::service::*;
+	use super::super::with_attrs::PrettyNamedClient;
 	use nanoipc;
 	use std::sync::Arc;
 	use std::io::Write;
@@ -40,6 +41,12 @@ mod tests {
 	#[test]
 	fn can_create_client() {
 		let client = nanoipc::init_duplex_client::<ServiceClient<_>>("ipc:///tmp/parity-nano-test10.ipc");
+		assert!(client.is_ok());
+	}
+
+	#[test]
+	fn can_create_renamed_client() {
+		let client = nanoipc::init_duplex_client::<PrettyNamedClient<_>>("ipc:///tmp/parity-nano-test10.ipc");
 		assert!(client.is_ok());
 	}
 

--- a/ipc/tests/with_attrs.rs
+++ b/ipc/tests/with_attrs.rs
@@ -14,18 +14,5 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-#![allow(dead_code)]
-
-extern crate ethcore_ipc as ipc;
-extern crate ethcore_devtools as devtools;
-extern crate semver;
-extern crate nanomsg;
-extern crate ethcore_ipc_nano as nanoipc;
-extern crate ethcore_util as util;
-
-pub mod service;
-mod examples;
-mod over_nano;
-mod nested;
-mod binary;
-mod with_attrs;
+#![allow(dead_code, unused_assignments, unused_variables)] // codegen issues
+include!(concat!(env!("OUT_DIR"), "/with_attrs_cg.rs"));

--- a/ipc/tests/with_attrs.rs.in
+++ b/ipc/tests/with_attrs.rs.in
@@ -25,7 +25,7 @@ pub struct BadlyNamedService;
 
 #[derive(Ipc)]
 #[ipc(client_ident="PrettyNamedClient")]
-impl  BadlyNamedService {
+impl BadlyNamedService {
 	fn is_zero(&self, x: u64) -> bool {
 		x == 0
 	}

--- a/ipc/tests/with_attrs.rs.in
+++ b/ipc/tests/with_attrs.rs.in
@@ -32,8 +32,3 @@ impl  BadlyNamedService {
 }
 
 impl ::ipc::IpcConfig for BadlyNamedService {}
-
-#[test]
-fn invoke() {
-
-}

--- a/ipc/tests/with_attrs.rs.in
+++ b/ipc/tests/with_attrs.rs.in
@@ -14,18 +14,26 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-#![allow(dead_code)]
+use std::sync::RwLock;
+use std::ops::*;
+use ipc::IpcConfig;
+use std::mem;
+use ipc::binary::BinaryConvertError;
+use std::collections::VecDeque;
 
-extern crate ethcore_ipc as ipc;
-extern crate ethcore_devtools as devtools;
-extern crate semver;
-extern crate nanomsg;
-extern crate ethcore_ipc_nano as nanoipc;
-extern crate ethcore_util as util;
+pub struct BadlyNamedService;
 
-pub mod service;
-mod examples;
-mod over_nano;
-mod nested;
-mod binary;
-mod with_attrs;
+#[derive(Ipc)]
+#[ipc(client_ident="PrettyNamedClient")]
+impl  BadlyNamedService {
+	fn is_zero(&self, x: u64) -> bool {
+		x == 0
+	}
+}
+
+impl ::ipc::IpcConfig for BadlyNamedService {}
+
+#[test]
+fn invoke() {
+
+}


### PR DESCRIPTION
```
#[derive(Ipc)]
#[ipc(client_ident="PrettyNamedClient")]
impl BadlyNamedService {
	fn is_zero(&self, x: u64) -> bool {
		x == 0
	}
}
```

so that above example become possible