### PR TITLE
Host validation (again)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -276,7 +276,7 @@ dependencies = [
  "ethcore-util 1.3.0",
  "hyper 0.9.4 (git+https://github.com/ethcore/hyper)",
  "jsonrpc-core 2.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-http-server 5.1.0 (git+https://github.com/ethcore/jsonrpc-http-server.git)",
+ "jsonrpc-http-server 6.1.0 (git+https://github.com/ethcore/jsonrpc-http-server.git)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime_guess 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-dapps 0.6.0 (git+https://github.com/ethcore/parity-ui.git)",
@@ -357,7 +357,7 @@ dependencies = [
  "ethsync 1.3.0",
  "json-ipc-server 0.2.4 (git+https://github.com/ethcore/json-ipc-server.git)",
  "jsonrpc-core 2.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
- "jsonrpc-http-server 5.1.0 (git+https://github.com/ethcore/jsonrpc-http-server.git)",
+ "jsonrpc-http-server 6.1.0 (git+https://github.com/ethcore/jsonrpc-http-server.git)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.7.9 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -629,8 +629,8 @@ dependencies = [
 
 [[package]]
 name = "jsonrpc-http-server"
-version = "5.1.0"
-source = "git+https://github.com/ethcore/jsonrpc-http-server.git#f16b956c61e60b3a530ad4bac82112a8974cf505"
+version = "6.1.0"
+source = "git+https://github.com/ethcore/jsonrpc-http-server.git#517a0d7b8c7fd099995ce4cc93f52789e83f2cdc"
 dependencies = [
  "hyper 0.9.4 (git+https://github.com/ethcore/hyper)",
  "jsonrpc-core 2.0.7 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/dapps/src/handlers/content.rs
+++ b/dapps/src/handlers/content.rs
@@ -38,6 +38,15 @@ impl ContentHandler {
 		}
 	}
 
+	pub fn forbidden(content: String, mimetype: String) -> Self {
+		ContentHandler {
+			code: StatusCode::Forbidden,
+			content: content,
+			mimetype: mimetype,
+			write_pos: 0
+		}
+	}
+
 	pub fn not_found(content: String, mimetype: String) -> Self {
 		ContentHandler {
 			code: StatusCode::NotFound,

--- a/dapps/src/lib.rs
+++ b/dapps/src/lib.rs
@@ -129,6 +129,7 @@ impl Server {
 			special.insert(router::SpecialEndpoint::Utils, apps::utils());
 			special
 		});
+		let bind_address = format!("{}", addr);
 
 		try!(hyper::Server::http(addr))
 			.handle(move |_| router::Router::new(
@@ -136,6 +137,7 @@ impl Server {
 				endpoints.clone(),
 				special.clone(),
 				authorization.clone(),
+				bind_address.clone(),
 			))
 			.map(|(l, srv)| {
 

--- a/dapps/src/router/host_validation.rs
+++ b/dapps/src/router/host_validation.rs
@@ -1,0 +1,42 @@
+// Copyright 2015, 2016 Ethcore (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+
+use DAPPS_DOMAIN;
+use hyper::server;
+use hyper::net::HttpStream;
+
+use jsonrpc_http_server::{is_host_header_valid};
+use handlers::ContentHandler;
+
+
+pub fn is_valid(request: &server::Request<HttpStream>, bind_address: &str, endpoints: Vec<String>) -> bool {
+	let mut endpoints = endpoints.into_iter()
+		.map(|endpoint| format!("{}{}", endpoint, DAPPS_DOMAIN))
+		.collect::<Vec<String>>();
+	endpoints.push(bind_address.into());
+	is_host_header_valid(request, &endpoints)
+}
+
+pub fn host_invalid_response() -> Box<server::Handler<HttpStream> + Send> {
+	Box::new(ContentHandler::forbidden(
+		r#"
+		<h1>Request with disallowed <code>Host</code> header has been blocked.</h1>
+		<p>Check the URL in your browser address bar.</p>
+		"#.into(),
+		"text/html".into()
+	))
+}

--- a/dapps/src/router/host_validation.rs
+++ b/dapps/src/router/host_validation.rs
@@ -27,7 +27,10 @@ pub fn is_valid(request: &server::Request<HttpStream>, bind_address: &str, endpo
 	let mut endpoints = endpoints.into_iter()
 		.map(|endpoint| format!("{}{}", endpoint, DAPPS_DOMAIN))
 		.collect::<Vec<String>>();
+	// Add localhost domain as valid too if listening on loopback interface.
+	endpoints.push(bind_address.replace("127.0.0.1", "localhost").into());
 	endpoints.push(bind_address.into());
+
 	is_host_header_valid(request, &endpoints)
 }
 

--- a/parity/cli.rs
+++ b/parity/cli.rs
@@ -36,7 +36,7 @@ Operating Options:
   --mode MODE              Set the operating mode. MODE can be one of:
                            active - Parity continuously syncs the chain.
                            passive - Parity syncs initially, then sleeps and
-                           wakes regularly to resync. 
+                           wakes regularly to resync.
                            dark - Parity syncs only when an external interface
                            is active. [default: active].
   --mode-timeout SECS      Specify the number of seconds before inactivity
@@ -107,6 +107,11 @@ API and Console Options:
                            name. Possible name are web3, eth, net, personal,
                            ethcore, ethcore_set, traces.
                            [default: web3,eth,net,ethcore,personal,traces].
+  --jsonrpc-hosts HOSTS    List of allowed Host header values. This option will
+                           validate the Host header sent by the browser, it
+                           is additional security against some attack
+                           vectors. Special options: "all", "none",
+                           [default: none].
 
   --no-ipc                 Disable JSON-RPC over IPC service.
   --ipc-path PATH          Specify custom path for JSON-RPC over IPC service
@@ -118,8 +123,8 @@ API and Console Options:
   --dapps-port PORT        Specify the port portion of the Dapps server
                            [default: 8080].
   --dapps-interface IP     Specify the hostname portion of the Dapps
-                           server, IP should be an interface's IP address, or
-                           all (all interfaces) or local [default: local].
+                           server, IP should be an interface's hostname / IP
+                           or local (localhost) [default: local].
   --dapps-user USERNAME    Specify username for Dapps server. It will be
                            used in HTTP Basic Authentication Scheme.
                            If --dapps-pass is not specified you will be
@@ -141,11 +146,11 @@ Sealing/Mining Options:
                            own - reseal only on a new local transaction;
                            ext - reseal only on a new external transaction;
                            all - reseal on all new transactions [default: own].
-  --reseal-min-period MS   Specify the minimum time between reseals from 
+  --reseal-min-period MS   Specify the minimum time between reseals from
                            incoming transactions. MS is time measured in
                            milliseconds [default: 2000].
   --work-queue-size ITEMS  Specify the number of historical work packages
-                           which are kept cached lest a solution is found for 
+                           which are kept cached lest a solution is found for
                            them later. High values take more memory but result
                            in fewer unusable solutions [default: 20].
   --tx-gas-limit GAS       Apply a limit of GAS as the maximum amount of gas
@@ -311,6 +316,7 @@ pub struct Args {
 	pub flag_jsonrpc_interface: String,
 	pub flag_jsonrpc_port: u16,
 	pub flag_jsonrpc_cors: Option<String>,
+	pub flag_jsonrpc_hosts: String,
 	pub flag_jsonrpc_apis: String,
 	pub flag_no_ipc: bool,
 	pub flag_ipc_path: String,

--- a/parity/cli.rs
+++ b/parity/cli.rs
@@ -123,8 +123,8 @@ API and Console Options:
   --dapps-port PORT        Specify the port portion of the Dapps server
                            [default: 8080].
   --dapps-interface IP     Specify the hostname portion of the Dapps
-                           server, IP should be an interface's hostname / IP
-                           or local (localhost) [default: local].
+                           server, IP should be an interface's IP address,
+                           or local [default: local].
   --dapps-user USERNAME    Specify username for Dapps server. It will be
                            used in HTTP Basic Authentication Scheme.
                            If --dapps-pass is not specified you will be

--- a/parity/configuration.rs
+++ b/parity/configuration.rs
@@ -424,9 +424,22 @@ impl Configuration {
 		self.args.flag_rpcapi.clone().unwrap_or(self.args.flag_jsonrpc_apis.clone())
 	}
 
-	pub fn rpc_cors(&self) -> Vec<String> {
+	pub fn rpc_cors(&self) -> Option<Vec<String>> {
 		let cors = self.args.flag_jsonrpc_cors.clone().or(self.args.flag_rpccorsdomain.clone());
-		cors.map_or_else(Vec::new, |c| c.split(',').map(|s| s.to_owned()).collect())
+		cors.map(|c| c.split(',').map(|s| s.to_owned()).collect())
+	}
+
+	pub fn rpc_hosts(&self) -> Option<Vec<String>> {
+		let hosts = self.args.flag_jsonrpc_hosts.split(',').collect::<Vec<&str>>();
+		// look for special values
+		for h in &hosts {
+			match *h {
+				"none" => return Some(Vec::new()),
+				"all" => return None,
+				_ => {},
+			}
+		}
+		Some(hosts.into_iter().map(|h| h.into()).collect())
 	}
 
 	fn geth_ipc_path(&self) -> String {
@@ -541,8 +554,7 @@ impl Configuration {
 
 	pub fn dapps_interface(&self) -> String {
 		match self.args.flag_dapps_interface.as_str() {
-			"all" => "0.0.0.0",
-			"local" => "127.0.0.1",
+			"local" => "localhost",
 			x => x,
 		}.into()
 	}
@@ -597,7 +609,7 @@ mod tests {
 			assert_eq!(net.rpc_enabled, true);
 			assert_eq!(net.rpc_interface, "all".to_owned());
 			assert_eq!(net.rpc_port, 8000);
-			assert_eq!(conf.rpc_cors(), vec!["*".to_owned()]);
+			assert_eq!(conf.rpc_cors(), Some(vec!["*".to_owned()]));
 			assert_eq!(conf.rpc_apis(), "web3,eth".to_owned());
 		}
 
@@ -618,6 +630,23 @@ mod tests {
 		// then
 		assert(conf1);
 		assert(conf2);
+	}
+
+	#[test]
+	fn should_parse_rpc_hosts() {
+		// given
+
+		// when
+		let conf0 = parse(&["parity"]);
+		let conf1 = parse(&["parity", "--jsonrpc-hosts", "none"]);
+		let conf2 = parse(&["parity", "--jsonrpc-hosts", "all"]);
+		let conf3 = parse(&["parity", "--jsonrpc-hosts", "ethcore.io,something.io"]);
+
+		// then
+		assert_eq!(conf0.rpc_hosts(), Some(Vec::new()));
+		assert_eq!(conf1.rpc_hosts(), Some(Vec::new()));
+		assert_eq!(conf2.rpc_hosts(), None);
+		assert_eq!(conf3.rpc_hosts(), Some(vec!["ethcore.io".into(), "something.io".into()]));
 	}
 }
 

--- a/parity/configuration.rs
+++ b/parity/configuration.rs
@@ -430,16 +430,13 @@ impl Configuration {
 	}
 
 	pub fn rpc_hosts(&self) -> Option<Vec<String>> {
-		let hosts = self.args.flag_jsonrpc_hosts.split(',').collect::<Vec<&str>>();
-		// look for special values
-		for h in &hosts {
-			match *h {
-				"none" => return Some(Vec::new()),
-				"all" => return None,
-				_ => {},
-			}
+		match self.args.flag_jsonrpc_hosts.as_ref() {
+			"none" => return Some(Vec::new()),
+			"all" => return None,
+			_ => {}
 		}
-		Some(hosts.into_iter().map(|h| h.into()).collect())
+		let hosts = self.args.flag_jsonrpc_hosts.split(',').map(|h| h.into()).collect();
+		Some(hosts)
 	}
 
 	fn geth_ipc_path(&self) -> String {
@@ -554,7 +551,7 @@ impl Configuration {
 
 	pub fn dapps_interface(&self) -> String {
 		match self.args.flag_dapps_interface.as_str() {
-			"local" => "localhost",
+			"local" => "127.0.0.1",
 			x => x,
 		}.into()
 	}

--- a/parity/main.rs
+++ b/parity/main.rs
@@ -280,6 +280,7 @@ fn execute_client(conf: Configuration, spec: Spec, client_config: ClientConfig, 
 		port: network_settings.rpc_port,
 		apis: conf.rpc_apis(),
 		cors: conf.rpc_cors(),
+		hosts: conf.rpc_hosts(),
 	}, &dependencies);
 
 	// setup ipc rpc

--- a/parity/rpc.rs
+++ b/parity/rpc.rs
@@ -32,7 +32,8 @@ pub struct HttpConfiguration {
 	pub interface: String,
 	pub port: u16,
 	pub apis: String,
-	pub cors: Vec<String>,
+	pub cors: Option<Vec<String>>,
+	pub hosts: Option<Vec<String>>,
 }
 
 pub struct IpcConfiguration {
@@ -66,7 +67,7 @@ pub fn new_http(conf: HttpConfiguration, deps: &Dependencies) -> Option<RpcServe
 	let url = format!("{}:{}", conf.interface, conf.port);
 	let addr = SocketAddr::from_str(&url).unwrap_or_else(|_| die!("{}: Invalid JSONRPC listen host/port given.", url));
 
-	Some(setup_http_rpc_server(deps, &addr, conf.cors, apis))
+	Some(setup_http_rpc_server(deps, &addr, conf.cors, conf.hosts, apis))
 }
 
 fn setup_rpc_server(apis: Vec<&str>, deps: &Dependencies) -> Server {
@@ -78,21 +79,17 @@ fn setup_rpc_server(apis: Vec<&str>, deps: &Dependencies) -> Server {
 pub fn setup_http_rpc_server(
 	dependencies: &Dependencies,
 	url: &SocketAddr,
-	cors_domains: Vec<String>,
+	cors_domains: Option<Vec<String>>,
+	allowed_hosts: Option<Vec<String>>,
 	apis: Vec<&str>,
 ) -> RpcServer {
 	let server = setup_rpc_server(apis, dependencies);
-	let start_result = server.start_http(url, cors_domains);
 	let ph = dependencies.panic_handler.clone();
+	let start_result = server.start_http(url, cors_domains, allowed_hosts, ph);
 	match start_result {
 		Err(RpcServerError::IoError(err)) => die_with_io_error("RPC", err),
 		Err(e) => die!("RPC: {:?}", e),
-		Ok(server) => {
-			server.set_panic_handler(move || {
-				ph.notify_all("Panic in RPC thread.".to_owned());
-			});
-			server
-		},
+		Ok(server) => server,
 	}
 }
 


### PR DESCRIPTION
Fixed binding on MacOSX. Adding `localhost:<p>` to allowed hosts if bidning_address is `127.0.0.1:<p>`:
https://github.com/ethcore/parity/pull/1666/files#diff-59467f61b674e2c26a30d11b1960c45fR31