### PR TITLE
small blooms optimization

### DIFF
--- a/ethcore/src/blockchain/blockchain.rs
+++ b/ethcore/src/blockchain/blockchain.rs
@@ -995,8 +995,13 @@ impl BlockChain {
 		let log_blooms = match info.location {
 			BlockLocation::Branch => HashMap::new(),
 			BlockLocation::CanonChain => {
-				let chain = bc::group::BloomGroupChain::new(self.blooms_config, self);
-				chain.insert(info.number as bc::Number, Bloom::from(header.log_bloom()).into())
+				let log_bloom = header.log_bloom();
+				if log_bloom.is_zero() {
+					HashMap::new()
+				} else {
+					let chain = bc::group::BloomGroupChain::new(self.blooms_config, self);
+					chain.insert(info.number as bc::Number, Bloom::from(log_bloom).into())
+				}
 			},
 			BlockLocation::BranchBecomingCanonChain(ref data) => {
 				let ancestor_number = self.block_number(&data.ancestor).unwrap();


### PR DESCRIPTION
this pr prevents blooms filters from rebuilding when it's not necessary

importing 475k blocks from file on master:

```
200k: 1 minute 47 seconds
475k: 4 minutes 27 seconds
```

importing 475k blocks on this branch:

```
200k: 1 minute 34 seconds (0.87%)
475k: 4 minutes 27 seconds (0.93%)
```