### PR TITLE
Fixing mutual recursive types serialization

### DIFF
--- a/rpc/src/v1/types/trace.rs
+++ b/rpc/src/v1/types/trace.rs
@@ -99,6 +99,7 @@ pub struct VMOperation {
 	/// Information concerning the execution of the operation.
 	pub ex: Option<VMExecutedOperation>,
 	/// Subordinate trace of the CALL/CREATE if applicable.
+	#[serde(bound="VMTrace: Serialize")]
 	pub sub: Option<VMTrace>,
 }
 


### PR DESCRIPTION
Fixes below error:
```
error[E0275]: overflow evaluating the requirement `v1::types::trace::VMOperation: serde::Serialize`
    --> /home/tomusdrw/eth/parity/dapps/target/release/build/ethcore-rpc-2826bc3b63de4723/out/mod.rs:3647:18
     |
3647 |             impl _serde::ser::Serialize for VMOperation where
     |                  ^^^^^^^^^^^^^^^^^^^^^^
     |
     = note: required by `serde::Serialize`

error: aborting due to previous error
```
Issue: https://github.com/serde-rs/serde/issues/441