### PR TITLE
Alter OverlayDB not to use disk ref-counting

### DIFF
--- a/util/src/error.rs
+++ b/util/src/error.rs
@@ -28,14 +28,17 @@ use hash::H256;
 pub enum BaseDataError {
 	/// An entry was removed more times than inserted.
 	NegativelyReferencedHash(H256),
+	/// An entry was referenced an invalid amount of times.
+	InvalidReferenceCount(H256, i32),
 }
 
 impl fmt::Display for BaseDataError {
 	fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
 		match *self {
 			BaseDataError::NegativelyReferencedHash(hash) =>
-				f.write_fmt(format_args!("Entry {} removed from database more times \
-					than it was added.", hash)),
+				write!(f, "Entry {} removed from database more times than it was added.", hash),
+			BaseDataError::InvalidReferenceCount(hash, rc) =>
+				write!(f, "Entry {} has invalid reference count of {}", hash, rc),
 		}
 	}
 }

--- a/util/src/journaldb/refcounteddb.rs
+++ b/util/src/journaldb/refcounteddb.rs
@@ -19,7 +19,7 @@
 use common::*;
 use rlp::*;
 use hashdb::*;
-use overlaydb::*;
+use ref_overlaydb::RefOverlayDB;
 use super::{DB_PREFIX_LEN, LATEST_ERA_KEY, VERSION_KEY};
 use super::traits::JournalDB;
 use kvdb::{Database, DBTransaction, DatabaseConfig};
@@ -34,7 +34,7 @@ use std::env;
 /// immediately. Rather some age (based on a linear but arbitrary metric) must pass before
 /// the removals actually take effect.
 pub struct RefCountedDB {
-	forward: OverlayDB,
+	forward: RefOverlayDB,
 	backing: Arc<Database>,
 	latest_era: Option<u64>,
 	inserts: Vec<H256>,
@@ -63,7 +63,7 @@ impl RefCountedDB {
 		let latest_era = backing.get(&LATEST_ERA_KEY).expect("Low-level database error.").map(|val| decode::<u64>(&val));
 
 		RefCountedDB {
-			forward: OverlayDB::new_with_arc(backing.clone()),
+			forward: RefOverlayDB::new_with_arc(backing.clone()),
 			backing: backing,
 			inserts: vec![],
 			removes: vec![],

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -138,6 +138,7 @@ pub mod hashdb;
 pub mod memorydb;
 pub mod migration;
 pub mod overlaydb;
+pub mod ref_overlaydb;
 pub mod journaldb;
 pub mod kvdb;
 mod math;

--- a/util/src/memorydb.rs
+++ b/util/src/memorydb.rs
@@ -162,6 +162,7 @@ impl MemoryDB {
 	/// Returns the size of allocated heap memory
 	pub fn mem_used(&self) -> usize {
 		self.data.heap_size_of_children()
+		+ self.aux.heap_size_of_children()
 	}
 
 	/// Remove an element and delete it from storage if reference count reaches zero.

--- a/util/src/overlaydb.rs
+++ b/util/src/overlaydb.rs
@@ -14,19 +14,26 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-//! Disk-backed `HashDB` implementation.
+//! Disk-backed, `HashDB` implementation.
 
-use error::*;
-use hash::*;
-use bytes::*;
-use rlp::*;
-use hashdb::*;
-use memorydb::*;
-use std::ops::*;
-use std::sync::*;
-use std::env;
-use std::collections::HashMap;
+use error::{BaseDataError, UtilError};
 use kvdb::{Database, DBTransaction};
+use memorydb::MemoryDB;
+use hash::{FixedHash, H32, H256};
+use hashdb::HashDB;
+use Bytes;
+
+use std::collections::HashMap;
+use std::sync::Arc;
+
+/// How to treat entries which can be deleted
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeletionMode {
+	/// Ignore them.
+	Ignore,
+	/// Delete them.
+	Delete,
+}
 
 /// Implementation of the `HashDB` trait for a disk-backed database with a memory overlay.
 ///
@@ -40,340 +47,126 @@ use kvdb::{Database, DBTransaction};
 pub struct OverlayDB {
 	overlay: MemoryDB,
 	backing: Arc<Database>,
+	mode: DeletionMode,
 }
 
 impl OverlayDB {
-	/// Create a new instance of OverlayDB given a `backing` database.
-	pub fn new(backing: Database) -> OverlayDB { Self::new_with_arc(Arc::new(backing)) }
+	/// Create a new instance of OverlayDB given a `backing` database and deletion mode.
+	pub fn new(backing: Database, mode: DeletionMode) -> Self {
+		OverlayDB::new_with_arc(Arc::new(backing), mode)
+	}
 
-	/// Create a new instance of OverlayDB given a `backing` database.
-	pub fn new_with_arc(backing: Arc<Database>) -> OverlayDB {
-		OverlayDB{ overlay: MemoryDB::new(), backing: backing }
+	/// Create a new instance of OverlayDB given a shared `backing` database.
+	pub fn new_with_arc(backing: Arc<Database>, mode: DeletionMode) -> Self {
+		OverlayDB {
+			overlay: MemoryDB::new(),
+			backing: backing,
+			mode: mode
+		}
 	}
 
 	/// Create a new instance of OverlayDB with an anonymous temporary database.
-	pub fn new_temp() -> OverlayDB {
-		let mut dir = env::temp_dir();
+	pub fn new_temp(mode: DeletionMode) -> Self {
+		let mut dir = ::std::env::temp_dir();
 		dir.push(H32::random().hex());
-		Self::new(Database::open_default(dir.to_str().unwrap()).unwrap())
+		Self::new(Database::open_default(dir.to_str().unwrap()).unwrap(), mode)
 	}
 
-	/// Commit all operations to given batch.
+	/// Commit all operations to given batch. Returns the number of insertions
+	/// and deletions.
 	pub fn commit_to_batch(&mut self, batch: &DBTransaction) -> Result<u32, UtilError> {
 		let mut ret = 0u32;
 		let mut deletes = 0usize;
-		for i in self.overlay.drain().into_iter() {
-			let (key, (value, rc)) = i;
-			if rc != 0 {
-				match self.payload(&key) {
-					Some(x) => {
-						let (back_value, back_rc) = x;
-						let total_rc: i32 = back_rc as i32 + rc;
-						if total_rc < 0 {
-							return Err(From::from(BaseDataError::NegativelyReferencedHash(key)));
-						}
-						deletes += if self.put_payload_in_batch(batch, &key, (back_value, total_rc as u32)) {1} else {0};
+		for (key, (value, rc)) in self.overlay.drain() {
+			match rc {
+				0 => continue,
+				1 => try!(batch.put(&key, &value)),
+				-1 => {
+					deletes += 1;
+					if self.mode == DeletionMode::Delete {
+						try!(batch.delete(&key));
 					}
-					None => {
-						if rc < 0 {
-							return Err(From::from(BaseDataError::NegativelyReferencedHash(key)));
-						}
-						self.put_payload_in_batch(batch, &key, (value, rc as u32));
-					}
-				};
-				ret += 1;
+				}
+				rc => return Err(BaseDataError::InvalidReferenceCount(key, rc).into()),
 			}
+
+			ret += 1;
 		}
-		trace!("OverlayDB::commit() deleted {} nodes", deletes);
+
+		trace!(target: "overlaydb", "OverlayDB::commit() deleted {} nodes", deletes);
 		Ok(ret)
 	}
 
-	/// Commit all memory operations to the backing database.
-	///
-	/// Returns either an error or the number of items changed in the backing database.
-	///
-	/// Will return an error if the number of `remove()`s ever exceeds the number of
-	/// `insert()`s for any key. This will leave the database in an undeterminate
-	/// state. Don't ever let it happen.
-	///
-	/// # Example
-	/// ```
-	/// extern crate ethcore_util;
-	/// use ethcore_util::hashdb::*;
-	/// use ethcore_util::overlaydb::*;
-	/// fn main() {
-	///   let mut m = OverlayDB::new_temp();
-	///   let key = m.insert(b"foo");			// insert item.
-	///   assert!(m.contains(&key));			// key exists (in memory).
-	///   assert_eq!(m.commit().unwrap(), 1);	// 1 item changed.
-	///   assert!(m.contains(&key));			// key still exists (in backing).
-	///   m.remove(&key);							// delete item.
-	///   assert!(!m.contains(&key));			// key "doesn't exist" (though still does in backing).
-	///   m.remove(&key);							// oh dear... more removes than inserts for the key...
-	///   //m.commit().unwrap();				// this commit/unwrap would cause a panic.
-	///   m.revert();							// revert both removes.
-	///   assert!(m.contains(&key));			// key now still exists.
-	/// }
-	/// ```
+	/// Commit all operations to the backing database. Returns the number of insertions and deletions.
 	pub fn commit(&mut self) -> Result<u32, UtilError> {
-		let mut ret = 0u32;
-		let mut deletes = 0usize;
-		for i in self.overlay.drain().into_iter() {
-			let (key, (value, rc)) = i;
-			if rc != 0 {
-				match self.payload(&key) {
-					Some(x) => {
-						let (back_value, back_rc) = x;
-						let total_rc: i32 = back_rc as i32 + rc;
-						if total_rc < 0 {
-							return Err(From::from(BaseDataError::NegativelyReferencedHash(key)));
-						}
-						deletes += if self.put_payload(&key, (back_value, total_rc as u32)) {1} else {0};
-					}
-					None => {
-						if rc < 0 {
-							return Err(From::from(BaseDataError::NegativelyReferencedHash(key)));
-						}
-						self.put_payload(&key, (value, rc as u32));
-					}
-				};
-				ret += 1;
-			}
-		}
-		trace!("OverlayDB::commit() deleted {} nodes", deletes);
-		Ok(ret)
+		let batch = DBTransaction::new();
+		let ops = try!(self.commit_to_batch(&batch));
+		try!(self.backing.write(batch));
+
+		Ok(ops)
 	}
 
-	/// Revert all operations on this object (i.e. `insert()`s and `remove()`s) since the
-	/// last `commit()`.
-	///
-	/// # Example
-	/// ```
-	/// extern crate ethcore_util;
-	/// use ethcore_util::hashdb::*;
-	/// use ethcore_util::overlaydb::*;
-	/// fn main() {
-	///   let mut m = OverlayDB::new_temp();
-	///   let foo = m.insert(b"foo");	// insert foo.
-	///   m.commit().unwrap();			// commit - new operations begin here...
-	///   let bar = m.insert(b"bar");	// insert bar.
-	///   m.remove(&foo);					// remove foo.
-	///   assert!(!m.contains(&foo));		// foo is gone.
-	///   assert!(m.contains(&bar));		// bar is here.
-	///   m.revert();					// revert the last two operations.
-	///   assert!(m.contains(&foo));		// foo is here.
-	///   assert!(!m.contains(&bar));		// bar is gone.
-	/// }
-	/// ```
-	pub fn revert(&mut self) { self.overlay.clear(); }
+	/// Revert all operations on this object since last commit.
+	pub fn revert(&mut self) { self.overlay.clear() }
 
-	/// Get the number of references that would be committed.
-	pub fn commit_refs(&self, key: &H256) -> i32 { self.overlay.raw(&key).map_or(0, |&(_, refs)| refs) }
-
-	/// Get the refs and value of the given key.
-	fn payload(&self, key: &H256) -> Option<(Bytes, u32)> {
-		self.backing.get(key)
-			.expect("Low-level database error. Some issue with your hard disk?")
-			.map(|d| {
-				let r = Rlp::new(&d);
-				(r.at(1).as_val(), r.at(0).as_val())
-			})
-	}
-
-	/// Put the refs and value of the given key, possibly deleting it from the db.
-	fn put_payload_in_batch(&self, batch: &DBTransaction, key: &H256, payload: (Bytes, u32)) -> bool {
-		if payload.1 > 0 {
-			let mut s = RlpStream::new_list(2);
-			s.append(&payload.1);
-			s.append(&payload.0);
-			batch.put(key, s.as_raw()).expect("Low-level database error. Some issue with your hard disk?");
-			false
-		} else {
-			batch.delete(key).expect("Low-level database error. Some issue with your hard disk?");
-			true
-		}
-	}
-
-	/// Put the refs and value of the given key, possibly deleting it from the db.
-	fn put_payload(&self, key: &H256, payload: (Bytes, u32)) -> bool {
-		if payload.1 > 0 {
-			let mut s = RlpStream::new_list(2);
-			s.append(&payload.1);
-			s.append(&payload.0);
-			self.backing.put(key, s.as_raw()).expect("Low-level database error. Some issue with your hard disk?");
-			false
-		} else {
-			self.backing.delete(key).expect("Low-level database error. Some issue with your hard disk?");
-			true
-		}
+	/// Get the value of the given key.
+	fn payload(&self, key: &H256) -> Option<Bytes> {
+		// TODO [rob] have this and HashDB functions all return Results.
+		self.backing.get(key).expect("Low level database error.").map(|v| v.to_vec())
 	}
 }
 
 impl HashDB for OverlayDB {
 	fn keys(&self) -> HashMap<H256, i32> {
-		let mut ret: HashMap<H256, i32> = HashMap::new();
+		let mut ret = HashMap::new();
+
 		for (key, _) in self.backing.iter() {
-			let h = H256::from_slice(key.deref());
-			let r = self.payload(&h).unwrap().1;
-			ret.insert(h, r as i32);
+			ret.insert(H256::from_slice(&*key), 1);
 		}
 
-		for (key, refs) in self.overlay.keys().into_iter() {
-			let refs = *ret.get(&key).unwrap_or(&0) + refs;
-			ret.insert(key, refs);
+		for (key, refs) in self.overlay.keys() {
+			*ret.entry(key).or_insert(0) += refs;
 		}
+
 		ret
 	}
+
 	fn get(&self, key: &H256) -> Option<&[u8]> {
-		// return ok if positive; if negative, check backing - might be enough references there to make
-		// it positive again.
-		let k = self.overlay.raw(key);
-		match k {
-			Some(&(ref d, rc)) if rc > 0 => Some(d),
-			_ => {
-				let memrc = k.map_or(0, |&(_, rc)| rc);
-				match self.payload(key) {
-					Some(x) => {
-						let (d, rc) = x;
-						if rc as i32 + memrc > 0 {
-							Some(&self.overlay.denote(key, d).0)
-						}
-						else {
-							None
-						}
-					}
-					// Replace above match arm with this once https://github.com/rust-lang/rust/issues/15287 is done.
-					//Some((d, rc)) if rc + memrc > 0 => Some(d),
-					_ => None,
-				}
-			}
+		match self.overlay.raw(key) {
+			Some(&(ref d, rc)) if rc > 0 => { Some(d) }
+			_ => if let Some(x) = self.payload(key) {
+				Some(&self.overlay.denote(key, x).0)
+			} else {
+				None
+			},
 		}
 	}
+
 	fn contains(&self, key: &H256) -> bool {
-		// return ok if positive; if negative, check backing - might be enough references there to make
-		// it positive again.
-		let k = self.overlay.raw(key);
-		match k {
-			Some(&(_, rc)) if rc > 0 => true,
-			_ => {
-				let memrc = k.map_or(0, |&(_, rc)| rc);
-				match self.payload(key) {
-					Some(x) => {
-						let (_, rc) = x;
-						rc as i32 + memrc > 0
-					}
-					// Replace above match arm with this once https://github.com/rust-lang/rust/issues/15287 is done.
-					//Some((d, rc)) if rc + memrc > 0 => true,
-					_ => false,
-				}
-			}
-		}
+		self.get(key).is_some()
 	}
-	fn insert(&mut self, value: &[u8]) -> H256 { self.overlay.insert(value) }
-	fn emplace(&mut self, key: H256, value: Bytes) { self.overlay.emplace(key, value); }
-	fn remove(&mut self, key: &H256) { self.overlay.remove(key); }
-}
 
-#[test]
-fn overlaydb_overlay_insert_and_remove() {
-	let mut trie = OverlayDB::new_temp();
-	let h = trie.insert(b"hello world");
-	assert_eq!(trie.get(&h).unwrap(), b"hello world");
-	trie.remove(&h);
-	assert_eq!(trie.get(&h), None);
-}
-
-#[test]
-fn overlaydb_backing_insert_revert() {
-	let mut trie = OverlayDB::new_temp();
-	let h = trie.insert(b"hello world");
-	assert_eq!(trie.get(&h).unwrap(), b"hello world");
-	trie.commit().unwrap();
-	assert_eq!(trie.get(&h).unwrap(), b"hello world");
-	trie.revert();
-	assert_eq!(trie.get(&h).unwrap(), b"hello world");
-}
-
-#[test]
-fn overlaydb_backing_remove() {
-	let mut trie = OverlayDB::new_temp();
-	let h = trie.insert(b"hello world");
-	trie.commit().unwrap();
-	trie.remove(&h);
-	assert_eq!(trie.get(&h), None);
-	trie.commit().unwrap();
-	assert_eq!(trie.get(&h), None);
-	trie.revert();
-	assert_eq!(trie.get(&h), None);
-}
-
-#[test]
-fn overlaydb_backing_remove_revert() {
-	let mut trie = OverlayDB::new_temp();
-	let h = trie.insert(b"hello world");
-	trie.commit().unwrap();
-	trie.remove(&h);
-	assert_eq!(trie.get(&h), None);
-	trie.revert();
-	assert_eq!(trie.get(&h).unwrap(), b"hello world");
-}
-
-#[test]
-fn overlaydb_negative() {
-	let mut trie = OverlayDB::new_temp();
-	let h = trie.insert(b"hello world");
-	trie.commit().unwrap();
-	trie.remove(&h);
-	trie.remove(&h);	//bad - sends us into negative refs.
-	assert_eq!(trie.get(&h), None);
-	assert!(trie.commit().is_err());
-}
-
-#[test]
-fn overlaydb_complex() {
-	let mut trie = OverlayDB::new_temp();
-	let hfoo = trie.insert(b"foo");
-	assert_eq!(trie.get(&hfoo).unwrap(), b"foo");
-	let hbar = trie.insert(b"bar");
-	assert_eq!(trie.get(&hbar).unwrap(), b"bar");
-	trie.commit().unwrap();
-	assert_eq!(trie.get(&hfoo).unwrap(), b"foo");
-	assert_eq!(trie.get(&hbar).unwrap(), b"bar");
-	trie.insert(b"foo");	// two refs
-	assert_eq!(trie.get(&hfoo).unwrap(), b"foo");
-	trie.commit().unwrap();
-	assert_eq!(trie.get(&hfoo).unwrap(), b"foo");
-	assert_eq!(trie.get(&hbar).unwrap(), b"bar");
-	trie.remove(&hbar);		// zero refs - delete
-	assert_eq!(trie.get(&hbar), None);
-	trie.remove(&hfoo);		// one ref - keep
-	assert_eq!(trie.get(&hfoo).unwrap(), b"foo");
-	trie.commit().unwrap();
-	assert_eq!(trie.get(&hfoo).unwrap(), b"foo");
-	trie.remove(&hfoo);		// zero ref - would delete, but...
-	assert_eq!(trie.get(&hfoo), None);
-	trie.insert(b"foo");	// one ref - keep after all.
-	assert_eq!(trie.get(&hfoo).unwrap(), b"foo");
-	trie.commit().unwrap();
-	assert_eq!(trie.get(&hfoo).unwrap(), b"foo");
-	trie.remove(&hfoo);		// zero ref - delete
-	assert_eq!(trie.get(&hfoo), None);
-	trie.commit().unwrap();	//
-	assert_eq!(trie.get(&hfoo), None);
-}
-
-#[test]
-fn playpen() {
-	use std::fs;
-	{
-		let db: Database = Database::open_default("/tmp/test").unwrap();
-		db.put(b"test", b"test2").unwrap();
-		match db.get(b"test") {
-			Ok(Some(value)) => println!("Got value {:?}", value.deref()),
-			Ok(None) => println!("No value for that key"),
-			Err(..) => println!("Gah"),
-		}
-		db.delete(b"test").unwrap();
+	fn insert(&mut self, value: &[u8]) -> H256 {
+		self.overlay.insert(value)
 	}
-	fs::remove_dir_all("/tmp/test").unwrap();
+
+	fn emplace(&mut self, key: H256, value: Bytes) {
+		self.overlay.emplace(key, value);
+	}
+
+	fn remove(&mut self, key: &H256) {
+		self.overlay.remove(key);
+	}
+
+	fn insert_aux(&mut self, hash: Bytes, value: Bytes) {
+		self.overlay.insert_aux(hash, value);
+	}
+
+	fn get_aux(&self, hash: &[u8]) -> Option<Bytes> {
+		self.overlay.get_aux(hash)
+	}
+
+	fn remove_aux(&mut self, hash: &[u8]) {
+		self.overlay.remove_aux(hash);
+	}
 }

--- a/util/src/overlaydb.rs
+++ b/util/src/overlaydb.rs
@@ -98,6 +98,7 @@ impl OverlayDB {
 	}
 
 	/// Commit all operations to the backing database. Returns the number of insertions and deletions.
+	/// This does not commit auxiliary data.
 	pub fn commit(&mut self) -> Result<u32, UtilError> {
 		let batch = DBTransaction::new();
 		let ops = try!(self.commit_to_batch(&batch));
@@ -108,6 +109,16 @@ impl OverlayDB {
 
 	/// Revert all operations on this object since last commit.
 	pub fn revert(&mut self) { self.overlay.clear() }
+
+	/// Drain auxiliary entries from the overlay.
+	pub fn drain_aux(&mut self) -> HashMap<Bytes, Bytes> {
+		self.overlay.drain_aux()
+	}
+
+	/// Returns the size of allocated heap memory.
+	pub fn mem_used(&self) -> usize {
+		self.overlay.mem_used()
+	}
 
 	/// Get the value of the given key.
 	fn payload(&self, key: &H256) -> Option<Bytes> {

--- a/util/src/overlaydb.rs
+++ b/util/src/overlaydb.rs
@@ -181,3 +181,44 @@ impl HashDB for OverlayDB {
 		self.overlay.remove_aux(hash);
 	}
 }
+
+#[cfg(test)]
+mod tests {
+	use super::{DeletionMode, OverlayDB};
+	use kvdb::Database;
+	use hashdb::HashDB;
+	use devtools::RandomTempPath;
+
+	// most of the functionality of `OverlayDB` is tested through
+	// `ArchiveDB`'s tests by proxy.
+
+	#[test]
+	fn ignore_remove() {
+		let path = RandomTempPath::create_dir();
+		let backing = Database::open_default(path.as_str()).unwrap();
+		let mut db = OverlayDB::new(backing, DeletionMode::Ignore);
+
+		let hash = db.insert(b"dog");
+		db.commit().unwrap();
+
+		db.remove(&hash);
+		db.commit().unwrap();
+
+		assert!(db.get(&hash).is_some())
+	}
+
+	#[test]
+	fn delete_remove() {
+		let path = RandomTempPath::create_dir();
+		let backing = Database::open_default(path.as_str()).unwrap();
+		let mut db = OverlayDB::new(backing, DeletionMode::Delete);
+
+		let hash = db.insert(b"dog");
+		db.commit().unwrap();
+
+		db.remove(&hash);
+		db.commit().unwrap();
+
+		assert!(db.get(&hash).is_none())
+	}
+}

--- a/util/src/ref_overlaydb.rs
+++ b/util/src/ref_overlaydb.rs
@@ -1,0 +1,381 @@
+// Copyright 2015, 2016 Ethcore (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Disk-backed, reference-counted `HashDB` implementation.
+
+use error::*;
+use hash::*;
+use bytes::*;
+use rlp::*;
+use hashdb::*;
+use memorydb::*;
+use std::ops::*;
+use std::sync::*;
+use std::env;
+use std::collections::HashMap;
+use kvdb::{Database, DBTransaction};
+
+/// Implementation of the `HashDB` trait for a disk-backed database with a memory overlay.
+///
+/// The operations `insert()` and `remove()` take place on the memory overlay; batches of
+/// such operations may be flushed to the disk-backed DB with `commit()` or discarded with
+/// `revert()`.
+///
+/// `lookup()` and `contains()` maintain normal behaviour - all `insert()` and `remove()`
+/// queries have an immediate effect in terms of these functions.
+///
+/// This uses reference-counting in the overlay and on disk in order to keep the database trim.
+#[derive(Clone)]
+pub struct RefOverlayDB {
+	overlay: MemoryDB,
+	backing: Arc<Database>,
+}
+
+impl RefOverlayDB {
+	/// Create a new instance of RefOverlayDB given a `backing` database.
+	pub fn new(backing: Database) -> RefOverlayDB { Self::new_with_arc(Arc::new(backing)) }
+
+	/// Create a new instance of RefOverlayDB given a `backing` database.
+	pub fn new_with_arc(backing: Arc<Database>) -> RefOverlayDB {
+		RefOverlayDB { overlay: MemoryDB::new(), backing: backing }
+	}
+
+	/// Create a new instance of RefOverlayDB with an anonymous temporary database.
+	pub fn new_temp() -> RefOverlayDB {
+		let mut dir = env::temp_dir();
+		dir.push(H32::random().hex());
+		Self::new(Database::open_default(dir.to_str().unwrap()).unwrap())
+	}
+
+	/// Commit all operations to given batch.
+	pub fn commit_to_batch(&mut self, batch: &DBTransaction) -> Result<u32, UtilError> {
+		let mut ret = 0u32;
+		let mut deletes = 0usize;
+		for i in self.overlay.drain().into_iter() {
+			let (key, (value, rc)) = i;
+			if rc != 0 {
+				match self.payload(&key) {
+					Some(x) => {
+						let (back_value, back_rc) = x;
+						let total_rc: i32 = back_rc as i32 + rc;
+						if total_rc < 0 {
+							return Err(BaseDataError::NegativelyReferencedHash(key).into());
+						}
+						deletes += if self.put_payload_in_batch(batch, &key, (back_value, total_rc as u32)) {1} else {0};
+					}
+					None => {
+						if rc < 0 {
+							return Err(BaseDataError::NegativelyReferencedHash(key).into());
+						}
+						self.put_payload_in_batch(batch, &key, (value, rc as u32));
+					}
+				};
+				ret += 1;
+			}
+		}
+		trace!(target: "ref_overlaydb", "RefOverlayDB::commit() deleted {} nodes", deletes);
+		Ok(ret)
+	}
+
+	/// Commit all memory operations to the backing database.
+	///
+	/// Returns either an error or the number of items changed in the backing database.
+	///
+	/// Will return an error if the number of `remove()`s ever exceeds the number of
+	/// `insert()`s for any key. This will leave the database in an undeterminate
+	/// state. Don't ever let it happen.
+	///
+	/// # Example
+	/// ```
+	/// extern crate ethcore_util;
+	/// use ethcore_util::hashdb::*;
+	/// use ethcore_util::ref_overlaydb::*;
+	/// fn main() {
+	///   let mut m = RefOverlayDB::new_temp();
+	///   let key = m.insert(b"foo");			// insert item.
+	///   assert!(m.contains(&key));			// key exists (in memory).
+	///   assert_eq!(m.commit().unwrap(), 1);	// 1 item changed.
+	///   assert!(m.contains(&key));			// key still exists (in backing).
+	///   m.remove(&key);							// delete item.
+	///   assert!(!m.contains(&key));			// key "doesn't exist" (though still does in backing).
+	///   m.remove(&key);							// oh dear... more removes than inserts for the key...
+	///   //m.commit().unwrap();				// this commit/unwrap would cause a panic.
+	///   m.revert();							// revert both removes.
+	///   assert!(m.contains(&key));			// key now still exists.
+	/// }
+	/// ```
+	pub fn commit(&mut self) -> Result<u32, UtilError> {
+		let mut ret = 0u32;
+		let mut deletes = 0usize;
+		for i in self.overlay.drain().into_iter() {
+			let (key, (value, rc)) = i;
+			if rc != 0 {
+				match self.payload(&key) {
+					Some(x) => {
+						let (back_value, back_rc) = x;
+						let total_rc: i32 = back_rc as i32 + rc;
+						if total_rc < 0 {
+							return Err(From::from(BaseDataError::NegativelyReferencedHash(key)));
+						}
+						deletes += if self.put_payload(&key, (back_value, total_rc as u32)) {1} else {0};
+					}
+					None => {
+						if rc < 0 {
+							return Err(From::from(BaseDataError::NegativelyReferencedHash(key)));
+						}
+						self.put_payload(&key, (value, rc as u32));
+					}
+				};
+				ret += 1;
+			}
+		}
+		trace!("OverlayDB::commit() deleted {} nodes", deletes);
+		Ok(ret)
+	}
+
+	/// Revert all operations on this object (i.e. `insert()`s and `remove()`s) since the
+	/// last `commit()`.
+	///
+	/// # Example
+	/// ```
+	/// extern crate ethcore_util;
+	/// use ethcore_util::hashdb::*;
+	/// use ethcore_util::ref_overlaydb::*;
+	/// fn main() {
+	///   let mut m = RefOverlayDB::new_temp();
+	///   let foo = m.insert(b"foo");	// insert foo.
+	///   m.commit().unwrap();			// commit - new operations begin here...
+	///   let bar = m.insert(b"bar");	// insert bar.
+	///   m.remove(&foo);					// remove foo.
+	///   assert!(!m.contains(&foo));		// foo is gone.
+	///   assert!(m.contains(&bar));		// bar is here.
+	///   m.revert();					// revert the last two operations.
+	///   assert!(m.contains(&foo));		// foo is here.
+	///   assert!(!m.contains(&bar));		// bar is gone.
+	/// }
+	/// ```
+	pub fn revert(&mut self) { self.overlay.clear(); }
+
+	/// Get the number of references that would be committed.
+	pub fn commit_refs(&self, key: &H256) -> i32 { self.overlay.raw(&key).map_or(0, |&(_, refs)| refs) }
+
+	/// Get the refs and value of the given key.
+	fn payload(&self, key: &H256) -> Option<(Bytes, u32)> {
+		self.backing.get(key)
+			.expect("Low-level database error. Some issue with your hard disk?")
+			.map(|d| {
+				let r = Rlp::new(&d);
+				(r.at(1).as_val(), r.at(0).as_val())
+			})
+	}
+
+	/// Put the refs and value of the given key, possibly deleting it from the db.
+	fn put_payload_in_batch(&self, batch: &DBTransaction, key: &H256, payload: (Bytes, u32)) -> bool {
+		if payload.1 > 0 {
+			let mut s = RlpStream::new_list(2);
+			s.append(&payload.1);
+			s.append(&payload.0);
+			batch.put(key, s.as_raw()).expect("Low-level database error. Some issue with your hard disk?");
+			false
+		} else {
+			batch.delete(key).expect("Low-level database error. Some issue with your hard disk?");
+			true
+		}
+	}
+
+	/// Put the refs and value of the given key, possibly deleting it from the db.
+	fn put_payload(&self, key: &H256, payload: (Bytes, u32)) -> bool {
+		if payload.1 > 0 {
+			let mut s = RlpStream::new_list(2);
+			s.append(&payload.1);
+			s.append(&payload.0);
+			self.backing.put(key, s.as_raw()).expect("Low-level database error. Some issue with your hard disk?");
+			false
+		} else {
+			self.backing.delete(key).expect("Low-level database error. Some issue with your hard disk?");
+			true
+		}
+	}
+}
+
+impl HashDB for RefOverlayDB {
+	fn keys(&self) -> HashMap<H256, i32> {
+		let mut ret: HashMap<H256, i32> = HashMap::new();
+		for (key, _) in self.backing.iter() {
+			let h = H256::from_slice(key.deref());
+			let r = self.payload(&h).unwrap().1;
+			ret.insert(h, r as i32);
+		}
+
+		for (key, refs) in self.overlay.keys().into_iter() {
+			let refs = *ret.get(&key).unwrap_or(&0) + refs;
+			ret.insert(key, refs);
+		}
+		ret
+	}
+	fn get(&self, key: &H256) -> Option<&[u8]> {
+		// return ok if positive; if negative, check backing - might be enough references there to make
+		// it positive again.
+		let k = self.overlay.raw(key);
+		match k {
+			Some(&(ref d, rc)) if rc > 0 => Some(d),
+			_ => {
+				let memrc = k.map_or(0, |&(_, rc)| rc);
+				match self.payload(key) {
+					Some(x) => {
+						let (d, rc) = x;
+						if rc as i32 + memrc > 0 {
+							Some(&self.overlay.denote(key, d).0)
+						}
+						else {
+							None
+						}
+					}
+					// Replace above match arm with this once https://github.com/rust-lang/rust/issues/15287 is done.
+					//Some((d, rc)) if rc + memrc > 0 => Some(d),
+					_ => None,
+				}
+			}
+		}
+	}
+	fn contains(&self, key: &H256) -> bool {
+		// return ok if positive; if negative, check backing - might be enough references there to make
+		// it positive again.
+		let k = self.overlay.raw(key);
+		match k {
+			Some(&(_, rc)) if rc > 0 => true,
+			_ => {
+				let memrc = k.map_or(0, |&(_, rc)| rc);
+				match self.payload(key) {
+					Some(x) => {
+						let (_, rc) = x;
+						rc as i32 + memrc > 0
+					}
+					// Replace above match arm with this once https://github.com/rust-lang/rust/issues/15287 is done.
+					//Some((d, rc)) if rc + memrc > 0 => true,
+					_ => false,
+				}
+			}
+		}
+	}
+	fn insert(&mut self, value: &[u8]) -> H256 { self.overlay.insert(value) }
+	fn emplace(&mut self, key: H256, value: Bytes) { self.overlay.emplace(key, value); }
+	fn remove(&mut self, key: &H256) { self.overlay.remove(key); }
+}
+
+#[test]
+fn overlaydb_overlay_insert_and_remove() {
+	let mut trie = RefOverlayDB::new_temp();
+	let h = trie.insert(b"hello world");
+	assert_eq!(trie.get(&h).unwrap(), b"hello world");
+	trie.remove(&h);
+	assert_eq!(trie.get(&h), None);
+}
+
+#[test]
+fn overlaydb_backing_insert_revert() {
+	let mut trie = RefOverlayDB::new_temp();
+	let h = trie.insert(b"hello world");
+	assert_eq!(trie.get(&h).unwrap(), b"hello world");
+	trie.commit().unwrap();
+	assert_eq!(trie.get(&h).unwrap(), b"hello world");
+	trie.revert();
+	assert_eq!(trie.get(&h).unwrap(), b"hello world");
+}
+
+#[test]
+fn overlaydb_backing_remove() {
+	let mut trie = RefOverlayDB::new_temp();
+	let h = trie.insert(b"hello world");
+	trie.commit().unwrap();
+	trie.remove(&h);
+	assert_eq!(trie.get(&h), None);
+	trie.commit().unwrap();
+	assert_eq!(trie.get(&h), None);
+	trie.revert();
+	assert_eq!(trie.get(&h), None);
+}
+
+#[test]
+fn overlaydb_backing_remove_revert() {
+	let mut trie = RefOverlayDB::new_temp();
+	let h = trie.insert(b"hello world");
+	trie.commit().unwrap();
+	trie.remove(&h);
+	assert_eq!(trie.get(&h), None);
+	trie.revert();
+	assert_eq!(trie.get(&h).unwrap(), b"hello world");
+}
+
+#[test]
+fn overlaydb_negative() {
+	let mut trie = RefOverlayDB::new_temp();
+	let h = trie.insert(b"hello world");
+	trie.commit().unwrap();
+	trie.remove(&h);
+	trie.remove(&h);	//bad - sends us into negative refs.
+	assert_eq!(trie.get(&h), None);
+	assert!(trie.commit().is_err());
+}
+
+#[test]
+fn overlaydb_complex() {
+	let mut trie = RefOverlayDB::new_temp();
+	let hfoo = trie.insert(b"foo");
+	assert_eq!(trie.get(&hfoo).unwrap(), b"foo");
+	let hbar = trie.insert(b"bar");
+	assert_eq!(trie.get(&hbar).unwrap(), b"bar");
+	trie.commit().unwrap();
+	assert_eq!(trie.get(&hfoo).unwrap(), b"foo");
+	assert_eq!(trie.get(&hbar).unwrap(), b"bar");
+	trie.insert(b"foo");	// two refs
+	assert_eq!(trie.get(&hfoo).unwrap(), b"foo");
+	trie.commit().unwrap();
+	assert_eq!(trie.get(&hfoo).unwrap(), b"foo");
+	assert_eq!(trie.get(&hbar).unwrap(), b"bar");
+	trie.remove(&hbar);		// zero refs - delete
+	assert_eq!(trie.get(&hbar), None);
+	trie.remove(&hfoo);		// one ref - keep
+	assert_eq!(trie.get(&hfoo).unwrap(), b"foo");
+	trie.commit().unwrap();
+	assert_eq!(trie.get(&hfoo).unwrap(), b"foo");
+	trie.remove(&hfoo);		// zero ref - would delete, but...
+	assert_eq!(trie.get(&hfoo), None);
+	trie.insert(b"foo");	// one ref - keep after all.
+	assert_eq!(trie.get(&hfoo).unwrap(), b"foo");
+	trie.commit().unwrap();
+	assert_eq!(trie.get(&hfoo).unwrap(), b"foo");
+	trie.remove(&hfoo);		// zero ref - delete
+	assert_eq!(trie.get(&hfoo), None);
+	trie.commit().unwrap();	//
+	assert_eq!(trie.get(&hfoo), None);
+}
+
+#[test]
+fn playpen() {
+	use std::fs;
+	{
+		let db: Database = Database::open_default("/tmp/test").unwrap();
+		db.put(b"test", b"test2").unwrap();
+		match db.get(b"test") {
+			Ok(Some(value)) => println!("Got value {:?}", value.deref()),
+			Ok(None) => println!("No value for that key"),
+			Err(..) => println!("Gah"),
+		}
+		db.delete(b"test").unwrap();
+	}
+	fs::remove_dir_all("/tmp/test").unwrap();
+}


### PR DESCRIPTION
The old OverlayDB is preserved in RefOverlayDB.

ArchiveDB uses the new OverlayDB. This abstraction will prove useful for #1679 

To be merged after #1702