### PR TITLE
Add timeout for eth_getWork call

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -426,6 +426,7 @@ dependencies = [
  "serde 0.7.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_codegen 0.7.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.7.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "transient-hashmap 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 

--- a/ethcore/src/client/test_client.rs
+++ b/ethcore/src/client/test_client.rs
@@ -73,6 +73,8 @@ pub struct TestBlockChainClient {
 	pub spec: Spec,
 	/// VM Factory
 	pub vm_factory: EvmFactory,
+	/// Timestamp assigned to latest sealed block
+	pub latest_block_timestamp: RwLock<u64>,
 }
 
 #[derive(Clone)]
@@ -114,6 +116,7 @@ impl TestBlockChainClient {
 			miner: Arc::new(Miner::with_spec(&spec)),
 			spec: spec,
 			vm_factory: EvmFactory::new(VMType::Interpreter),
+			latest_block_timestamp: RwLock::new(10_000_000),
 		};
 		client.add_blocks(1, EachBlockWith::Nothing); // add genesis block
 		client.genesis_hash = client.last_hash.read().clone();
@@ -153,6 +156,11 @@ impl TestBlockChainClient {
 	/// Set block queue size for testing
 	pub fn set_queue_size(&self, size: usize) {
 		self.queue_size.store(size, AtomicOrder::Relaxed);
+	}
+
+	/// Set timestamp assigned to latest sealed block
+	pub fn set_latest_block_timestamp(&self, ts: u64) {
+		*self.latest_block_timestamp.write() = ts;
 	}
 
 	/// Add blocks to test client.
@@ -279,7 +287,7 @@ impl MiningBlockChainClient for TestBlockChainClient {
 			extra_data
 		).expect("Opening block for tests will not fail.");
 		// TODO [todr] Override timestamp for predictability (set_timestamp_now kind of sucks)
-		open_block.set_timestamp(10_000_000);
+		open_block.set_timestamp(*self.latest_block_timestamp.read());
 		open_block
 	}
 

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -28,6 +28,7 @@ serde_macros = { version = "0.7.0", optional = true }
 clippy = { version = "0.0.82", optional = true}
 json-ipc-server = { git = "https://github.com/ethcore/json-ipc-server.git" }
 ethcore-ipc = { path = "../ipc/rpc" }
+time = "0.1"
 
 [build-dependencies]
 serde_codegen = { version = "0.7.0", optional = true }

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -35,6 +35,7 @@ extern crate ethsync;
 extern crate transient_hashmap;
 extern crate json_ipc_server as ipc;
 extern crate ethcore_ipc;
+extern crate time;
 
 #[cfg(test)]
 extern crate ethjson;

--- a/rpc/src/v1/helpers/errors.rs
+++ b/rpc/src/v1/helpers/errors.rs
@@ -30,6 +30,7 @@ mod codes {
 	pub const UNSUPPORTED_REQUEST: i64 = -32000;
 	pub const NO_WORK: i64 = -32001;
 	pub const NO_AUTHOR: i64 = -32002;
+	pub const NO_NEW_WORK: i64 = -32003;
 	pub const UNKNOWN_ERROR: i64 = -32009;
 	pub const TRANSACTION_ERROR: i64 = -32010;
 	pub const ACCOUNT_LOCKED: i64 = -32020;
@@ -110,6 +111,14 @@ pub fn no_work() -> Error {
 	Error {
 		code: ErrorCode::ServerError(codes::NO_WORK),
 		message: "Still syncing.".into(),
+		data: None
+	}
+}
+
+pub fn no_new_work() -> Error {
+	Error {
+		code: ErrorCode::ServerError(codes::NO_NEW_WORK),
+		message: "Work has not changed.".into(),
 		data: None
 	}
 }


### PR DESCRIPTION
Fixes #1818.
I implemented the timeout by comparing the current time to the block timestamp.
We obviously have to add some documentation as well, but I wanted to get this out for review first.
Also had to play some games with the tests to get it to work.