### PR TITLE
IPC codegen enhancement - allow void methods

### DIFF
--- a/ipc/codegen/src/codegen.rs
+++ b/ipc/codegen/src/codegen.rs
@@ -201,15 +201,20 @@ fn implement_dispatch_arm_invoke_stmt(
 		{
 			let _sp = ext_cx.call_site();
 			let mut tt = ::std::vec::Vec::new();
+
 			tt.push(::syntax::ast::TokenTree::Token(_sp, ::syntax::parse::token::OpenDelim(::syntax::parse::token::Brace)));
-			tt.push(::syntax::ast::TokenTree::Token(_sp, ::syntax::parse::token::ModSep));
-			tt.push(::syntax::ast::TokenTree::Token(_sp, ::syntax::parse::token::Ident(ext_cx.ident_of("ipc"))));
-			tt.push(::syntax::ast::TokenTree::Token(_sp, ::syntax::parse::token::ModSep));
-			tt.push(::syntax::ast::TokenTree::Token(_sp, ::syntax::parse::token::Ident(ext_cx.ident_of("binary"))));
-			tt.push(::syntax::ast::TokenTree::Token(_sp, ::syntax::parse::token::ModSep));
-			tt.push(::syntax::ast::TokenTree::Token(_sp, ::syntax::parse::token::Ident(ext_cx.ident_of("serialize"))));
-			tt.push(::syntax::ast::TokenTree::Token(_sp, ::syntax::parse::token::OpenDelim(::syntax::parse::token::Paren)));
-			tt.push(::syntax::ast::TokenTree::Token(_sp, ::syntax::parse::token::BinOp(::syntax::parse::token::And)));
+
+			if dispatch.return_type_ty.is_some() {
+				tt.push(::syntax::ast::TokenTree::Token(_sp, ::syntax::parse::token::ModSep));
+				tt.push(::syntax::ast::TokenTree::Token(_sp, ::syntax::parse::token::Ident(ext_cx.ident_of("ipc"))));
+				tt.push(::syntax::ast::TokenTree::Token(_sp, ::syntax::parse::token::ModSep));
+				tt.push(::syntax::ast::TokenTree::Token(_sp, ::syntax::parse::token::Ident(ext_cx.ident_of("binary"))));
+				tt.push(::syntax::ast::TokenTree::Token(_sp, ::syntax::parse::token::ModSep));
+				tt.push(::syntax::ast::TokenTree::Token(_sp, ::syntax::parse::token::Ident(ext_cx.ident_of("serialize"))));
+				tt.push(::syntax::ast::TokenTree::Token(_sp, ::syntax::parse::token::OpenDelim(::syntax::parse::token::Paren)));
+				tt.push(::syntax::ast::TokenTree::Token(_sp, ::syntax::parse::token::BinOp(::syntax::parse::token::And)));
+			}
+
 			tt.push(::syntax::ast::TokenTree::Token(_sp, ::syntax::parse::token::Ident(ext_cx.ident_of("self"))));
 			tt.push(::syntax::ast::TokenTree::Token(_sp, ::syntax::parse::token::Dot));
 			tt.extend(::quasi::ToTokens::to_tokens(&function_name, ext_cx).into_iter());
@@ -221,12 +226,25 @@ fn implement_dispatch_arm_invoke_stmt(
 			}
 
 			tt.push(::syntax::ast::TokenTree::Token(_sp, ::syntax::parse::token::CloseDelim(::syntax::parse::token::Paren)));
-			tt.push(::syntax::ast::TokenTree::Token(_sp, ::syntax::parse::token::CloseDelim(::syntax::parse::token::Paren)));
-			tt.push(::syntax::ast::TokenTree::Token(_sp, ::syntax::parse::token::Dot));
-			tt.push(::syntax::ast::TokenTree::Token(_sp, ::syntax::parse::token::Ident(ext_cx.ident_of("unwrap"))));
-			tt.push(::syntax::ast::TokenTree::Token(_sp, ::syntax::parse::token::OpenDelim(::syntax::parse::token::Paren)));
-			tt.push(::syntax::ast::TokenTree::Token(_sp, ::syntax::parse::token::CloseDelim(::syntax::parse::token::Paren)));
+
+			if dispatch.return_type_ty.is_some() {
+				tt.push(::syntax::ast::TokenTree::Token(_sp, ::syntax::parse::token::CloseDelim(::syntax::parse::token::Paren)));
+				tt.push(::syntax::ast::TokenTree::Token(_sp, ::syntax::parse::token::Dot));
+				tt.push(::syntax::ast::TokenTree::Token(_sp, ::syntax::parse::token::Ident(ext_cx.ident_of("unwrap"))));
+				tt.push(::syntax::ast::TokenTree::Token(_sp, ::syntax::parse::token::OpenDelim(::syntax::parse::token::Paren)));
+				tt.push(::syntax::ast::TokenTree::Token(_sp, ::syntax::parse::token::CloseDelim(::syntax::parse::token::Paren)));
+			}
+			else {
+				tt.push(::syntax::ast::TokenTree::Token(_sp, ::syntax::parse::token::Semi));
+				tt.push(::syntax::ast::TokenTree::Token(_sp, ::syntax::parse::token::Ident(ext_cx.ident_of("Vec"))));
+				tt.push(::syntax::ast::TokenTree::Token(_sp, ::syntax::parse::token::ModSep));
+				tt.push(::syntax::ast::TokenTree::Token(_sp, ::syntax::parse::token::Ident(ext_cx.ident_of("new"))));
+				tt.push(::syntax::ast::TokenTree::Token(_sp, ::syntax::parse::token::OpenDelim(::syntax::parse::token::Paren)));
+				tt.push(::syntax::ast::TokenTree::Token(_sp, ::syntax::parse::token::CloseDelim(::syntax::parse::token::Paren)));
+
+			}
 			tt.push(::syntax::ast::TokenTree::Token(_sp, ::syntax::parse::token::CloseDelim(::syntax::parse::token::Brace)));
+
 			tt
 		})).unwrap()
 }

--- a/ipc/tests/examples.rs
+++ b/ipc/tests/examples.rs
@@ -190,4 +190,20 @@ mod tests {
 
 		assert_eq!(struct_, new_struct);
 	}
+
+	#[test]
+	fn can_call_void_method() {
+		let mut socket = TestSocket::new();
+		socket.read_buffer = vec![1];
+		let service_client = ServiceClient::init(socket);
+
+		service_client.void(99);
+
+		assert_eq!(vec![
+			0, 19,
+			0, 0, 0, 0, 0, 0, 0, 0,
+			8, 0, 0, 0, 0, 0, 0, 0,
+			99, 0, 0, 0, 0, 0, 0, 0],
+			service_client.socket().write().unwrap().write_buffer.clone());
+	}
 }

--- a/ipc/tests/service.rs.in
+++ b/ipc/tests/service.rs.in
@@ -39,12 +39,14 @@ impl Service {
 		*lock = *lock + f as usize;
 		f
 	}
+
 	pub fn rollback(&self, a: Option<u32>, b: u32) -> i32 {
 		let a_0 = a.unwrap_or_else(|| 0);
 		let mut lock = self.rollbacks.write().unwrap();
 		*lock = *lock + a_0 as usize - b as usize;
 		(a_0 - b) as i32
 	}
+
 	pub fn push_custom(&self, data: CustomData) -> bool {
 		let mut clock = self.commits.write().unwrap();
 		let mut rlock = self.commits.write().unwrap();
@@ -53,6 +55,9 @@ impl Service {
 		*rlock = data.b as usize;
 
 		true
+	}
+
+	pub fn void(&self, a: u64) {
 	}
 }
 


### PR DESCRIPTION
Previously codegen assumed that it needs to serialize something for every method it generated invocation of, now it's not