### PR TITLE
RPC for importing geth keys

### DIFF
--- a/ethcore/src/account_provider.rs
+++ b/ethcore/src/account_provider.rs
@@ -142,7 +142,6 @@ impl AddressBook {
 	pub fn new(path: String) -> Self {
 		trace!(target: "addressbook", "new({})", path);
 		let mut path: PathBuf = path.into();
-		path.pop();
 		path.push("address_book.json");
 		trace!(target: "addressbook", "path={:?}", path);
 		let mut r = AddressBook {
@@ -387,9 +386,23 @@ impl AccountProvider {
 
 #[cfg(test)]
 mod tests {
-	use super::AccountProvider;
+	use super::{AccountProvider, AddressBook};
+	use std::collections::HashMap;
+	use ethjson::misc::AccountMeta;
 	use ethstore::ethkey::{Generator, Random};
 	use std::time::Duration;
+	use devtools::RandomTempPath;
+
+	#[test]
+	fn should_save_and_reload_address_book() {
+		let temp = RandomTempPath::create_dir();
+		let path = temp.as_str().to_owned();
+		let mut b = AddressBook::new(path.clone());
+		b.set_name(1.into(), "One".to_owned());
+		b.set_meta(1.into(), "{1:1}".to_owned());
+		let b = AddressBook::new(path);
+		assert_eq!(b.get(), hash_map![1.into() => AccountMeta{name: "One".to_owned(), meta: "{1:1}".to_owned(), uuid: None}]);
+	}
 
 	#[test]
 	fn unlock_account_temp() {

--- a/ethcore/src/account_provider.rs
+++ b/ethcore/src/account_provider.rs
@@ -382,6 +382,17 @@ impl AccountProvider {
 		let signature = try!(self.sstore.sign(&account, &password, &message));
 		Ok(H520(signature.into()))
 	}
+
+	/// Returns the underlying `SecretStore` reference if one exists.
+	pub fn list_geth_accounts(&self, testnet: bool) -> Vec<H160> {
+		self.sstore.list_geth_accounts(testnet).into_iter().map(|a| Address::from(a).into()).collect()
+	}
+
+	/// Returns the underlying `SecretStore` reference if one exists.
+	pub fn import_geth_accounts(&self, desired: Vec<H160>, testnet: bool) -> Result<Vec<H160>, Error> {
+		let desired = desired.into_iter().map(|a| Address::from(a).into()).collect();
+		Ok(try!(self.sstore.import_geth_accounts(desired, testnet)).into_iter().map(|a| Address::from(a).into()).collect())
+	}
 }
 
 #[cfg(test)]

--- a/ethstore/src/dir/disk.rs
+++ b/ethstore/src/dir/disk.rs
@@ -149,6 +149,8 @@ impl KeyDirectory for DiskDirectory {
 			Some((path, _)) => fs::remove_file(path).map_err(From::from)
 		}
 	}
+
+	fn path(&self) -> Option<&PathBuf> { Some(&self.path) }
 }
 
 

--- a/ethstore/src/dir/disk.rs
+++ b/ethstore/src/dir/disk.rs
@@ -22,7 +22,7 @@ use ethkey::Address;
 use {json, SafeAccount, Error};
 use super::KeyDirectory;
 
-const IGNORED_FILES: &'static [&'static str] = &["thumbs.db"];
+const IGNORED_FILES: &'static [&'static str] = &["thumbs.db", "address_book.json"];
 
 #[cfg(not(windows))]
 fn restrict_permissions_to_owner(file_path: &Path) -> Result<(), i32>  {

--- a/ethstore/src/dir/mod.rs
+++ b/ethstore/src/dir/mod.rs
@@ -15,6 +15,7 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 use ethkey::Address;
+use std::path::{PathBuf};
 use {SafeAccount, Error};
 
 mod disk;
@@ -30,6 +31,7 @@ pub trait KeyDirectory: Send + Sync {
 	fn load(&self) -> Result<Vec<SafeAccount>, Error>;
 	fn insert(&self, account: SafeAccount) -> Result<SafeAccount, Error>;
 	fn remove(&self, address: &Address) -> Result<(), Error>;
+	fn path(&self) -> Option<&PathBuf> { None }
 }
 
 pub use self::disk::DiskDirectory;

--- a/ethstore/src/ethstore.rs
+++ b/ethstore/src/ethstore.rs
@@ -27,6 +27,7 @@ use {Error, SecretStore};
 use json;
 use json::UUID;
 use presale::PresaleWallet;
+use import;
 
 pub struct EthStore {
 	dir: Box<KeyDirectory>,
@@ -176,5 +177,13 @@ impl SecretStore for EthStore {
 
 	fn local_path(&self) -> String {
 		self.dir.path().map(|p| p.to_string_lossy().into_owned()).unwrap_or_else(|| String::new())
-	} 
+	}
+
+	fn list_geth_accounts(&self, testnet: bool) -> Vec<Address> {
+		import::read_geth_accounts(testnet)
+	}
+
+	fn import_geth_accounts(&self, desired: Vec<Address>, testnet: bool) -> Result<Vec<Address>, Error> {
+		import::import_geth_accounts(&*self.dir, desired.into_iter().collect(), testnet)
+	}
 }

--- a/ethstore/src/ethstore.rs
+++ b/ethstore/src/ethstore.rs
@@ -173,4 +173,8 @@ impl SecretStore for EthStore {
 		// save to file
 		self.save(account)
 	}
+
+	fn local_path(&self) -> String {
+		self.dir.path().map(|p| p.to_string_lossy().into_owned()).unwrap_or_else(|| String::new())
+	} 
 }

--- a/ethstore/src/lib.rs
+++ b/ethstore/src/lib.rs
@@ -48,8 +48,7 @@ mod secret_store;
 pub use self::account::SafeAccount;
 pub use self::error::Error;
 pub use self::ethstore::EthStore;
-pub use self::import::import_accounts;
+pub use self::import::{import_accounts, read_geth_accounts};
 pub use self::presale::PresaleWallet;
 pub use self::secret_store::SecretStore;
 pub use self::random::random_phrase;
-

--- a/ethstore/src/secret_store.rs
+++ b/ethstore/src/secret_store.rs
@@ -44,5 +44,9 @@ pub trait SecretStore: Send + Sync {
 	fn set_meta(&self, address: &Address, meta: String) -> Result<(), Error>;
 
 	fn local_path(&self) -> String;
+
+	fn list_geth_accounts(&self, testnet: bool) -> Vec<Address>;
+
+	fn import_geth_accounts(&self, desired: Vec<Address>, testnet: bool) -> Result<Vec<Address>, Error>;
 }
 

--- a/ethstore/src/secret_store.rs
+++ b/ethstore/src/secret_store.rs
@@ -42,5 +42,7 @@ pub trait SecretStore: Send + Sync {
 	fn set_name(&self, address: &Address, name: String) -> Result<(), Error>;
 
 	fn set_meta(&self, address: &Address, meta: String) -> Result<(), Error>;
+
+	fn local_path(&self) -> String;
 }
 

--- a/json/src/hash.rs
+++ b/json/src/hash.rs
@@ -17,8 +17,9 @@
 //! Lenient hash json deserialization for test json files.
 
 use std::str::FromStr;
-use serde::{Deserialize, Deserializer, Error};
+use serde::{Deserialize, Deserializer, Serialize, Serializer, Error};
 use serde::de::Visitor;
+use rustc_serialize::hex::ToHex;
 use util::hash::{H64 as Hash64, Address as Hash160, H256 as Hash256, H2048 as Hash2048};
 
 
@@ -31,6 +32,12 @@ macro_rules! impl_hash {
 		impl Into<$inner> for $name {
 			fn into(self) -> $inner {
 				self.0
+			}
+		}
+
+		impl From<$inner> for $name {
+			fn from(i: $inner) -> Self {
+				$name(i)
 			}
 		}
 
@@ -64,6 +71,14 @@ macro_rules! impl_hash {
 				}
 
 				deserializer.deserialize(HashVisitor)
+			}
+		}
+
+		impl Serialize for $name {
+			fn serialize<S>(&self, serializer: &mut S) -> Result<(), S::Error> where S: Serializer {
+				let mut hex = "0x".to_owned();
+				hex.push_str(&self.0.to_hex());
+				serializer.serialize_str(&hex)
 			}
 		}
 	}

--- a/json/src/misc/account_meta.rs
+++ b/json/src/misc/account_meta.rs
@@ -1,0 +1,58 @@
+// Copyright 2015, 2016 Ethcore (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Misc deserialization.
+
+use std::io::{Read, Write};
+use std::collections::HashMap;
+use serde_json;
+use util;
+use hash;
+
+/// Collected account metadata
+#[derive(Clone, Debug, PartialEq, Serialize, Deserialize)]
+pub struct AccountMeta {
+	/// The name of the account.
+	pub name: String,
+	/// The rest of the metadata of the account.
+	pub meta: String,
+	/// The 128-bit UUID of the account, if it has one (brain-wallets don't).
+	pub uuid: Option<String>,
+}
+
+impl Default for AccountMeta {
+	fn default() -> Self {
+		AccountMeta {
+			name: String::new(),
+			meta: "{}".to_owned(),
+			uuid: None,
+		}
+	}
+}
+
+impl AccountMeta {
+	/// Read a hash map of Address -> AccountMeta.
+	pub fn read_address_map<R>(reader: R) -> Result<HashMap<util::Address, AccountMeta>, serde_json::Error> where R: Read {
+		serde_json::from_reader(reader).map(|ok: HashMap<hash::Address, AccountMeta>|
+			ok.into_iter().map(|(a, m)| (a.into(), m)).collect()
+		)
+	}
+
+	/// Write a hash map of Address -> AccountMeta.  
+	pub fn write_address_map<W>(m: &HashMap<util::Address, AccountMeta>, writer: &mut W) -> Result<(), serde_json::Error> where W: Write {
+		serde_json::to_writer(writer, &m.iter().map(|(a, m)| (a.clone().into(), m)).collect::<HashMap<hash::Address, _>>())
+	}
+}

--- a/json/src/misc/mod.rs
+++ b/json/src/misc/mod.rs
@@ -14,19 +14,8 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-extern crate rustc_serialize;
-extern crate serde;
-extern crate serde_json;
-extern crate ethcore_util as util;
+//! Misc deserialization.
 
-pub mod hash;
-pub mod uint;
-pub mod bytes;
-pub mod blockchain;
-pub mod spec;
-pub mod trie;
-pub mod vm;
-pub mod maybe;
-pub mod state;
-pub mod transaction;
-pub mod misc;
+mod account_meta;
+
+pub use self::account_meta::AccountMeta;

--- a/parity/cli.rs
+++ b/parity/cli.rs
@@ -19,7 +19,7 @@ use docopt::Docopt;
 
 pub const USAGE: &'static str = r#"
 Parity. Ethereum Client.
-  By Wood/Paronyan/Kotewicz/Drwięga/Volf/.
+  By Wood/Paronyan/Kotewicz/Drwięga/Volf et al.
   Copyright 2015, 2016 Ethcore (UK) Limited
 
 Usage:

--- a/parity/cli.rs
+++ b/parity/cli.rs
@@ -19,7 +19,7 @@ use docopt::Docopt;
 
 pub const USAGE: &'static str = r#"
 Parity. Ethereum Client.
-  By Wood/Paronyan/Kotewicz/Drwięga/Volf.
+  By Wood/Paronyan/Kotewicz/Drwięga/Volf/.
   Copyright 2015, 2016 Ethcore (UK) Limited
 
 Usage:
@@ -67,7 +67,6 @@ Account Options:
   --keys-iterations NUM    Specify the number of iterations to use when
                            deriving key from the password (bigger is more
                            secure) [default: 10240].
-  --no-import-keys         Do not import keys from legacy clients.
   --force-signer           Enable Trusted Signer WebSocket endpoint used by
                            Signer UIs, even when --unlock is in use.
   --no-signer              Disable Trusted Signer WebSocket endpoint used by
@@ -248,6 +247,7 @@ Legacy Options:
   --testnet                Geth-compatible testnet mode. Equivalent to --chain
                            testnet --keys-path $HOME/parity/testnet-keys.
                            Overrides the --keys-path option.
+  --import-geth-keys       Attempt to import keys from Geth client.
   --datadir PATH           Equivalent to --db-path PATH.
   --networkid INDEX        Equivalent to --network-id INDEX.
   --peers NUM              Equivalent to --min-peers NUM.
@@ -310,7 +310,7 @@ pub struct Args {
 	pub flag_password: Vec<String>,
 	pub flag_keys_path: String,
 	pub flag_keys_iterations: u32,
-	pub flag_no_import_keys: bool,
+	pub flag_import_geth_keys: bool,
 	pub flag_bootnodes: Option<String>,
 	pub flag_network_id: Option<String>,
 	pub flag_pruning: String,

--- a/parity/configuration.rs
+++ b/parity/configuration.rs
@@ -310,7 +310,7 @@ impl Configuration {
 	fn accounts_config(&self) -> Result<AccountsConfig, String> {
 		let cfg = AccountsConfig {
 			iterations: self.args.flag_keys_iterations,
-			import_keys: !self.args.flag_no_import_keys,
+			import_keys: self.args.flag_import_geth_keys,
 			testnet: self.args.flag_testnet,
 			password_files: self.args.flag_password.clone(),
 			unlocked_accounts: try!(to_addresses(&self.args.flag_unlock)),

--- a/parity/params.rs
+++ b/parity/params.rs
@@ -167,7 +167,7 @@ impl Default for AccountsConfig {
 	fn default() -> Self {
 		AccountsConfig {
 			iterations: 10240,
-			import_keys: true,
+			import_keys: false,
 			testnet: false,
 			password_files: Vec::new(),
 			unlocked_accounts: Vec::new(),

--- a/rpc/src/v1/impls/personal.rs
+++ b/rpc/src/v1/impls/personal.rs
@@ -184,4 +184,21 @@ impl<C: 'static, M: 'static> Personal for PersonalClient<C, M> where C: MiningBl
 			(format!("0x{}", a.hex()), Value::Object(m))
 		}).collect::<BTreeMap<_, _>>()))
 	}
+
+	fn geth_accounts(&self, params: Params) -> Result<Value, Error> {
+		try!(self.active());
+		try!(expect_no_params(params));
+		let store = take_weak!(self.accounts);
+		to_value(&store.list_geth_accounts(false).into_iter().map(Into::into).collect::<Vec<RpcH160>>())
+	}
+
+	fn import_geth_accounts(&self, params: Params) -> Result<Value, Error> {
+		from_params::<(Vec<RpcH160>,)>(params).and_then(|(addresses,)| {
+			let store = take_weak!(self.accounts);
+			to_value(&try!(store
+				.import_geth_accounts(addresses.into_iter().map(Into::into).collect(), false)
+				.map_err(|e| errors::account("Couldn't import Geth accounts", e))
+			).into_iter().map(Into::into).collect::<Vec<RpcH160>>())
+		})
+	}
 }

--- a/rpc/src/v1/traits/personal.rs
+++ b/rpc/src/v1/traits/personal.rs
@@ -54,6 +54,12 @@ pub trait Personal: Sized + Send + Sync + 'static {
 	/// Returns accounts information.
 	fn accounts_info(&self, _: Params) -> Result<Value, Error>;
 
+	/// Returns the accounts available for importing from Geth.
+	fn geth_accounts(&self, _: Params) -> Result<Value, Error>;
+
+	/// Imports a number of Geth accounts, with the list provided as the argument.
+	fn import_geth_accounts(&self, _: Params) -> Result<Value, Error>;
+
 	/// Should be used to convert object to io delegate.
 	fn to_delegate(self) -> IoDelegate<Self> {
 		let mut delegate = IoDelegate::new(Arc::new(self));
@@ -67,6 +73,8 @@ pub trait Personal: Sized + Send + Sync + 'static {
 		delegate.add_method("personal_setAccountName", Personal::set_account_name);
 		delegate.add_method("personal_setAccountMeta", Personal::set_account_meta);
 		delegate.add_method("personal_accountsInfo", Personal::accounts_info);
+		delegate.add_method("personal_listGethAccounts", Personal::geth_accounts);
+		delegate.add_method("personal_importGethAccounts", Personal::import_geth_accounts);
 
 		delegate
 	}


### PR DESCRIPTION
Closes #1906 
Depends on #1914

Two RPCs:
- `personal_listGethAccounts` `()` *returns* `[account0, account1, ...]` for each key found in the Geth key store.
- `personal_importGethAccounts` `([account0, account1, ...])` *returns* `[imported0, imported1, ...]` will import each given account into the Parity key store.

Importing Geth keys now done either through an explicit CLI option `--import-geth-keys` or through the on-ramping in the UI.