### PR TITLE
Fixed public address config

### DIFF
--- a/parity/configuration.rs
+++ b/parity/configuration.rs
@@ -254,7 +254,7 @@ impl Configuration {
 			let host = IpAddr::from_str(host).unwrap_or_else(|_| die!("Invalid host given with `--nat extip:{}`", host));
 			Some(SocketAddr::new(host, port))
 		} else {
-			listen_address
+			None
 		};
 		(listen_address, public_address)
 	}


### PR DESCRIPTION
Public address should be none to enable auto-detection and NAT mapping