### PR TITLE
Fixing account naming

### DIFF
--- a/ethstore/src/dir/disk.rs
+++ b/ethstore/src/dir/disk.rs
@@ -77,7 +77,9 @@ impl DiskDirectory {
 			.map(json::KeyFile::load)
 			.zip(paths.into_iter())
 			.map(|(file, path)| match file {
-				Ok(file) => Ok((path, file.into())),
+				Ok(file) => Ok((path.clone(), SafeAccount::from_file(
+					file, path.file_name().and_then(|n| n.to_str()).expect("Keys have valid UTF8 names only.").to_owned()
+				))),
 				Err(err) => Err(Error::InvalidKeyFile(format!("{:?}: {}", path, err))),
 			})
 			.collect()
@@ -99,21 +101,24 @@ impl KeyDirectory for DiskDirectory {
 
 		// build file path
 		let mut account = account;
-		account.path = account.path.or_else(|| {
-			let mut keyfile_path = self.path.clone();
-			let timestamp = time::strftime("%Y-%m-%d_%H:%M:%S_%Z", &time::now()).unwrap_or("???".to_owned());
-			keyfile_path.push(format!("{}-{}.json", keyfile.id, timestamp));
-			Some(keyfile_path)
+		account.filename = account.filename.or_else(|| {
+			let timestamp = time::strftime("%Y-%m-%d_%H.%M.%S_%Z", &time::now()).unwrap_or("???".to_owned());
+			Some(format!("{}-{}.json", keyfile.id, timestamp))
 		});
+
+		let keyfile_path = {
+			let mut p = self.path.clone();
+			p.push(account.filename.as_ref().expect("build-file-path ensures is not None; qed"));
+			p
+		};
 
 		{
 			// save the file
-			let path = account.path.as_ref().expect("build-file-path ensures is not None; qed");
-			let mut file = try!(fs::File::create(path));
+			let mut file = try!(fs::File::create(&keyfile_path));
 			try!(keyfile.write(&mut file).map_err(|e| Error::Custom(format!("{:?}", e))));
 
-			if let Err(_) = restrict_permissions_to_owner(path) {
-				fs::remove_file(path).expect("Expected to remove recently created file");
+			if let Err(_) = restrict_permissions_to_owner(keyfile_path.as_path()) {
+				fs::remove_file(keyfile_path).expect("Expected to remove recently created file");
 				return Err(Error::Io(io::Error::last_os_error()));
 			}
 		}
@@ -133,5 +138,35 @@ impl KeyDirectory for DiskDirectory {
 			None => Err(Error::InvalidAccount),
 			Some((path, _)) => fs::remove_file(path).map_err(From::from)
 		}
+	}
+}
+
+
+#[cfg(test)]
+mod test {
+	use std::{env, fs};
+	use super::DiskDirectory;
+	use dir::KeyDirectory;
+	use account::SafeAccount;
+	use ethkey::{Random, Generator};
+
+	#[test]
+	fn should_create_new_account() {
+		// given
+		let dir = env::temp_dir();
+		let keypair = Random.generate().unwrap();
+		let password = "hello world";
+		let directory = DiskDirectory::create(dir.clone()).unwrap();
+
+		// when
+		let account = SafeAccount::create(&keypair, [0u8; 16], password, 1024, "Test".to_owned(), "{}".to_owned());
+		let res = directory.insert(account);
+
+
+		// then
+		assert!(res.is_ok(), "Should save account succesfuly.");
+
+		// cleanup
+		fs::remove_dir_all(dir).unwrap();
 	}
 }

--- a/ethstore/src/dir/disk.rs
+++ b/ethstore/src/dir/disk.rs
@@ -101,7 +101,7 @@ impl KeyDirectory for DiskDirectory {
 
 		// build file path
 		let filename = account.filename.as_ref().cloned().unwrap_or_else(|| {
-			let timestamp = time::strftime("%Y-%m-%dT%H-%M-%S", &time::now_utc()).unwrap_or("???".to_owned());
+			let timestamp = time::strftime("%Y-%m-%dT%H-%M-%S", &time::now_utc()).expect("Time-format string is valid.");
 			format!("UTC--{}Z--{:?}", timestamp, account.address)
 		});
 

--- a/ethstore/src/import.rs
+++ b/ethstore/src/import.rs
@@ -14,15 +14,20 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
+use std::collections::HashSet;
 use ethkey::Address;
 use dir::KeyDirectory;
 use Error;
 
 pub fn import_accounts(src: &KeyDirectory, dst: &KeyDirectory) -> Result<Vec<Address>, Error> {
 	let accounts = try!(src.load());
-	accounts.into_iter().map(|a| {
-		let address = a.address.clone();
-		try!(dst.insert(a));
-		Ok(address)
-	}).collect()
+	let existing_accounts = try!(dst.load()).into_iter().map(|a| a.address).collect::<HashSet<_>>();
+
+	accounts.into_iter()
+		.filter(|a| !existing_accounts.contains(&a.address))
+		.map(|a| {
+			let address = a.address.clone();
+			try!(dst.insert(a));
+			Ok(address)
+		}).collect()
 }


### PR DESCRIPTION
1. `:` is not valid part of filename on windows
2. `From<KeyFile>` implementation removed and replaced with `SafeAccount::from_file` usage.

I'm still doing some more tests to confirm that those issues are solved:
Closes #1808 
Closes #1809 