### PR TITLE
Update sealing just once when  externally importing many blocks

### DIFF
--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -40,8 +40,8 @@ use log_entry::LocalizedLogEntry;
 use block_queue::{BlockQueue, BlockQueueInfo};
 use blockchain::{BlockChain, BlockProvider, TreeRoute, ImportRoute};
 use client::{BlockID, TransactionID, UncleID, TraceId, Mode, ClientConfig, DatabaseCompactionProfile,
-	BlockChainClient, MiningBlockChainClient, TraceFilter, CallAnalytics, TransactionImportError,
-	BlockImportError, TransactionImportResult};
+	BlockChainClient, MiningBlockChainClient, TraceFilter, CallAnalytics,
+	BlockImportError};
 use client::Error as ClientError;
 use env_info::EnvInfo;
 use executive::{Executive, Executed, TransactOptions, contract_address};
@@ -52,7 +52,7 @@ use trace;
 pub use types::blockchain_info::BlockChainInfo;
 pub use types::block_status::BlockStatus;
 use evm::Factory as EvmFactory;
-use miner::{Miner, MinerService, AccountDetails};
+use miner::{Miner, MinerService};
 
 const MAX_TX_QUEUE_SIZE: usize = 4096;
 const MAX_QUEUE_SIZE_TO_SLEEP_ON: usize = 2;
@@ -409,12 +409,8 @@ impl Client {
 	pub fn import_queued_transactions(&self, transactions: &[Bytes]) -> usize {
 		let _timer = PerfTimer::new("import_queued_transactions");
 		self.queue_transactions.fetch_sub(transactions.len(), AtomicOrdering::SeqCst);
-		let fetch_account = |a: &Address| AccountDetails {
-			nonce: self.latest_nonce(a),
-			balance: self.latest_balance(a),
-		};
-		let tx = transactions.iter().filter_map(|bytes| UntrustedRlp::new(&bytes).as_val().ok()).collect();
-		let results = self.miner.import_transactions(self, tx, fetch_account);
+		let txs = transactions.iter().filter_map(|bytes| UntrustedRlp::new(&bytes).as_val().ok()).collect();
+		let results = self.miner.import_external_transactions(self, txs);
 		results.len()
 	}
 
@@ -860,18 +856,6 @@ impl BlockChainClient for Client {
 
 	fn last_hashes(&self) -> LastHashes {
 		self.build_last_hashes(self.chain.best_block_hash())
-	}
-
-	fn import_transactions(&self, transactions: Vec<SignedTransaction>) -> Vec<Result<TransactionImportResult, TransactionImportError>> {
-		let fetch_account = |a: &Address| AccountDetails {
-			nonce: self.latest_nonce(a),
-			balance: self.latest_balance(a),
-		};
-
-		self.miner.import_transactions(self, transactions, &fetch_account)
-			.into_iter()
-			.map(|res| res.map_err(|e| e.into()))
-			.collect()
 	}
 
 	fn queue_transactions(&self, transactions: Vec<Bytes>) {

--- a/ethcore/src/client/mod.rs
+++ b/ethcore/src/client/mod.rs
@@ -48,7 +48,7 @@ use receipt::LocalizedReceipt;
 use trace::LocalizedTrace;
 use evm::Factory as EvmFactory;
 pub use block_import_error::BlockImportError;
-pub use transaction_import::{TransactionImportResult, TransactionImportError};
+pub use transaction_import::TransactionImportResult;
 
 /// Options concerning what analytics we run on the call.
 #[derive(Eq, PartialEq, Default, Clone, Copy, Debug)]
@@ -191,9 +191,6 @@ pub trait BlockChainClient : Sync + Send {
 
 	/// Get last hashes starting from best block.
 	fn last_hashes(&self) -> LastHashes;
-
-	/// import transactions from network/other 3rd party
-	fn import_transactions(&self, transactions: Vec<SignedTransaction>) -> Vec<Result<TransactionImportResult, TransactionImportError>>;
 
 	/// Queue transactions for importing.
 	fn queue_transactions(&self, transactions: Vec<Bytes>);

--- a/ethcore/src/client/test_client.rs
+++ b/ethcore/src/client/test_client.rs
@@ -22,7 +22,7 @@ use transaction::{Transaction, LocalizedTransaction, SignedTransaction, Action};
 use blockchain::TreeRoute;
 use client::{BlockChainClient, MiningBlockChainClient, BlockChainInfo, BlockStatus, BlockID,
 	TransactionID, UncleID, TraceId, TraceFilter, LastHashes, CallAnalytics,
-	TransactionImportError, BlockImportError};
+	BlockImportError};
 use header::{Header as BlockHeader, BlockNumber};
 use filter::Filter;
 use log_entry::LocalizedLogEntry;
@@ -38,8 +38,6 @@ use block::{OpenBlock, SealedBlock};
 use executive::Executed;
 use error::{ExecutionError};
 use trace::LocalizedTrace;
-
-use miner::{TransactionImportResult, AccountDetails};
 
 /// Test client.
 pub struct TestBlockChainClient {
@@ -275,6 +273,10 @@ impl BlockChainClient for TestBlockChainClient {
 		}
 	}
 
+	fn latest_nonce(&self, address: &Address) -> U256 {
+		self.nonce(address, BlockID::Latest).unwrap()
+	}
+
 	fn code(&self, address: &Address) -> Option<Bytes> {
 		self.code.read().unwrap().get(address).cloned()
 	}
@@ -285,6 +287,10 @@ impl BlockChainClient for TestBlockChainClient {
 		} else {
 			None
 		}
+	}
+
+	fn latest_balance(&self, address: &Address) -> U256 {
+		self.balance(address, BlockID::Latest).unwrap()
 	}
 
 	fn storage_at(&self, address: &Address, position: &H256, id: BlockID) -> Option<H256> {
@@ -488,24 +494,10 @@ impl BlockChainClient for TestBlockChainClient {
 		unimplemented!();
 	}
 
-	fn import_transactions(&self, transactions: Vec<SignedTransaction>) -> Vec<Result<TransactionImportResult, TransactionImportError>> {
-		let nonces = self.nonces.read().unwrap();
-		let balances = self.balances.read().unwrap();
-		let fetch_account = |a: &Address| AccountDetails {
-			nonce: nonces[a],
-			balance: balances[a],
-		};
-
-		self.miner.import_transactions(self, transactions, &fetch_account)
-			.into_iter()
-			.map(|res| res.map_err(|e| e.into()))
-			.collect()
-	}
-
 	fn queue_transactions(&self, transactions: Vec<Bytes>) {
 		// import right here
-		let tx = transactions.into_iter().filter_map(|bytes| UntrustedRlp::new(&bytes).as_val().ok()).collect();
-		self.import_transactions(tx);
+		let txs = transactions.into_iter().filter_map(|bytes| UntrustedRlp::new(&bytes).as_val().ok()).collect();
+		self.miner.import_external_transactions(self, txs);
 	}
 
 	fn pending_transactions(&self) -> Vec<SignedTransaction> {

--- a/ethcore/src/miner/miner.rs
+++ b/ethcore/src/miner/miner.rs
@@ -315,6 +315,19 @@ impl Miner {
 		!have_work
 	}
 
+	fn add_transactions_to_queue(&self, chain: &MiningBlockChainClient, transactions: Vec<SignedTransaction>, origin: TransactionOrigin, transaction_queue: &mut TransactionQueue) ->
+		Vec<Result<TransactionImportResult, Error>> {
+
+		let fetch_account = |a: &Address| AccountDetails {
+			nonce: chain.latest_nonce(a),
+			balance: chain.latest_balance(a),
+		};
+
+		transactions.into_iter()
+			.map(|tx| transaction_queue.add(tx, &fetch_account, origin))
+			.collect()
+	}
+
 	/// Are we allowed to do a non-mandatory reseal?
 	fn tx_reseal_allowed(&self) -> bool { Instant::now() > *self.next_allowed_reseal.lock().unwrap() }
 }
@@ -478,27 +491,24 @@ impl MinerService for Miner {
 		self.gas_range_target.read().unwrap().1
 	}
 
-	fn import_transactions<T>(&self, chain: &MiningBlockChainClient, transactions: Vec<SignedTransaction>, fetch_account: T) ->
-		Vec<Result<TransactionImportResult, Error>>
-		where T: Fn(&Address) -> AccountDetails {
-		let results: Vec<Result<TransactionImportResult, Error>> = {
-			let mut transaction_queue = self.transaction_queue.lock().unwrap();
-			transactions.into_iter()
-				.map(|tx| transaction_queue.add(tx, &fetch_account, TransactionOrigin::External))
-				.collect()
-		};
-		if !results.is_empty() && self.options.reseal_on_external_tx && 	self.tx_reseal_allowed() {
+	fn import_external_transactions(&self, chain: &MiningBlockChainClient, transactions: Vec<SignedTransaction>) ->
+		Vec<Result<TransactionImportResult, Error>> {
+
+		let mut transaction_queue = self.transaction_queue.lock().unwrap();
+		let results = self.add_transactions_to_queue(chain, transactions, TransactionOrigin::External,
+													 &mut transaction_queue);
+
+		if !results.is_empty() && self.options.reseal_on_external_tx &&	self.tx_reseal_allowed() {
 			self.update_sealing(chain);
 		}
 		results
 	}
 
-	fn import_own_transaction<T>(
+	fn import_own_transaction(
 		&self,
 		chain: &MiningBlockChainClient,
 		transaction: SignedTransaction,
-		fetch_account: T
-	) -> Result<TransactionImportResult, Error> where T: Fn(&Address) -> AccountDetails {
+	) -> Result<TransactionImportResult, Error> {
 
 		let hash = transaction.hash();
 		trace!(target: "own_tx", "Importing transaction: {:?}", transaction);
@@ -506,7 +516,7 @@ impl MinerService for Miner {
 		let imported = {
 			// Be sure to release the lock before we call enable_and_prepare_sealing
 			let mut transaction_queue = self.transaction_queue.lock().unwrap();
-			let import = transaction_queue.add(transaction, &fetch_account, TransactionOrigin::Local);
+			let import = self.add_transactions_to_queue(chain, vec![transaction], TransactionOrigin::Local, &mut transaction_queue).pop().unwrap();
 
 			match import {
 				Ok(ref res) => {
@@ -657,7 +667,12 @@ impl MinerService for Miner {
 				// Client should send message after commit to db and inserting to chain.
 				.expect("Expected in-chain blocks.");
 			let block = BlockView::new(&block);
-			block.transactions()
+			let txs = block.transactions();
+			// populate sender
+			for tx in &txs {
+				let _sender = tx.sender();
+			}
+			txs
 		}
 
 		// 1. We ignore blocks that were `imported` (because it means that they are not in canon-chain, and transactions
@@ -674,14 +689,9 @@ impl MinerService for Miner {
 				.par_iter()
 				.map(|h| fetch_transactions(chain, h));
 			out_of_chain.for_each(|txs| {
-				// populate sender
-				for tx in &txs {
-					let _sender = tx.sender();
-				}
-				let _ = self.import_transactions(chain, txs, |a| AccountDetails {
-					nonce: chain.latest_nonce(a),
-					balance: chain.latest_balance(a),
-				});
+				let mut transaction_queue = self.transaction_queue.lock().unwrap();
+				let _ = self.add_transactions_to_queue(chain, txs, TransactionOrigin::External,
+													   &mut transaction_queue);
 			});
 		}
 

--- a/ethcore/src/miner/mod.rs
+++ b/ethcore/src/miner/mod.rs
@@ -107,14 +107,12 @@ pub trait MinerService : Send + Sync {
 	fn set_tx_gas_limit(&self, limit: U256);
 
 	/// Imports transactions to transaction queue.
-	fn import_transactions<T>(&self, chain: &MiningBlockChainClient, transactions: Vec<SignedTransaction>, fetch_account: T) ->
-		Vec<Result<TransactionImportResult, Error>>
-		where T: Fn(&Address) -> AccountDetails, Self: Sized;
+	fn import_external_transactions(&self, chain: &MiningBlockChainClient, transactions: Vec<SignedTransaction>) ->
+		Vec<Result<TransactionImportResult, Error>>;
 
 	/// Imports own (node owner) transaction to queue.
-	fn import_own_transaction<T>(&self, chain: &MiningBlockChainClient, transaction: SignedTransaction, fetch_account: T) ->
-		Result<TransactionImportResult, Error>
-		where T: Fn(&Address) -> AccountDetails, Self: Sized;
+	fn import_own_transaction(&self, chain: &MiningBlockChainClient, transaction: SignedTransaction) ->
+		Result<TransactionImportResult, Error>;
 
 	/// Returns hashes of transactions currently in pending
 	fn pending_transactions_hashes(&self) -> Vec<H256>;

--- a/rpc/src/v1/impls/mod.rs
+++ b/rpc/src/v1/impls/mod.rs
@@ -55,7 +55,7 @@ pub use self::rpc::RpcClient;
 
 use v1::types::TransactionRequest;
 use ethcore::error::Error as EthcoreError;
-use ethcore::miner::{AccountDetails, MinerService};
+use ethcore::miner::MinerService;
 use ethcore::client::MiningBlockChainClient;
 use ethcore::transaction::{Action, SignedTransaction, Transaction};
 use ethcore::account_provider::{AccountProvider, Error as AccountError};
@@ -79,12 +79,7 @@ fn dispatch_transaction<C, M>(client: &C, miner: &M, signed_transaction: SignedT
 	where C: MiningBlockChainClient, M: MinerService {
 	let hash = signed_transaction.hash();
 
-	let import = miner.import_own_transaction(client, signed_transaction, |a: &Address| {
-		AccountDetails {
-			nonce: client.latest_nonce(&a),
-			balance: client.latest_balance(&a),
-		}
-	});
+	let import = miner.import_own_transaction(client, signed_transaction);
 
 	import
 		.map_err(transaction_error)


### PR DESCRIPTION
Fixes Issue #1372

The change factors out an "add_transactions_to_queue" private function on the miner which queues transactions without updating sealing. The externally visible "import_transactions" function will add transactions and seal (with the throttling from @5d3ff3d). The externally visible "chain_new_blocks" function chains all the new transactions and updates sealing once.