### PR TITLE
refactoring of handshake messages serialization in ipc

### DIFF
--- a/ipc/rpc/Cargo.toml
+++ b/ipc/rpc/Cargo.toml
@@ -8,6 +8,6 @@ license = "GPL-3.0"
 
 [dependencies]
 ethcore-devtools = { path = "../../devtools" }
-semver = "0.2.0"
 nanomsg = { git = "https://github.com/ethcore/nanomsg.rs.git" }
 ethcore-util = { path = "../../util" }
+semver = "0.2"

--- a/ipc/rpc/src/binary.rs
+++ b/ipc/rpc/src/binary.rs
@@ -21,6 +21,7 @@ use util::numbers::{U256, U512, H256, H2048, Address};
 use std::mem;
 use std::collections::{VecDeque, BTreeMap};
 use std::ops::Range;
+use super::Handshake;
 
 #[derive(Debug)]
 pub struct BinaryConvertError;
@@ -554,6 +555,61 @@ macro_rules! binary_fixed_size {
 	}
 }
 
+/// Fixed-sized version of Handshake struct
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BinHandshake {
+	api_version: BinVersion,
+	protocol_version: BinVersion,
+}
+
+/// Shorten version of semver Version without `pre` and `build` information
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct BinVersion {
+	pub major: u64,
+	pub minor: u64,
+	pub patch: u64,
+}
+
+impl From<Handshake> for BinHandshake {
+	fn from(other: Handshake) -> Self {
+		BinHandshake {
+			api_version: BinVersion::from(other.api_version),
+			protocol_version: BinVersion::from(other.protocol_version),
+		}
+	}
+}
+
+impl BinHandshake {
+	pub fn to_semver(self) -> Handshake {
+		Handshake {
+			api_version: self.api_version.to_semver(),
+			protocol_version: self.protocol_version.to_semver(),
+		}
+	}
+}
+
+impl BinVersion {
+	pub fn to_semver(self) -> ::semver::Version {
+		::semver::Version {
+			major: self.major,
+			minor: self.minor,
+			patch: self.patch,
+			pre: vec![],
+			build: vec![],
+		}
+	}
+}
+
+impl From<::semver::Version> for BinVersion {
+	fn from(other: ::semver::Version) -> Self {
+ 		BinVersion {
+			major: other.major,
+			minor: other.minor,
+			patch: other.patch,
+		}
+	}
+}
+
 binary_fixed_size!(u64);
 binary_fixed_size!(u32);
 binary_fixed_size!(usize);
@@ -564,6 +620,7 @@ binary_fixed_size!(U512);
 binary_fixed_size!(H256);
 binary_fixed_size!(H2048);
 binary_fixed_size!(Address);
+binary_fixed_size!(BinHandshake);
 
 #[test]
 fn vec_serialize() {
@@ -706,8 +763,6 @@ fn serialize_opt_vec() {
 
 #[test]
 fn serialize_opt_vec_payload() {
- 	use std::io::Cursor;
-
 	let optional_vec: Option<Vec<u8>> = None;
 	let payload = serialize(&optional_vec).unwrap();
 
@@ -775,4 +830,24 @@ fn serialize_btree() {
 	let res = deserialize_from::<BTreeMap<u64, u64>, _>(&mut buff).unwrap();
 
 	assert_eq!(res[&1u64], 5u64);
+}
+
+#[test]
+fn serialize_handshake() {
+	use std::io::{Cursor, SeekFrom, Seek};
+
+	let mut buff = Cursor::new(Vec::new());
+
+	let handshake = Handshake {
+		api_version: ::semver::Version::parse("1.2.0").unwrap(),
+		protocol_version: ::semver::Version::parse("1.2.0").unwrap(),
+	};
+
+	serialize_into(&BinHandshake::from(handshake.clone()), &mut buff).unwrap();
+
+	buff.seek(SeekFrom::Start(0)).unwrap();
+	let res = deserialize_from::<BinHandshake, _>(&mut buff).unwrap().to_semver();
+
+	assert_eq!(res, handshake);
+
 }

--- a/ipc/rpc/src/interface.rs
+++ b/ipc/rpc/src/interface.rs
@@ -20,6 +20,7 @@ use std::io::{Read, Write};
 use std::marker::Sync;
 use semver::Version;
 
+#[derive(Debug, PartialEq, Eq, Clone)]
 /// Handshake for client and server to negotiate api/protocol version
 pub struct Handshake {
 	pub protocol_version: Version,

--- a/ipc/rpc/src/lib.rs
+++ b/ipc/rpc/src/lib.rs
@@ -24,4 +24,4 @@ extern crate ethcore_util as util;
 pub mod interface;
 pub mod binary;
 pub use interface::{IpcInterface, IpcSocket, invoke, IpcConfig, Handshake, Error, WithSocket};
-pub use binary::{BinaryConvertable, BinaryConvertError};
+pub use binary::{BinaryConvertable, BinaryConvertError, BinHandshake};


### PR DESCRIPTION
works better when there are several interfaces implemented for one basic service 