### PR TITLE
Revert "Exclude generated code from coverage"

### DIFF
--- a/scripts/cov.sh
+++ b/scripts/cov.sh
@@ -37,9 +37,7 @@ src/tests,\
 util/json-tests,\
 util/src/network/tests,\
 ethcore/src/evm/tests,\
-ethstore/tests,\
-target/debug/build,\
-target/release/build\
+ethstore/tests\
 "
 
 rm -rf $KCOV_TARGET


### PR DESCRIPTION
Reverts ethcore/parity#1720

> Example file which is not covered by tests now:

> ```
parity/target/debug/build/ethcore-rpc-5d362971a12aa1de/out/mod.rs
```

> Instead of excluding `target/debug/build` the files which are used to generate this code should be excluded.