### PR TITLE
Return storage as H256 from RPC.

### DIFF
--- a/rpc/src/v1/impls/eth.rs
+++ b/rpc/src/v1/impls/eth.rs
@@ -375,7 +375,7 @@ impl<C, S: ?Sized, M, EM> Eth for EthClient<C, S, M, EM> where
 				match block_number {
 					BlockNumber::Pending => to_value(&RpcU256::from(take_weak!(self.miner).storage_at(&*take_weak!(self.client), &address, &H256::from(position)))),
 					id => match take_weak!(self.client).storage_at(&address, &H256::from(position), id.into()) {
-						Some(s) => to_value(&RpcU256::from(s)),
+						Some(s) => to_value(&RpcH256::from(s)),
 						None => Err(make_unsupported_err()), // None is only returned on unsupported requests.
 					}
 				}

--- a/rpc/src/v1/tests/mocked/eth.rs
+++ b/rpc/src/v1/tests/mocked/eth.rs
@@ -299,7 +299,7 @@ fn rpc_eth_storage_at() {
 		"params": ["0x0000000000000000000000000000000000000001", "0x4", "latest"],
 		"id": 1
 	}"#;
-	let response = r#"{"jsonrpc":"2.0","result":"0x07","id":1}"#;
+	let response = r#"{"jsonrpc":"2.0","result":"0x0000000000000000000000000000000000000000000000000000000000000007","id":1}"#;
 
 	assert_eq!(tester.io.handle_request(request), Some(response.to_owned()));
 }


### PR DESCRIPTION
[This change](https://github.com/ethcore/parity/wiki/JSONRPC/_compare/c61757c307b4c0bbb334b046b526dec58a17a2e9...fb3d89dd83cbd78129085e803542b6c03cdd5a72) in the spec, following a (fairly sensible) geth bug and [requested by a user](https://github.com/ethcore/parity/issues/1761).