### PR TITLE
Fix up the VM trace.

### DIFF
--- a/ethcore/src/executive.rs
+++ b/ethcore/src/executive.rs
@@ -99,11 +99,11 @@ impl<'a> Executive<'a> {
 		let check = options.check_nonce;
 		match options.tracing {
 			true => match options.vm_tracing {
-				true => self.transact_with_tracer(t, check, ExecutiveTracer::default(), ExecutiveVMTracer::default()),
+				true => self.transact_with_tracer(t, check, ExecutiveTracer::default(), ExecutiveVMTracer::toplevel()),
 				false => self.transact_with_tracer(t, check, ExecutiveTracer::default(), NoopVMTracer),
 			},
 			false => match options.vm_tracing {
-				true => self.transact_with_tracer(t, check, NoopTracer, ExecutiveVMTracer::default()),
+				true => self.transact_with_tracer(t, check, NoopTracer, ExecutiveVMTracer::toplevel()),
 				false => self.transact_with_tracer(t, check, NoopTracer, NoopVMTracer),
 			},
 		}

--- a/ethcore/src/executive.rs
+++ b/ethcore/src/executive.rs
@@ -634,7 +634,7 @@ mod tests {
 		let engine = TestEngine::new(5);
 		let mut substate = Substate::new();
 		let mut tracer = ExecutiveTracer::default();
-		let mut vm_tracer = ExecutiveVMTracer::default();
+		let mut vm_tracer = ExecutiveVMTracer::toplevel();
 
 		let gas_left = {
 			let mut ex = Executive::new(&mut state, &info, &engine, &factory);
@@ -693,7 +693,7 @@ mod tests {
 			],
 			subs: vec![
 				VMTrace {
-					parent_step: 7,
+					parent_step: 6,
 					code: vec![96, 16, 128, 96, 12, 96, 0, 57, 96, 0, 243, 0, 96, 0, 53, 84, 21, 96, 9, 87, 0, 91, 96, 32, 53, 96, 0, 53, 85],
 					operations: vec![
 						VMOperation { pc: 0, instruction: 96, gas_cost: 3.into(), executed: Some(VMExecutedOperation { gas_used: 67976.into(), stack_push: vec_into![16], mem_diff: None, store_diff: None }) },
@@ -743,7 +743,7 @@ mod tests {
 		let engine = TestEngine::new(5);
 		let mut substate = Substate::new();
 		let mut tracer = ExecutiveTracer::default();
-		let mut vm_tracer = ExecutiveVMTracer::default();
+		let mut vm_tracer = ExecutiveVMTracer::toplevel();
 
 		let gas_left = {
 			let mut ex = Executive::new(&mut state, &info, &engine, &factory);

--- a/ethcore/src/trace/executive_tracer.rs
+++ b/ethcore/src/trace/executive_tracer.rs
@@ -160,9 +160,22 @@ impl Tracer for ExecutiveTracer {
 }
 
 /// Simple VM tracer. Traces all operations.
-#[derive(Default)]
 pub struct ExecutiveVMTracer {
 	data: VMTrace,
+}
+
+impl ExecutiveVMTracer {
+	/// Create a new top-level instance.
+	pub fn toplevel() -> Self {
+		ExecutiveVMTracer {
+			data: VMTrace {
+				parent_step: 0,
+				code: vec![],
+				operations: vec![Default::default()],	// prefill with a single entry so that prepare_subtrace can get the parent_step
+				subs: vec![],
+			}
+		}
+	}
 }
 
 impl VMTracer for ExecutiveVMTracer {
@@ -188,7 +201,7 @@ impl VMTracer for ExecutiveVMTracer {
 
 	fn prepare_subtrace(&self, code: &[u8]) -> Self {
 		ExecutiveVMTracer { data: VMTrace {
-			parent_step: self.data.operations.len(),
+			parent_step: self.data.operations.len() - 1,	// won't overflow since we must already have pushed an operation in trace_prepare_execute.
 			code: code.to_vec(),
 			operations: vec![],
 			subs: vec![],

--- a/ethcore/src/types/trace_types/trace.rs
+++ b/ethcore/src/types/trace_types/trace.rs
@@ -473,7 +473,7 @@ impl Decodable for VMExecutedOperation {
 	}
 }
 
-#[derive(Debug, Clone, PartialEq, Binary)]
+#[derive(Debug, Clone, PartialEq, Binary, Default)]
 /// A record of the execution of a single VM operation.
 pub struct VMOperation {
 	/// The program counter.


### PR DESCRIPTION
VM tracing didn't quite match up the `CALL` with the subtrace - the `parent_step` was one too big. this fixes it by reducing it by one.