### PR TITLE
Add non-key addresses for JSONRPC

### DIFF
--- a/ethcore/src/account_provider.rs
+++ b/ethcore/src/account_provider.rs
@@ -142,7 +142,6 @@ impl AddressBook {
 	pub fn new(path: String) -> Self {
 		trace!(target: "addressbook", "new({})", path);
 		let mut path: PathBuf = path.into();
-		path.pop();
 		path.push("address_book.json");
 		trace!(target: "addressbook", "path={:?}", path);
 		let mut r = AddressBook {
@@ -387,9 +386,23 @@ impl AccountProvider {
 
 #[cfg(test)]
 mod tests {
-	use super::AccountProvider;
+	use super::{AccountProvider, AddressBook};
+	use std::collections::HashMap;
+	use ethjson::misc::AccountMeta;
 	use ethstore::ethkey::{Generator, Random};
 	use std::time::Duration;
+	use devtools::RandomTempPath;
+
+	#[test]
+	fn should_save_and_reload_address_book() {
+		let temp = RandomTempPath::create_dir();
+		let path = temp.as_str().to_owned();
+		let mut b = AddressBook::new(path.clone());
+		b.set_name(1.into(), "One".to_owned());
+		b.set_meta(1.into(), "{1:1}".to_owned());
+		let b = AddressBook::new(path);
+		assert_eq!(b.get(), hash_map![1.into() => AccountMeta{name: "One".to_owned(), meta: "{1:1}".to_owned(), uuid: None}]);
+	}
 
 	#[test]
 	fn unlock_account_temp() {

--- a/ethstore/src/dir/disk.rs
+++ b/ethstore/src/dir/disk.rs
@@ -149,6 +149,8 @@ impl KeyDirectory for DiskDirectory {
 			Some((path, _)) => fs::remove_file(path).map_err(From::from)
 		}
 	}
+
+	fn path(&self) -> Option<&PathBuf> { Some(&self.path) }
 }
 
 

--- a/ethstore/src/dir/disk.rs
+++ b/ethstore/src/dir/disk.rs
@@ -22,7 +22,7 @@ use ethkey::Address;
 use {json, SafeAccount, Error};
 use super::KeyDirectory;
 
-const IGNORED_FILES: &'static [&'static str] = &["thumbs.db"];
+const IGNORED_FILES: &'static [&'static str] = &["thumbs.db", "address_book.json"];
 
 #[cfg(not(windows))]
 fn restrict_permissions_to_owner(file_path: &Path) -> Result<(), i32>  {

--- a/ethstore/src/dir/mod.rs
+++ b/ethstore/src/dir/mod.rs
@@ -15,6 +15,7 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 use ethkey::Address;
+use std::path::{PathBuf};
 use {SafeAccount, Error};
 
 mod disk;
@@ -30,6 +31,7 @@ pub trait KeyDirectory: Send + Sync {
 	fn load(&self) -> Result<Vec<SafeAccount>, Error>;
 	fn insert(&self, account: SafeAccount) -> Result<SafeAccount, Error>;
 	fn remove(&self, address: &Address) -> Result<(), Error>;
+	fn path(&self) -> Option<&PathBuf> { None }
 }
 
 pub use self::disk::DiskDirectory;

--- a/ethstore/src/ethstore.rs
+++ b/ethstore/src/ethstore.rs
@@ -173,4 +173,8 @@ impl SecretStore for EthStore {
 		// save to file
 		self.save(account)
 	}
+
+	fn local_path(&self) -> String {
+		self.dir.path().map(|p| p.to_string_lossy().into_owned()).unwrap_or_else(|| String::new())
+	} 
 }

--- a/ethstore/src/secret_store.rs
+++ b/ethstore/src/secret_store.rs
@@ -42,5 +42,7 @@ pub trait SecretStore: Send + Sync {
 	fn set_name(&self, address: &Address, name: String) -> Result<(), Error>;
 
 	fn set_meta(&self, address: &Address, meta: String) -> Result<(), Error>;
+
+	fn local_path(&self) -> String;
 }
 

--- a/json/src/hash.rs
+++ b/json/src/hash.rs
@@ -17,8 +17,9 @@
 //! Lenient hash json deserialization for test json files.
 
 use std::str::FromStr;
-use serde::{Deserialize, Deserializer, Error};
+use serde::{Deserialize, Deserializer, Serialize, Serializer, Error};
 use serde::de::Visitor;
+use rustc_serialize::hex::ToHex;
 use util::hash::{H64 as Hash64, Address as Hash160, H256 as Hash256, H2048 as Hash2048};
 
 
@@ -31,6 +32,12 @@ macro_rules! impl_hash {
 		impl Into<$inner> for $name {
 			fn into(self) -> $inner {
 				self.0
+			}
+		}
+
+		impl From<$inner> for $name {
+			fn from(i: $inner) -> Self {
+				$name(i)
 			}
 		}
 
@@ -64,6 +71,14 @@ macro_rules! impl_hash {
 				}
 
 				deserializer.deserialize(HashVisitor)
+			}
+		}
+
+		impl Serialize for $name {
+			fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error> where S: Serializer {
+				let mut hex = "0x".to_owned();
+				hex.push_str(&self.0.to_hex());
+				serializer.serialize_str(&hex)
 			}
 		}
 	}

--- a/json/src/misc/account_meta.rs
+++ b/json/src/misc/account_meta.rs
@@ -1,0 +1,58 @@
+// Copyright 2015, 2016 Ethcore (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Misc deserialization.
+
+use std::io::{Read, Write};
+use std::collections::HashMap;
+use serde_json;
+use util;
+use hash;
+
+/// Collected account metadata
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct AccountMeta {
+	/// The name of the account.
+	pub name: String,
+	/// The rest of the metadata of the account.
+	pub meta: String,
+	/// The 128-bit UUID of the account, if it has one (brain-wallets don't).
+	pub uuid: Option<String>,
+}
+
+impl Default for AccountMeta {
+	fn default() -> Self {
+		AccountMeta {
+			name: String::new(),
+			meta: "{}".to_owned(),
+			uuid: None,
+		}
+	}
+}
+
+impl AccountMeta {
+	/// Read a hash map of Address -> AccountMeta.
+	pub fn read_address_map<R>(reader: R) -> Result<HashMap<util::Address, AccountMeta>, serde_json::Error> where R: Read {
+		serde_json::from_reader(reader).map(|ok: HashMap<hash::Address, AccountMeta>|
+			ok.into_iter().map(|(a, m)| (a.into(), m)).collect()
+		)
+	}
+
+	/// Write a hash map of Address -> AccountMeta.  
+	pub fn write_address_map<W>(m: &HashMap<util::Address, AccountMeta>, writer: &mut W) -> Result<(), serde_json::Error> where W: Write {
+		serde_json::to_writer(writer, &m.iter().map(|(a, m)| (a.clone().into(), m)).collect::<HashMap<hash::Address, _>>())
+	}
+}

--- a/json/src/misc/mod.rs
+++ b/json/src/misc/mod.rs
@@ -14,19 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-extern crate rustc_serialize;
-extern crate serde;
-extern crate serde_json;
-extern crate ethcore_util as util;
+//! Misc deserialization.
 
-pub mod hash;
-pub mod uint;
-pub mod bytes;
-pub mod blockchain;
-pub mod spec;
-pub mod trie;
-pub mod vm;
-pub mod maybe;
-pub mod state;
-pub mod transaction;
-pub mod misc;
+mod account_meta;
+
+pub use self::account_meta::AccountMeta;


### PR DESCRIPTION
Fixes #1895 

Lots of ways to do this and this will probably get refactored into something more substantial long-term, but for now it delivers the required functionality, it's quick and it's minimally invasive.

- Add `AddressBook` JSON disk-backed map from `Address` -> `AccountMeta` (move `AccountMeta` into `ethcore-json` module and implement derialization and deserialization).
- Add corresponding address book access/modifier functions to `AccountProvider`.
- Add conduits to let `AccountProvider` derive the local keys path from `SecretStore`.
- Augment the JSONRPC accounts functionality to include entries from the address book.

Future work:
- ~~Tests for `AddressBook`~~.
- Consider moving `AddressBook` into `ethstore` module altogether.
- Consider encrypting contents of disk-backed file.
- Consider using database rather than JSON file.
- Consider adding name-based indexing.