### PR TITLE
add systemd service file

### DIFF
--- a/parity.service
+++ b/parity.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Parity Daemon
+
+[Service]
+EnvironmentFile=%h/.parity/parity.conf
+ExecStart=/usr/bin/parity $ARGS
+
+[Install]
+WantedBy=default.target
+
+


### PR DESCRIPTION
Start parity as user service with systemd. 

1. Place this file in your home systemd/user directory.
2. Write the `~/.parity/parity.conf` according to your needs. The syntax shall be : `ARGS="args1 args2"`
3. Start the parity service: `$ systemctl --user parity`
4. Verify its status: `$ systemctl --user status parity`
5. Make the service starts at boot: `$ systemctl --user enable parity`
