### PR TITLE
Enable state queries for OverlayRecent DB

### DIFF
--- a/util/src/journaldb/archivedb.rs
+++ b/util/src/journaldb/archivedb.rs
@@ -202,7 +202,7 @@ impl JournalDB for ArchiveDB {
 	fn latest_era(&self) -> Option<u64> { self.latest_era }
 
 	fn state(&self, id: &H256) -> Option<Bytes> {
-		self.backing.get_by_prefix(&id[0..12]).and_then(|b| Some(b.to_vec()))
+		self.backing.get_by_prefix(&id[0..DB_PREFIX_LEN]).map(|b| b.to_vec())
 	}
 
 	fn is_pruned(&self) -> bool { false }

--- a/util/src/journaldb/earlymergedb.rs
+++ b/util/src/journaldb/earlymergedb.rs
@@ -339,6 +339,10 @@ impl JournalDB for EarlyMergeDB {
 		}
  	}
 
+	fn state(&self, id: &H256) -> Option<Bytes> {
+		self.backing.get_by_prefix(&id[0..DB_PREFIX_LEN]).map(|b| b.to_vec())
+	}
+
 	#[cfg_attr(feature="dev", allow(cyclomatic_complexity))]
 	fn commit(&mut self, now: u64, id: &H256, end: Option<(u64, H256)>) -> Result<u32, UtilError> {
 		// journal format:

--- a/util/src/journaldb/refcounteddb.rs
+++ b/util/src/journaldb/refcounteddb.rs
@@ -111,6 +111,10 @@ impl JournalDB for RefCountedDB {
 
 	fn latest_era(&self) -> Option<u64> { self.latest_era }
 
+	fn state(&self, id: &H256) -> Option<Bytes> {
+		self.backing.get_by_prefix(&id[0..DB_PREFIX_LEN]).map(|b| b.to_vec())
+	}
+
 	fn commit(&mut self, now: u64, id: &H256, end: Option<(u64, H256)>) -> Result<u32, UtilError> {
 		// journal format:
 		// [era, 0] => [ id, [insert_0, ...], [remove_0, ...] ]

--- a/util/src/journaldb/traits.rs
+++ b/util/src/journaldb/traits.rs
@@ -39,9 +39,7 @@ pub trait JournalDB : HashDB + Send + Sync {
 	fn commit(&mut self, now: u64, id: &H256, end: Option<(u64, H256)>) -> Result<u32, UtilError>;
 
 	/// State data query
-	fn state(&self, _id: &H256) -> Option<Bytes> {
-		None
-	}
+	fn state(&self, _id: &H256) -> Option<Bytes>;
 
 	/// Whether this database is pruned.
 	fn is_pruned(&self) -> bool { true }


### PR DESCRIPTION
Memory overlay in `OverlayRecentDB` now uses 96-bit keys to support state node lookup