### PR TITLE
Migrate rlp from ElasticArray to SmallVec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,6 +499,7 @@ dependencies = [
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha3 0.1.0",
+ "smallvec 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
  "table 0.1.0",
  "target_info 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,7 +499,7 @@ dependencies = [
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha3 0.1.0",
- "smallvec 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)",
+ "smallvec 0.1.8 (git+https://github.com/servo/rust-smallvec)",
  "table 0.1.0",
  "target_info 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1373,6 +1373,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "smallvec"
 version = "0.1.8"
+source = "git+https://github.com/servo/rust-smallvec#7e07fc01b2af4ba60994303dfcdf27f78bc9752c"
+
+[[package]]
+name = "smallvec"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1747,6 +1752,7 @@ dependencies = [
 "checksum slab 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d807fd58c4181bbabed77cb3b891ba9748241a552bcc5be698faaebefc54f46e"
 "checksum slab 0.2.0 (git+https://github.com/carllerche/slab?rev=5476efcafb)" = "<none>"
 "checksum slab 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6dbdd334bd28d328dad1c41b0ea662517883d8880d8533895ef96c8003dec9c4"
+"checksum smallvec 0.1.8 (git+https://github.com/servo/rust-smallvec)" = "<none>"
 "checksum smallvec 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "fcc8d19212aacecf95e4a7a2179b26f7aeb9732a915cf01f05b0d3e044865410"
 "checksum solicit 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "172382bac9424588d7840732b250faeeef88942e37b6e35317dce98cafdd75b2"
 "checksum spmc 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "93bdab61c1a413e591c4d17388ffa859eaff2df27f1e13a5ec8b716700605adf"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -499,7 +499,7 @@ dependencies = [
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc_version 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "sha3 0.1.0",
- "smallvec 0.1.8 (git+https://github.com/servo/rust-smallvec)",
+ "smallvec 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "table 0.1.0",
  "target_info 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1373,11 +1373,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "smallvec"
 version = "0.1.8"
-source = "git+https://github.com/servo/rust-smallvec#7e07fc01b2af4ba60994303dfcdf27f78bc9752c"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "smallvec"
-version = "0.1.8"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
@@ -1752,8 +1752,8 @@ dependencies = [
 "checksum slab 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d807fd58c4181bbabed77cb3b891ba9748241a552bcc5be698faaebefc54f46e"
 "checksum slab 0.2.0 (git+https://github.com/carllerche/slab?rev=5476efcafb)" = "<none>"
 "checksum slab 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "6dbdd334bd28d328dad1c41b0ea662517883d8880d8533895ef96c8003dec9c4"
-"checksum smallvec 0.1.8 (git+https://github.com/servo/rust-smallvec)" = "<none>"
 "checksum smallvec 0.1.8 (registry+https://github.com/rust-lang/crates.io-index)" = "fcc8d19212aacecf95e4a7a2179b26f7aeb9732a915cf01f05b0d3e044865410"
+"checksum smallvec 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "9907c67eff60f46cbc2847fb0be5bd1ec54e73c0c7dc07bb97a83236179d016d"
 "checksum solicit 0.4.4 (registry+https://github.com/rust-lang/crates.io-index)" = "172382bac9424588d7840732b250faeeef88942e37b6e35317dce98cafdd75b2"
 "checksum spmc 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)" = "93bdab61c1a413e591c4d17388ffa859eaff2df27f1e13a5ec8b716700605adf"
 "checksum stable-heap 0.1.0 (git+https://github.com/carllerche/stable-heap?rev=3c5cd1ca47)" = "<none>"

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -32,8 +32,8 @@ parking_lot = "0.2.6"
 using_queue = { path = "using_queue" }
 table = { path = "table" }
 ansi_term = "0.7"
-# smallvec = "0.1.8"
-smallvec = { git = "https://github.com/servo/rust-smallvec" }
+smallvec = "0.2"
+# smallvec = { git = "https://github.com/servo/rust-smallvec" }
 
 [features]
 default = []

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -32,6 +32,7 @@ parking_lot = "0.2.6"
 using_queue = { path = "using_queue" }
 table = { path = "table" }
 ansi_term = "0.7"
+smallvec = "0.1.8"
 
 [features]
 default = []

--- a/util/Cargo.toml
+++ b/util/Cargo.toml
@@ -32,7 +32,8 @@ parking_lot = "0.2.6"
 using_queue = { path = "using_queue" }
 table = { path = "table" }
 ansi_term = "0.7"
-smallvec = "0.1.8"
+# smallvec = "0.1.8"
+smallvec = { git = "https://github.com/servo/rust-smallvec" }
 
 [features]
 default = []

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -112,6 +112,7 @@ extern crate parking_lot;
 pub extern crate using_queue;
 pub extern crate table;
 extern crate ansi_term;
+extern crate smallvec;
 
 pub mod bloom;
 pub mod standard;

--- a/util/src/rlp/bytes.rs
+++ b/util/src/rlp/bytes.rs
@@ -23,44 +23,7 @@ use std::cmp::Ordering;
 use std::error::Error as StdError;
 use bigint::uint::{Uint, U128, U256};
 use hash::{H64, H128, H160, H256, H512, H520, H2048};
-use elastic_array::*;
-
-/// Vector like object
-pub trait VecLike<T> {
-	/// Add an element to the collection
-    fn vec_push(&mut self, value: T);
-
-	/// Add a slice to the collection
-    fn vec_extend(&mut self, slice: &[T]);
-}
-
-impl<T> VecLike<T> for Vec<T> where T: Copy {
-	fn vec_push(&mut self, value: T) {
-		Vec::<T>::push(self, value)
-	}
-
-	fn vec_extend(&mut self, slice: &[T]) {
-		Vec::<T>::extend_from_slice(self, slice)
-	}
-}
-
-macro_rules! impl_veclike_for_elastic_array {
-	($from: ident) => {
-		impl<T> VecLike<T> for $from<T> where T: Copy {
-			fn vec_push(&mut self, value: T) {
-				$from::<T>::push(self, value)
-			}
-			fn vec_extend(&mut self, slice: &[T]) {
-				$from::<T>::append_slice(self, slice)
-
-			}
-		}
-	}
-}
-
-impl_veclike_for_elastic_array!(ElasticArray16);
-impl_veclike_for_elastic_array!(ElasticArray32);
-impl_veclike_for_elastic_array!(ElasticArray1024);
+use smallvec::VecLike;
 
 /// Converts given type to its shortest representation in bytes
 ///
@@ -74,7 +37,9 @@ pub trait ToBytes {
 
 impl <'a> ToBytes for &'a str {
 	fn to_bytes<V: VecLike<u8>>(&self, out: &mut V) {
-		out.vec_extend(self.as_bytes());
+		for &byte in self.as_bytes() {
+			out.push(byte);
+		}
 	}
 
 	fn to_bytes_len(&self) -> usize {
@@ -84,7 +49,9 @@ impl <'a> ToBytes for &'a str {
 
 impl ToBytes for String {
 	fn to_bytes<V: VecLike<u8>>(&self, out: &mut V) {
-		out.vec_extend(self.as_bytes());
+		for &byte in self.as_bytes() {
+			out.push(byte);
+		}
 	}
 
 	fn to_bytes_len(&self) -> usize {
@@ -97,7 +64,7 @@ impl ToBytes for u64 {
 		let count = self.to_bytes_len();
 		for i in 0..count {
 			let j = count - 1 - i;
-			out.vec_push((*self >> (j * 8)) as u8);
+			out.push((*self >> (j * 8)) as u8);
 		}
 	}
 
@@ -106,7 +73,7 @@ impl ToBytes for u64 {
 
 impl ToBytes for bool {
 	fn to_bytes<V: VecLike<u8>>(&self, out: &mut V) {
-		out.vec_push(if *self { 1u8 } else { 0u8 })
+		out.push(if *self { 1u8 } else { 0u8 })
 	}
 
 	fn to_bytes_len(&self) -> usize { 1 }
@@ -135,7 +102,7 @@ macro_rules! impl_uint_to_bytes {
 				let count = self.to_bytes_len();
 				for i in 0..count {
 					let j = count - 1 - i;
-					out.vec_push(self.byte(j));
+					out.push(self.byte(j));
 				}
 			}
 			fn to_bytes_len(&self) -> usize { (self.bits() + 7) / 8 }
@@ -150,7 +117,9 @@ macro_rules! impl_hash_to_bytes {
 	($name: ident) => {
 		impl ToBytes for $name {
 			fn to_bytes<V: VecLike<u8>>(&self, out: &mut V) {
-				out.vec_extend(&self);
+				for &byte in self.0.iter() {
+					out.push(byte);
+				}
 			}
 			fn to_bytes_len(&self) -> usize { self.len() }
 		}

--- a/util/src/rlp/bytes.rs
+++ b/util/src/rlp/bytes.rs
@@ -37,9 +37,7 @@ pub trait ToBytes {
 
 impl <'a> ToBytes for &'a str {
 	fn to_bytes<V: VecLike<u8>>(&self, out: &mut V) {
-		for &byte in self.as_bytes() {
-			out.push(byte);
-		}
+		out.extend(self.as_bytes().iter().cloned());
 	}
 
 	fn to_bytes_len(&self) -> usize {
@@ -49,9 +47,7 @@ impl <'a> ToBytes for &'a str {
 
 impl ToBytes for String {
 	fn to_bytes<V: VecLike<u8>>(&self, out: &mut V) {
-		for &byte in self.as_bytes() {
-			out.push(byte);
-		}
+		out.extend(self.as_bytes().iter().cloned());
 	}
 
 	fn to_bytes_len(&self) -> usize {
@@ -117,9 +113,7 @@ macro_rules! impl_hash_to_bytes {
 	($name: ident) => {
 		impl ToBytes for $name {
 			fn to_bytes<V: VecLike<u8>>(&self, out: &mut V) {
-				for &byte in self.0.iter() {
-					out.push(byte);
-				}
+				out.extend(self.iter().cloned());
 			}
 			fn to_bytes_len(&self) -> usize { self.len() }
 		}

--- a/util/src/rlp/mod.rs
+++ b/util/src/rlp/mod.rs
@@ -64,7 +64,7 @@ pub use self::untrusted_rlp::{UntrustedRlp, UntrustedRlpIterator, PayloadInfo, P
 pub use self::rlpin::{Rlp, RlpIterator};
 pub use self::rlpstream::RlpStream;
 pub use self::rlpcompression::RlpType;
-pub use elastic_array::ElasticArray1024;
+pub use smallvec::SmallVec;
 use super::hash::H256;
 
 /// The RLP encoded empty data (used to mean "null value").
@@ -105,7 +105,7 @@ pub fn decode<T>(bytes: &[u8]) -> T where T: RlpDecodable {
 /// 	assert_eq!(out, vec![0x83, b'c', b'a', b't']);
 /// }
 /// ```
-pub fn encode<E>(object: &E) -> ElasticArray1024<u8> where E: RlpEncodable {
+pub fn encode<E>(object: &E) -> SmallVec<[u8; 1024]> where E: RlpEncodable {
 	let mut stream = RlpStream::new();
 	stream.append(object);
 	stream.drain()

--- a/util/src/rlp/rlpcompression.rs
+++ b/util/src/rlp/rlpcompression.rs
@@ -14,8 +14,9 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-use rlp::{UntrustedRlp, View, Compressible, encode, ElasticArray1024, Stream, RlpStream};
+use rlp::{UntrustedRlp, View, Compressible, encode, Stream, RlpStream};
 use rlp::commonrlps::{BLOCKS_RLP_SWAPPER, SNAPSHOT_RLP_SWAPPER};
+use smallvec::SmallVec;
 use std::collections::HashMap;
 
 /// Stores RLPs used for compression
@@ -59,14 +60,14 @@ pub enum RlpType {
 	Snapshot,
 }
 
-fn to_elastic(slice: &[u8]) -> ElasticArray1024<u8> {
-	let mut out = ElasticArray1024::new();
-	out.append_slice(slice);
+fn to_small_vec(slice: &[u8]) -> SmallVec<[u8; 1024]> {
+	let mut out = SmallVec::new();
+	out.extend(slice.iter().cloned());
 	out
 }
 
-fn map_rlp<F>(rlp: &UntrustedRlp, f: F) -> Option<ElasticArray1024<u8>> where
-	F: Fn(&UntrustedRlp) -> Option<ElasticArray1024<u8>> {
+fn map_rlp<F>(rlp: &UntrustedRlp, f: F) -> Option<SmallVec<[u8; 1024]>> where
+	F: Fn(&UntrustedRlp) -> Option<SmallVec<[u8; 1024]>> {
 	match rlp.iter()
 	.fold((false, RlpStream::new_list(rlp.item_count())),
 		|(is_some, mut acc), subrlp| {
@@ -84,28 +85,28 @@ fn map_rlp<F>(rlp: &UntrustedRlp, f: F) -> Option<ElasticArray1024<u8>> where
 }
 
 /// Replace common RLPs with invalid shorter ones.
-fn simple_compress(rlp: &UntrustedRlp, swapper: &InvalidRlpSwapper) -> ElasticArray1024<u8> {
+fn simple_compress(rlp: &UntrustedRlp, swapper: &InvalidRlpSwapper) -> SmallVec<[u8; 1024]> {
 	if rlp.is_data() {
-		to_elastic(swapper.get_invalid(rlp.as_raw()).unwrap_or_else(|| rlp.as_raw()))
+		to_small_vec(swapper.get_invalid(rlp.as_raw()).unwrap_or_else(|| rlp.as_raw()))
 	} else {
-		map_rlp(rlp, |r| Some(simple_compress(r, swapper))).unwrap_or_else(|| to_elastic(rlp.as_raw()))
+		map_rlp(rlp, |r| Some(simple_compress(r, swapper))).unwrap_or_else(|| to_small_vec(rlp.as_raw()))
 	}
 }
 
 /// Recover valid RLP from a compressed form.
-fn simple_decompress(rlp: &UntrustedRlp, swapper: &InvalidRlpSwapper) -> ElasticArray1024<u8> {
+fn simple_decompress(rlp: &UntrustedRlp, swapper: &InvalidRlpSwapper) -> SmallVec<[u8; 1024]> {
 	if rlp.is_data() {
-		to_elastic(swapper.get_valid(rlp.as_raw()).unwrap_or_else(|| rlp.as_raw()))
+		to_small_vec(swapper.get_valid(rlp.as_raw()).unwrap_or_else(|| rlp.as_raw()))
 	} else {
-		map_rlp(rlp, |r| Some(simple_decompress(r, swapper))).unwrap_or_else(|| to_elastic(rlp.as_raw()))
+		map_rlp(rlp, |r| Some(simple_decompress(r, swapper))).unwrap_or_else(|| to_small_vec(rlp.as_raw()))
 	}
 }
 
 /// Replace common RLPs with invalid shorter ones, None if no compression achieved.
 /// Tries to compress data insides.
-fn deep_compress(rlp: &UntrustedRlp, swapper: &InvalidRlpSwapper) -> Option<ElasticArray1024<u8>> {
+fn deep_compress(rlp: &UntrustedRlp, swapper: &InvalidRlpSwapper) -> Option<SmallVec<[u8; 1024]>> {
 	let simple_swap = ||
-		swapper.get_invalid(rlp.as_raw()).map(to_elastic);
+		swapper.get_invalid(rlp.as_raw()).map(to_small_vec);
 	if rlp.is_data() {
 		// Try to treat the inside as RLP.
 		return match rlp.payload_info() {
@@ -132,9 +133,9 @@ fn deep_compress(rlp: &UntrustedRlp, swapper: &InvalidRlpSwapper) -> Option<Elas
 
 /// Recover valid RLP from a compressed form, None if no decompression achieved.
 /// Tries to decompress compressed data insides.
-fn deep_decompress(rlp: &UntrustedRlp, swapper: &InvalidRlpSwapper) -> Option<ElasticArray1024<u8>> {
+fn deep_decompress(rlp: &UntrustedRlp, swapper: &InvalidRlpSwapper) -> Option<SmallVec<[u8; 1024]>> {
 	let simple_swap = ||
-		swapper.get_valid(rlp.as_raw()).map(to_elastic);
+		swapper.get_valid(rlp.as_raw()).map(to_small_vec);
 	// Simply decompress data.
 	if rlp.is_data() { return simple_swap(); }
 	match rlp.item_count() {
@@ -152,17 +153,17 @@ fn deep_decompress(rlp: &UntrustedRlp, swapper: &InvalidRlpSwapper) -> Option<El
 impl<'a> Compressible for UntrustedRlp<'a> {
 	type DataType = RlpType;
 
-	fn compress(&self, t: RlpType) -> ElasticArray1024<u8> {
+	fn compress(&self, t: RlpType) -> SmallVec<[u8; 1024]> {
 		match t {
 			RlpType::Snapshot => simple_compress(self, &SNAPSHOT_RLP_SWAPPER),
-			RlpType::Blocks => deep_compress(self, &BLOCKS_RLP_SWAPPER).unwrap_or_else(|| to_elastic(self.as_raw())),
+			RlpType::Blocks => deep_compress(self, &BLOCKS_RLP_SWAPPER).unwrap_or_else(|| to_small_vec(self.as_raw())),
 		}
 	}
 
-	fn decompress(&self, t: RlpType) -> ElasticArray1024<u8> {
+	fn decompress(&self, t: RlpType) -> SmallVec<[u8; 1024]> {
 		match t {
 			RlpType::Snapshot => simple_decompress(self, &SNAPSHOT_RLP_SWAPPER),
-			RlpType::Blocks => deep_decompress(self, &BLOCKS_RLP_SWAPPER).unwrap_or_else(|| to_elastic(self.as_raw())),
+			RlpType::Blocks => deep_decompress(self, &BLOCKS_RLP_SWAPPER).unwrap_or_else(|| to_small_vec(self.as_raw())),
 		}
 	}
 }

--- a/util/src/rlp/rlpstream.rs
+++ b/util/src/rlp/rlpstream.rs
@@ -277,9 +277,7 @@ struct U8Slice<'a>(&'a [u8]);
 
 impl<'a> ByteEncodable for U8Slice<'a> {
 	fn to_bytes<V: VecLike<u8>>(&self, out: &mut V) {
-		for &byte in self.0 {
-			out.push(byte);
-		}
+		out.extend(self.0.iter().cloned());
 	}
 
 	fn bytes_len(&self) -> usize {

--- a/util/src/rlp/rlptraits.rs
+++ b/util/src/rlp/rlptraits.rs
@@ -15,10 +15,9 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 //! Common RLP traits
-use rlp::bytes::VecLike;
 use rlp::{DecoderError, UntrustedRlp};
 use rlp::rlpstream::RlpStream;
-use elastic_array::ElasticArray1024;
+use smallvec::{SmallVec, VecLike};
 use hash::H256;
 use sha3::*;
 
@@ -249,7 +248,7 @@ pub trait Encodable {
 	fn rlp_append(&self, s: &mut RlpStream);
 
 	/// Get rlp-encoded bytes for this instance
-	fn rlp_bytes(&self) -> ElasticArray1024<u8> {
+	fn rlp_bytes(&self) -> SmallVec<[u8; 1024]> {
 		let mut s = RlpStream::new();
 		self.rlp_append(&mut s);
 		s.drain()
@@ -371,7 +370,7 @@ pub trait Compressible: Sized {
 	type DataType;
 
 	/// Compress given RLP type using appropriate methods.
-	fn compress(&self, t: Self::DataType) -> ElasticArray1024<u8>;
+	fn compress(&self, t: Self::DataType) -> SmallVec<[u8; 1024]>;
 	/// Decompress given RLP type using appropriate methods.
-	fn decompress(&self, t: Self::DataType) -> ElasticArray1024<u8>;
+	fn decompress(&self, t: Self::DataType) -> SmallVec<[u8; 1024]>;
 }

--- a/util/src/trie/triedbmut.rs
+++ b/util/src/trie/triedbmut.rs
@@ -24,7 +24,7 @@ use ::bytes::ToPretty;
 use ::nibbleslice::NibbleSlice;
 use ::rlp::{Rlp, RlpStream, View, Stream};
 
-use elastic_array::ElasticArray1024;
+use smallvec::SmallVec;
 
 use std::collections::{HashSet, VecDeque};
 use std::mem;
@@ -122,7 +122,7 @@ impl Node {
 
 	// encode a node to RLP
 	// TODO: parallelize
-	fn into_rlp<F>(self, mut child_cb: F) -> ElasticArray1024<u8>
+	fn into_rlp<F>(self, mut child_cb: F) -> SmallVec<[u8; 1024]>
 		where F: FnMut(NodeHandle, &mut RlpStream)
 	{
 		match self {


### PR DESCRIPTION
This helps out with #1822.
Unfortunately, the smallvec::VecLike trait does not support a firsthand extend operation, so I had to replace those with push loops. It is slightly less ergonomic, but should hopefully compile away into the same code. We can likely upstream this improvement to smallvec's VecLike trait.