### PR TITLE
Bumping JSONRPC-http-server

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -630,7 +630,7 @@ dependencies = [
 [[package]]
 name = "jsonrpc-http-server"
 version = "6.1.0"
-source = "git+https://github.com/ethcore/jsonrpc-http-server.git#517a0d7b8c7fd099995ce4cc93f52789e83f2cdc"
+source = "git+https://github.com/ethcore/jsonrpc-http-server.git#4e3f93eb79125e91a46e04d77c25ff8885498b86"
 dependencies = [
  "hyper 0.9.4 (git+https://github.com/ethcore/hyper)",
  "jsonrpc-core 2.0.7 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
Contains a fix for `localhost:8545` being disallowed to connect by default.

https://github.com/ethcore/jsonrpc-http-server/pull/23/files