### PR TITLE
IPC RPC deriving for traits

### DIFF
--- a/ipc/tests/examples.rs
+++ b/ipc/tests/examples.rs
@@ -19,10 +19,11 @@ mod tests {
 
 	use super::super::service::*;
 	use super::super::binary::*;
-	use super::super::nested::{DBClient,DBWriter};
+	use super::super::nested::{DBClient, DBWriter};
 	use ipc::*;
 	use devtools::*;
 	use semver::Version;
+	use std::sync::Arc;
 
 	#[test]
 	fn call_service() {
@@ -33,7 +34,7 @@ mod tests {
 			4, 0, 0, 0, 0, 0, 0, 0,
 			10, 0, 0, 0]);
 
-		let service = Service::new();
+		let service = Arc::new(Service::new());
 		assert_eq!(0, *service.commits.read().unwrap());
 
 		service.dispatch(&mut socket);
@@ -65,7 +66,7 @@ mod tests {
 				0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
 			]);
 
-		let service = Service::new();
+		let service = Arc::new(Service::new());
 		let result = service.dispatch(&mut socket);
 
 		// single `true`
@@ -109,9 +110,9 @@ mod tests {
 
 	#[test]
 	fn query_default_version() {
-		let ver = Service::protocol_version();
+		let ver = Arc::<Service>::protocol_version();
 		assert_eq!(ver, Version::parse("1.0.0").unwrap());
-		let ver = Service::api_version();
+		let ver = Arc::<Service>::api_version();
 		assert_eq!(ver, Version::parse("1.0.0").unwrap());
 	}
 

--- a/ipc/tests/nested.rs.in
+++ b/ipc/tests/nested.rs.in
@@ -33,7 +33,7 @@ pub trait DBWriter {
 	fn write_slice(&self, data: &[u8]) -> Result<(), DBError>;
 }
 
-impl<L: Sized> IpcConfig for DB<L> {}
+impl IpcConfig<DBWriter> for ::std::sync::Arc<DBWriter> {}
 
 #[derive(Binary)]
 pub enum DBError { Write, Read }
@@ -53,3 +53,9 @@ impl<L: Sized> DBWriter for DB<L> {
 	}
 }
 
+#[derive(Ipc)]
+trait DBNotify {
+	fn notify(&self, a: u64, b: u64) -> bool;
+}
+
+impl IpcConfig<DBNotify> for ::std::sync::Arc<DBNotify> { }

--- a/ipc/tests/service.rs.in
+++ b/ipc/tests/service.rs.in
@@ -70,4 +70,4 @@ impl Service {
 	}
 }
 
-impl ::ipc::IpcConfig for Service {}
+impl ::ipc::IpcConfig<Service> for ::std::sync::Arc<Service> {}

--- a/ipc/tests/with_attrs.rs.in
+++ b/ipc/tests/with_attrs.rs.in
@@ -31,4 +31,4 @@ impl BadlyNamedService {
 	}
 }
 
-impl ::ipc::IpcConfig for BadlyNamedService {}
+impl ::ipc::IpcConfig<BadlyNamedService> for ::std::sync::Arc<BadlyNamedService> {}

--- a/parity/informant.rs
+++ b/parity/informant.rs
@@ -21,7 +21,7 @@ use self::ansi_term::Style;
 use std::time::{Instant, Duration};
 use std::ops::{Deref, DerefMut};
 use ethsync::{SyncStatus, NetworkConfiguration};
-use util::{Uint, RwLock};
+use util::{Uint, RwLockable};
 use ethcore::client::*;
 use number_prefix::{binary_prefix, Standalone, Prefixed};
 

--- a/parity/informant.rs
+++ b/parity/informant.rs
@@ -21,7 +21,7 @@ use self::ansi_term::Style;
 use std::time::{Instant, Duration};
 use std::ops::{Deref, DerefMut};
 use ethsync::{SyncStatus, NetworkConfiguration};
-use util::{Uint, RwLockable};
+use util::{Uint, RwLock};
 use ethcore::client::*;
 use number_prefix::{binary_prefix, Standalone, Prefixed};
 


### PR DESCRIPTION
```
#[derive(Ipc)]
trait DBNotify {
	fn notify(&self, a: u64, b: u64) -> bool;
}
```

so that above become possible

needed for pub/sub IPC scenarios

goes after #1584