### PR TITLE
Asynchronous transactions (polling based for now).

### DIFF
--- a/rpc/src/v1/helpers/mod.rs
+++ b/rpc/src/v1/helpers/mod.rs
@@ -22,4 +22,4 @@ mod signing_queue;
 pub use self::poll_manager::PollManager;
 pub use self::poll_filter::PollFilter;
 pub use self::requests::{TransactionRequest, TransactionConfirmation, CallRequest};
-pub use self::signing_queue::{ConfirmationsQueue, SigningQueue, QueueEvent};
+pub use self::signing_queue::{ConfirmationsQueue, ConfirmationPromise, ConfirmationResult, SigningQueue, QueueEvent};

--- a/rpc/src/v1/helpers/signing_queue.rs
+++ b/rpc/src/v1/helpers/signing_queue.rs
@@ -150,7 +150,7 @@ impl ConfirmationPromise {
 	/// Returns `None` if transaction was rejected or timeout reached.
 	/// Returns `Some(result)` if transaction was confirmed.
 	pub fn wait_until(&self, deadline: Instant) -> ConfirmationResult {
-		info!(target: "own_tx", "Signer: Awaiting transaction confirmation... ({:?}).", self.id);
+		trace!(target: "own_tx", "Signer: Awaiting transaction confirmation... ({:?}).", self.id);
 		loop {
 			let now = Instant::now();
 			// Check the result...

--- a/rpc/src/v1/helpers/signing_queue.rs
+++ b/rpc/src/v1/helpers/signing_queue.rs
@@ -155,11 +155,13 @@ impl ConfirmationPromise {
 			let now = Instant::now();
 			// Check the result...
 			match *self.result.lock() {
-				// Waiting and deadline not yet passed - wait a while longer.  
-				ConfirmationResult::Waiting if now < deadline => thread::park_timeout(deadline - now),
+				// Waiting and deadline not yet passed continue looping.  
+				ConfirmationResult::Waiting if now < deadline => {}
 				// Anything else - return.
 				ref a => return a.clone(),
 			}
+			// wait a while longer - maybe the solution will arrive.
+			thread::park_timeout(deadline - now);
 		}
 	}
 }

--- a/rpc/src/v1/helpers/signing_queue.rs
+++ b/rpc/src/v1/helpers/signing_queue.rs
@@ -77,8 +77,9 @@ pub trait SigningQueue: Send + Sync {
 	fn is_empty(&self) -> bool;
 }
 
-#[derive(Debug, PartialEq)]
-enum ConfirmationResult {
+#[derive(Debug, Clone, PartialEq)]
+/// Result of a pending transaction.
+pub enum ConfirmationResult {
 	/// The transaction has not yet been confirmed nor rejected.
 	Waiting,
 	/// The transaction has been rejected.
@@ -125,34 +126,41 @@ impl ConfirmationToken {
 }
 
 impl ConfirmationPromise {
+	/// Get the ID for this request.
+	pub fn id(&self) -> U256 { self.id }
+
 	/// Blocks current thread and awaits for
 	/// resolution of the transaction (rejected / confirmed)
 	/// Returns `None` if transaction was rejected or timeout reached.
 	/// Returns `Some(result)` if transaction was confirmed.
 	pub fn wait_with_timeout(&self) -> Option<RpcResult> {
 		let timeout = Duration::from_secs(QUEUE_TIMEOUT_DURATION_SEC);
-		let deadline = Instant::now() + timeout;
+		let res = self.wait_until(Instant::now() + timeout);
+		match res {
+			ConfirmationResult::Confirmed(h) => Some(h),
+			ConfirmationResult::Rejected | ConfirmationResult::Waiting => None,
+		}
+	}
 
+	/// Just get the result, assuming it exists.
+	pub fn result(&self) -> ConfirmationResult { self.wait_until(Instant::now()) }
+
+	/// Blocks current thread and awaits for
+	/// resolution of the transaction (rejected / confirmed)
+	/// Returns `None` if transaction was rejected or timeout reached.
+	/// Returns `Some(result)` if transaction was confirmed.
+	pub fn wait_until(&self, deadline: Instant) -> ConfirmationResult {
 		info!(target: "own_tx", "Signer: Awaiting transaction confirmation... ({:?}).", self.id);
 		loop {
 			let now = Instant::now();
-			if now >= deadline {
-				break;
-			}
-			// Park thread (may wake up spuriously)
-			thread::park_timeout(deadline - now);
-			// Take confirmation result
-			let res = self.result.lock();
-			// Check the result
-			match *res {
-				ConfirmationResult::Rejected => return None,
-				ConfirmationResult::Confirmed(ref h) => return Some(h.clone()),
-				ConfirmationResult::Waiting => continue,
+			// Check the result...
+			match *self.result.lock() {
+				// Waiting and deadline not yet passed - wait a while longer.  
+				ConfirmationResult::Waiting if now < deadline => thread::park_timeout(deadline - now),
+				// Anything else - return.
+				ref a => return a.clone(),
 			}
 		}
-		// We reached the timeout. Just return `None`
-		trace!(target: "own_tx", "Signer: Confirmation timeout reached... ({:?}).", self.id);
-		None
 	}
 }
 
@@ -237,7 +245,7 @@ impl Drop for ConfirmationsQueue {
 	}
 }
 
-impl SigningQueue for  ConfirmationsQueue {
+impl SigningQueue for ConfirmationsQueue {
 	fn add_request(&self, transaction: TransactionRequest) -> ConfirmationPromise {
 		// Increment id
 		let id = {

--- a/rpc/src/v1/impls/eth.rs
+++ b/rpc/src/v1/impls/eth.rs
@@ -302,7 +302,7 @@ impl<C, S, M, EM> Eth for EthClient<C, S, M, EM> where
 				};
 				to_value(&res)
 			}
-			_ => Err(Error::invalid_params())
+			_ => Err(Error::invalid_params()),
 		}
 	}
 

--- a/rpc/src/v1/traits/eth.rs
+++ b/rpc/src/v1/traits/eth.rs
@@ -206,14 +206,23 @@ pub trait EthSigning: Sized + Send + Sync + 'static {
 	/// Signs the data with given address signature.
 	fn sign(&self, _: Params) -> Result<Value, Error>;
 
-	/// Sends transaction.
+	/// Sends transaction; may be asynchronous.
+	/// If it cannot yet be signed, it will return a transaction ID for
+	/// later use with check_transaction. 
 	fn send_transaction(&self, _: Params) -> Result<Value, Error>;
+
+	/// Checks the progress of a previously posted transaction.
+	/// Should be given a valid send_transaction ID.
+	/// Returns the transaction hash, the zero hash (not yet available),
+	/// or an error. 
+	fn check_transaction(&self, _: Params) -> Result<Value, Error>;
 
 	/// Should be used to convert object to io delegate.
 	fn to_delegate(self) -> IoDelegate<Self> {
 		let mut delegate = IoDelegate::new(Arc::new(self));
 		delegate.add_method("eth_sign", EthSigning::sign);
 		delegate.add_method("eth_sendTransaction", EthSigning::send_transaction);
+		delegate.add_method("eth_checkTransaction", EthSigning::check_transaction);
 		delegate
 	}
 }

--- a/rpc/src/v1/traits/eth.rs
+++ b/rpc/src/v1/traits/eth.rs
@@ -206,10 +206,15 @@ pub trait EthSigning: Sized + Send + Sync + 'static {
 	/// Signs the data with given address signature.
 	fn sign(&self, _: Params) -> Result<Value, Error>;
 
-	/// Sends transaction; may be asynchronous.
+	/// Sends transaction; will block for 20s to try to return the
+	/// transaction hash.
 	/// If it cannot yet be signed, it will return a transaction ID for
 	/// later use with check_transaction. 
 	fn send_transaction(&self, _: Params) -> Result<Value, Error>;
+
+	/// Posts transaction asynchronously.
+	/// Will return a transaction ID for later use with check_transaction. 
+	fn post_transaction(&self, _: Params) -> Result<Value, Error>;
 
 	/// Checks the progress of a previously posted transaction.
 	/// Should be given a valid send_transaction ID.
@@ -222,6 +227,7 @@ pub trait EthSigning: Sized + Send + Sync + 'static {
 		let mut delegate = IoDelegate::new(Arc::new(self));
 		delegate.add_method("eth_sign", EthSigning::sign);
 		delegate.add_method("eth_sendTransaction", EthSigning::send_transaction);
+		delegate.add_method("eth_postTransaction", EthSigning::post_transaction);
 		delegate.add_method("eth_checkTransaction", EthSigning::check_transaction);
 		delegate
 	}


### PR DESCRIPTION
- Add `eth_postTransaction` as an async alternative to `eth_sendTransaction`. Returns a Confirmation promise ID.
- Add `eth_checkTransaction`, takes a single argument - a Confirmation promise ID and returns
one of:
  - Transaction hash (signed and submitted).
  - `null` (still pending, call again later),
  - Zero hash (will never be signed).