### PR TITLE
remove internal locking from DBTransaction

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -290,7 +290,6 @@ version = "1.4.0"
 dependencies = [
  "clippy 0.0.85 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethabi 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethcore-devtools 1.4.0",
  "ethcore-rpc 1.4.0",
  "ethcore-util 1.4.0",
  "hyper 0.9.4 (git+https://github.com/ethcore/hyper)",

--- a/ethcore/src/blockchain/blockchain.rs
+++ b/ethcore/src/blockchain/blockchain.rs
@@ -380,7 +380,7 @@ impl BlockChain {
 					children: vec![]
 				};
 
-				let batch = DBTransaction::new(&db);
+				let mut batch = DBTransaction::new(&db);
 				batch.put(db::COL_HEADERS, &hash, block.header_rlp().as_raw());
 				batch.put(db::COL_BODIES, &hash, &Self::block_to_body(genesis));
 
@@ -419,7 +419,7 @@ impl BlockChain {
 					}
 				}
 
-				let batch = db.transaction();
+				let mut batch = db.transaction();
 				batch.put(db::COL_EXTRA, b"first", &hash);
 				db.write(batch).expect("Low level database error.");
 
@@ -451,7 +451,7 @@ impl BlockChain {
 	#[cfg(test)]
 	fn rewind(&self) -> Option<H256> {
 		use db::Key;
-		let batch = self.db.transaction();
+		let mut batch =self.db.transaction();
 		// track back to the best block we have in the blocks database
 		if let Some(best_block_hash) = self.db.get(db::COL_EXTRA, b"best").unwrap() {
 			let best_block_hash = H256::from_slice(&best_block_hash);
@@ -604,7 +604,7 @@ impl BlockChain {
 
 		assert!(self.pending_best_block.read().is_none());
 
-		let batch = self.db.transaction();
+		let mut batch = self.db.transaction();
 
 		let block_rlp = UntrustedRlp::new(bytes);
 		let compressed_header = block_rlp.at(0).unwrap().compress(RlpType::Blocks);
@@ -625,7 +625,7 @@ impl BlockChain {
 				location: BlockLocation::CanonChain,
 			};
 
-			self.prepare_update(&batch, ExtrasUpdate {
+			self.prepare_update(&mut batch, ExtrasUpdate {
 				block_hashes: self.prepare_block_hashes_update(bytes, &info),
 				block_details: self.prepare_block_details_update(bytes, &info),
 				block_receipts: self.prepare_block_receipts_update(receipts, &info),
@@ -659,7 +659,7 @@ impl BlockChain {
 			let mut update = HashMap::new();
 			update.insert(hash, block_details);
 
-			self.prepare_update(&batch, ExtrasUpdate {
+			self.prepare_update(&mut batch, ExtrasUpdate {
 				block_hashes: self.prepare_block_hashes_update(bytes, &info),
 				block_details: update,
 				block_receipts: self.prepare_block_receipts_update(receipts, &info),
@@ -682,7 +682,7 @@ impl BlockChain {
 		let mut parent_details = self.block_details(&block_hash)
 			.unwrap_or_else(|| panic!("Invalid block hash: {:?}", block_hash));
 
-		let batch = self.db.transaction();
+		let mut batch = self.db.transaction();
 		parent_details.children.push(child_hash);
 
 		let mut update = HashMap::new();
@@ -701,7 +701,7 @@ impl BlockChain {
 	/// Inserts the block into backing cache database.
 	/// Expects the block to be valid and already verified.
 	/// If the block is already known, does nothing.
-	pub fn insert_block(&self, batch: &DBTransaction, bytes: &[u8], receipts: Vec<Receipt>) -> ImportRoute {
+	pub fn insert_block(&self, batch: &mut DBTransaction, bytes: &[u8], receipts: Vec<Receipt>) -> ImportRoute {
 		// create views onto rlp
 		let block = BlockView::new(bytes);
 		let header = block.header_view();
@@ -782,7 +782,7 @@ impl BlockChain {
 	}
 
 	/// Prepares extras update.
-	fn prepare_update(&self, batch: &DBTransaction, update: ExtrasUpdate, is_best: bool) {
+	fn prepare_update(&self, batch: &mut DBTransaction, update: ExtrasUpdate, is_best: bool) {
 		{
 			let block_hashes: Vec<_> = update.block_details.keys().cloned().collect();
 
@@ -1142,8 +1142,8 @@ mod tests {
 		assert_eq!(bc.best_block_number(), 0);
 
 		// when
-		let batch = db.transaction();
-		bc.insert_block(&batch, &first, vec![]);
+		let mut batch =db.transaction();
+		bc.insert_block(&mut batch, &first, vec![]);
 		assert_eq!(bc.best_block_number(), 0);
 		bc.commit();
 		// NOTE no db.write here (we want to check if best block is cached)
@@ -1172,8 +1172,8 @@ mod tests {
 		assert_eq!(bc.block_hash(1), None);
 		assert_eq!(bc.block_details(&genesis_hash).unwrap().children, vec![]);
 
-		let batch = db.transaction();
-		bc.insert_block(&batch, &first, vec![]);
+		let mut batch =db.transaction();
+		bc.insert_block(&mut batch, &first, vec![]);
 		db.write(batch).unwrap();
 		bc.commit();
 
@@ -1198,11 +1198,11 @@ mod tests {
 		let bc = BlockChain::new(Config::default(), &genesis, db.clone());
 
 		let mut block_hashes = vec![genesis_hash.clone()];
-		let batch = db.transaction();
+		let mut batch =db.transaction();
 		for _ in 0..10 {
 			let block = canon_chain.generate(&mut finalizer).unwrap();
 			block_hashes.push(BlockView::new(&block).header_view().sha3());
-			bc.insert_block(&batch, &block, vec![]);
+			bc.insert_block(&mut batch, &block, vec![]);
 			bc.commit();
 		}
 		db.write(batch).unwrap();
@@ -1233,20 +1233,20 @@ mod tests {
 		let db = new_db(temp.as_str());
 		let bc = BlockChain::new(Config::default(), &genesis, db.clone());
 
-		let batch = db.transaction();
+		let mut batch =db.transaction();
 		for b in &[&b1a, &b1b, &b2a, &b2b, &b3a, &b3b, &b4a, &b4b, &b5a, &b5b] {
-			bc.insert_block(&batch, b, vec![]);
+			bc.insert_block(&mut batch, b, vec![]);
 			bc.commit();
 		}
-		bc.insert_block(&batch, &b1b, vec![]);
-		bc.insert_block(&batch, &b2a, vec![]);
-		bc.insert_block(&batch, &b2b, vec![]);
-		bc.insert_block(&batch, &b3a, vec![]);
-		bc.insert_block(&batch, &b3b, vec![]);
-		bc.insert_block(&batch, &b4a, vec![]);
-		bc.insert_block(&batch, &b4b, vec![]);
-		bc.insert_block(&batch, &b5a, vec![]);
-		bc.insert_block(&batch, &b5b, vec![]);
+		bc.insert_block(&mut batch, &b1b, vec![]);
+		bc.insert_block(&mut batch, &b2a, vec![]);
+		bc.insert_block(&mut batch, &b2b, vec![]);
+		bc.insert_block(&mut batch, &b3a, vec![]);
+		bc.insert_block(&mut batch, &b3b, vec![]);
+		bc.insert_block(&mut batch, &b4a, vec![]);
+		bc.insert_block(&mut batch, &b4b, vec![]);
+		bc.insert_block(&mut batch, &b5a, vec![]);
+		bc.insert_block(&mut batch, &b5b, vec![]);
 		db.write(batch).unwrap();
 
 		assert_eq!(
@@ -1281,17 +1281,17 @@ mod tests {
 		let db = new_db(temp.as_str());
 		let bc = BlockChain::new(Config::default(), &genesis, db.clone());
 
-		let batch = db.transaction();
-		let ir1 = bc.insert_block(&batch, &b1, vec![]);
+		let mut batch =db.transaction();
+		let ir1 = bc.insert_block(&mut batch, &b1, vec![]);
 		bc.commit();
-		let ir2 = bc.insert_block(&batch, &b2, vec![]);
+		let ir2 = bc.insert_block(&mut batch, &b2, vec![]);
 		bc.commit();
-		let ir3b = bc.insert_block(&batch, &b3b, vec![]);
+		let ir3b = bc.insert_block(&mut batch, &b3b, vec![]);
 		bc.commit();
 		db.write(batch).unwrap();
 		assert_eq!(bc.block_hash(3).unwrap(), b3b_hash);
-		let batch = db.transaction();
-		let ir3a = bc.insert_block(&batch, &b3a, vec![]);
+		let mut batch =db.transaction();
+		let ir3a = bc.insert_block(&mut batch, &b3a, vec![]);
 		bc.commit();
 		db.write(batch).unwrap();
 
@@ -1397,8 +1397,8 @@ mod tests {
 			let db = new_db(temp.as_str());
 			let bc = BlockChain::new(Config::default(), &genesis, db.clone());
 			assert_eq!(bc.best_block_hash(), genesis_hash);
-			let batch = db.transaction();
-			bc.insert_block(&batch, &first, vec![]);
+			let mut batch =db.transaction();
+			bc.insert_block(&mut batch, &first, vec![]);
 			db.write(batch).unwrap();
 			bc.commit();
 			assert_eq!(bc.best_block_hash(), first_hash);
@@ -1462,8 +1462,8 @@ mod tests {
 		let temp = RandomTempPath::new();
 		let db = new_db(temp.as_str());
 		let bc = BlockChain::new(Config::default(), &genesis, db.clone());
-		let batch = db.transaction();
-		bc.insert_block(&batch, &b1, vec![]);
+		let mut batch =db.transaction();
+		bc.insert_block(&mut batch, &b1, vec![]);
 		db.write(batch).unwrap();
 		bc.commit();
 
@@ -1475,8 +1475,8 @@ mod tests {
 	}
 
 	fn insert_block(db: &Arc<Database>, bc: &BlockChain, bytes: &[u8], receipts: Vec<Receipt>) -> ImportRoute {
-		let batch = db.transaction();
-		let res = bc.insert_block(&batch, bytes, receipts);
+		let mut batch =db.transaction();
+		let res = bc.insert_block(&mut batch, bytes, receipts);
 		db.write(batch).unwrap();
 		bc.commit();
 		res
@@ -1564,16 +1564,16 @@ mod tests {
 			let bc = BlockChain::new(Config::default(), &genesis, db.clone());
 			let uncle = canon_chain.fork(1).generate(&mut finalizer.fork()).unwrap();
 
-			let batch = db.transaction();
+			let mut batch =db.transaction();
 			// create a longer fork
 			for _ in 0..5 {
 				let canon_block = canon_chain.generate(&mut finalizer).unwrap();
-				bc.insert_block(&batch, &canon_block, vec![]);
+				bc.insert_block(&mut batch, &canon_block, vec![]);
 				bc.commit();
 			}
 
 			assert_eq!(bc.best_block_number(), 5);
-			bc.insert_block(&batch, &uncle, vec![]);
+			bc.insert_block(&mut batch, &uncle, vec![]);
 			db.write(batch).unwrap();
 			bc.commit();
 		}
@@ -1599,10 +1599,10 @@ mod tests {
 		let db = new_db(temp.as_str());
 		let bc = BlockChain::new(Config::default(), &genesis, db.clone());
 
-		let batch = db.transaction();
-		bc.insert_block(&batch, &first, vec![]);
+		let mut batch =db.transaction();
+		bc.insert_block(&mut batch, &first, vec![]);
 		bc.commit();
-		bc.insert_block(&batch, &second, vec![]);
+		bc.insert_block(&mut batch, &second, vec![]);
 		bc.commit();
 		db.write(batch).unwrap();
 

--- a/ethcore/src/db.rs
+++ b/ethcore/src/db.rs
@@ -83,10 +83,10 @@ pub trait Key<T> {
 /// Should be used to write value into database.
 pub trait Writable {
 	/// Writes the value into the database.
-	fn write<T, R>(&self, col: Option<u32>, key: &Key<T, Target = R>, value: &T) where T: Encodable, R: Deref<Target = [u8]>;
+	fn write<T, R>(&mut self, col: Option<u32>, key: &Key<T, Target = R>, value: &T) where T: Encodable, R: Deref<Target = [u8]>;
 
 	/// Writes the value into the database and updates the cache.
-	fn write_with_cache<K, T, R>(&self, col: Option<u32>, cache: &mut Cache<K, T>, key: K, value: T, policy: CacheUpdatePolicy) where
+	fn write_with_cache<K, T, R>(&mut self, col: Option<u32>, cache: &mut Cache<K, T>, key: K, value: T, policy: CacheUpdatePolicy) where
 	K: Key<T, Target = R> + Hash + Eq,
 	T: Encodable,
 	R: Deref<Target = [u8]> {
@@ -102,7 +102,7 @@ pub trait Writable {
 	}
 
 	/// Writes the values into the database and updates the cache.
-	fn extend_with_cache<K, T, R>(&self, col: Option<u32>, cache: &mut Cache<K, T>, values: HashMap<K, T>, policy: CacheUpdatePolicy) where
+	fn extend_with_cache<K, T, R>(&mut self, col: Option<u32>, cache: &mut Cache<K, T>, values: HashMap<K, T>, policy: CacheUpdatePolicy) where
 	K: Key<T, Target = R> + Hash + Eq,
 	T: Encodable,
 	R: Deref<Target = [u8]> {
@@ -169,7 +169,7 @@ pub trait Readable {
 }
 
 impl Writable for DBTransaction {
-	fn write<T, R>(&self, col: Option<u32>, key: &Key<T, Target = R>, value: &T) where T: Encodable, R: Deref<Target = [u8]> {
+	fn write<T, R>(&mut self, col: Option<u32>, key: &Key<T, Target = R>, value: &T) where T: Encodable, R: Deref<Target = [u8]> {
 		self.put(col, &key.key(), &encode(value));
 	}
 }

--- a/ethcore/src/snapshot/mod.rs
+++ b/ethcore/src/snapshot/mod.rs
@@ -443,10 +443,10 @@ impl StateRebuilder {
 			}
 
 			// commit all account tries to the db, but only in this thread.
-			let batch = backing.transaction();
+			let mut batch = backing.transaction();
 			for handle in handles {
 				let mut thread_db = try!(handle.join());
-				try!(thread_db.inject(&batch));
+				try!(thread_db.inject(&mut batch));
 			}
 			try!(backing.write(batch).map_err(::util::UtilError::SimpleString));
 
@@ -468,8 +468,8 @@ impl StateRebuilder {
 			}
 		}
 
-		let batch = backing.transaction();
-		try!(self.db.inject(&batch));
+		let mut batch = backing.transaction();
+		try!(self.db.inject(&mut batch));
 		try!(backing.write(batch).map_err(::util::UtilError::SimpleString));
 		trace!(target: "snapshot", "current state root: {:?}", self.state_root);
 		Ok(())

--- a/ethcore/src/snapshot/tests/blocks.rs
+++ b/ethcore/src/snapshot/tests/blocks.rs
@@ -43,13 +43,15 @@ fn chunk_and_restore(amount: u64) {
 	let bc = BlockChain::new(Default::default(), &genesis, old_db.clone());
 
 	// build the blockchain.
+	let mut batch = old_db.transaction();
 	for _ in 0..amount {
 		let block = canon_chain.generate(&mut finalizer).unwrap();
-		let batch = old_db.transaction();
-		bc.insert_block(&batch, &block, vec![]);
+		bc.insert_block(&mut batch, &block, vec![]);
 		bc.commit();
-		old_db.write(batch).unwrap();
 	}
+
+	old_db.write(batch).unwrap();
+
 
 	let best_hash = bc.best_block_hash();
 

--- a/ethcore/src/tests/helpers.rs
+++ b/ethcore/src/tests/helpers.rs
@@ -259,9 +259,9 @@ pub fn generate_dummy_blockchain(block_number: u32) -> GuardedTempResult<BlockCh
 	let db = new_db(temp.as_str());
 	let bc = BlockChain::new(BlockChainConfig::default(), &create_unverifiable_block(0, H256::zero()), db.clone());
 
-	let batch = db.transaction();
+	let mut batch = db.transaction();
 	for block_order in 1..block_number {
-		bc.insert_block(&batch, &create_unverifiable_block(block_order, bc.best_block_hash()), vec![]);
+		bc.insert_block(&mut batch, &create_unverifiable_block(block_order, bc.best_block_hash()), vec![]);
 		bc.commit();
 	}
 	db.write(batch).unwrap();
@@ -278,9 +278,9 @@ pub fn generate_dummy_blockchain_with_extra(block_number: u32) -> GuardedTempRes
 	let bc = BlockChain::new(BlockChainConfig::default(), &create_unverifiable_block(0, H256::zero()), db.clone());
 
 
-	let batch = db.transaction();
+	let mut batch = db.transaction();
 	for block_order in 1..block_number {
-		bc.insert_block(&batch, &create_unverifiable_block_with_extra(block_order, bc.best_block_hash(), None), vec![]);
+		bc.insert_block(&mut batch, &create_unverifiable_block_with_extra(block_order, bc.best_block_hash(), None), vec![]);
 		bc.commit();
 	}
 	db.write(batch).unwrap();

--- a/ethcore/src/trace/db.rs
+++ b/ethcore/src/trace/db.rs
@@ -142,7 +142,7 @@ impl<T> TraceDB<T> where T: DatabaseExtras {
 			false => [0x0]
 		};
 
-		let batch = DBTransaction::new(&tracesdb);
+		let mut batch = DBTransaction::new(&tracesdb);
 		batch.put(db::COL_TRACE, b"enabled", &encoded_tracing);
 		batch.put(db::COL_TRACE, b"version", TRACE_DB_VER);
 		tracesdb.write(batch).unwrap();
@@ -261,7 +261,7 @@ impl<T> TraceDatabase for TraceDB<T> where T: DatabaseExtras {
 
 	/// Traces of import request's enacted blocks are expected to be already in database
 	/// or to be the currently inserted trace.
-	fn import(&self, batch: &DBTransaction, request: ImportRequest) {
+	fn import(&self, batch: &mut DBTransaction, request: ImportRequest) {
 		// valid (canon):  retracted 0, enacted 1 => false, true,
 		// valid (branch): retracted 0, enacted 0 => false, false,
 		// valid (bbcc):   retracted 1, enacted 1 => true, true,
@@ -611,8 +611,8 @@ mod tests {
 
 		// import block 0
 		let request = create_simple_import_request(0, block_0.clone());
-		let batch = DBTransaction::new(&db);
-		tracedb.import(&batch, request);
+		let mut batch = DBTransaction::new(&db);
+		tracedb.import(&mut batch, request);
 		db.write(batch).unwrap();
 
 		let filter = Filter {
@@ -627,8 +627,8 @@ mod tests {
 
 		// import block 1
 		let request = create_simple_import_request(1, block_1.clone());
-		let batch = DBTransaction::new(&db);
-		tracedb.import(&batch, request);
+		let mut batch = DBTransaction::new(&db);
+		tracedb.import(&mut batch, request);
 		db.write(batch).unwrap();
 
 		let filter = Filter {
@@ -686,8 +686,8 @@ mod tests {
 
 			// import block 0
 			let request = create_simple_import_request(0, block_0.clone());
-			let batch = DBTransaction::new(&db);
-			tracedb.import(&batch, request);
+			let mut batch = DBTransaction::new(&db);
+			tracedb.import(&mut batch, request);
 			db.write(batch).unwrap();
 		}
 

--- a/ethcore/src/trace/mod.rs
+++ b/ethcore/src/trace/mod.rs
@@ -121,7 +121,7 @@ pub trait Database {
 	fn tracing_enabled(&self) -> bool;
 
 	/// Imports new block traces.
-	fn import(&self, batch: &DBTransaction, request: ImportRequest);
+	fn import(&self, batch: &mut DBTransaction, request: ImportRequest);
 
 	/// Returns localized trace at given position.
 	fn trace(&self, block_number: BlockNumber, tx_position: usize, trace_position: Vec<usize>) -> Option<LocalizedTrace>;

--- a/util/src/journaldb/archivedb.rs
+++ b/util/src/journaldb/archivedb.rs
@@ -156,7 +156,7 @@ impl JournalDB for ArchiveDB {
 		self.latest_era.is_none()
 	}
 
-	fn commit(&mut self, batch: &DBTransaction, now: u64, _id: &H256, _end: Option<(u64, H256)>) -> Result<u32, UtilError> {
+	fn commit(&mut self, batch: &mut DBTransaction, now: u64, _id: &H256, _end: Option<(u64, H256)>) -> Result<u32, UtilError> {
 		let mut inserts = 0usize;
 		let mut deletes = 0usize;
 
@@ -185,7 +185,7 @@ impl JournalDB for ArchiveDB {
 		Ok((inserts + deletes) as u32)
 	}
 
-	fn inject(&mut self, batch: &DBTransaction) -> Result<u32, UtilError> {
+	fn inject(&mut self, batch: &mut DBTransaction) -> Result<u32, UtilError> {
 		let mut inserts = 0usize;
 		let mut deletes = 0usize;
 

--- a/util/src/journaldb/earlymergedb.rs
+++ b/util/src/journaldb/earlymergedb.rs
@@ -101,13 +101,13 @@ impl EarlyMergeDB {
 	}
 
 	// The next three are valid only as long as there is an insert operation of `key` in the journal.
-	fn set_already_in(batch: &DBTransaction, col: Option<u32>, key: &H256) { batch.put(col, &Self::morph_key(key, 0), &[1u8]); }
-	fn reset_already_in(batch: &DBTransaction, col: Option<u32>, key: &H256) { batch.delete(col, &Self::morph_key(key, 0)); }
+	fn set_already_in(batch: &mut DBTransaction, col: Option<u32>, key: &H256) { batch.put(col, &Self::morph_key(key, 0), &[1u8]); }
+	fn reset_already_in(batch: &mut DBTransaction, col: Option<u32>, key: &H256) { batch.delete(col, &Self::morph_key(key, 0)); }
 	fn is_already_in(backing: &Database, col: Option<u32>, key: &H256) -> bool {
 		backing.get(col, &Self::morph_key(key, 0)).expect("Low-level database error. Some issue with your hard disk?").is_some()
 	}
 
-	fn insert_keys(inserts: &[(H256, Bytes)], backing: &Database, col: Option<u32>, refs: &mut HashMap<H256, RefInfo>, batch: &DBTransaction, trace: bool) {
+	fn insert_keys(inserts: &[(H256, Bytes)], backing: &Database, col: Option<u32>, refs: &mut HashMap<H256, RefInfo>, batch: &mut DBTransaction, trace: bool) {
 		for &(ref h, ref d) in inserts {
 			if let Some(c) = refs.get_mut(h) {
 				// already counting. increment.
@@ -156,7 +156,7 @@ impl EarlyMergeDB {
 		trace!(target: "jdb.fine", "replay_keys: (end) refs={:?}", refs);
 	}
 
-	fn remove_keys(deletes: &[H256], refs: &mut HashMap<H256, RefInfo>, batch: &DBTransaction, col: Option<u32>, from: RemoveFrom, trace: bool) {
+	fn remove_keys(deletes: &[H256], refs: &mut HashMap<H256, RefInfo>, batch: &mut DBTransaction, col: Option<u32>, from: RemoveFrom, trace: bool) {
 		// with a remove on {queue_refs: 1, in_archive: true}, we have two options:
 		// - convert to {queue_refs: 1, in_archive: false} (i.e. remove it from the conceptual archive)
 		// - convert to {queue_refs: 0, in_archive: true} (i.e. remove it from the conceptual queue)
@@ -337,7 +337,7 @@ impl JournalDB for EarlyMergeDB {
 	}
 
 	#[cfg_attr(feature="dev", allow(cyclomatic_complexity))]
-	fn commit(&mut self, batch: &DBTransaction, now: u64, id: &H256, end: Option<(u64, H256)>) -> Result<u32, UtilError> {
+	fn commit(&mut self, batch: &mut DBTransaction, now: u64, id: &H256, end: Option<(u64, H256)>) -> Result<u32, UtilError> {
 		// journal format:
 		// [era, 0] => [ id, [insert_0, ...], [remove_0, ...] ]
 		// [era, 1] => [ id, [insert_0, ...], [remove_0, ...] ]
@@ -514,7 +514,7 @@ impl JournalDB for EarlyMergeDB {
 		Ok(0)
 	}
 
-	fn inject(&mut self, batch: &DBTransaction) -> Result<u32, UtilError> {
+	fn inject(&mut self, batch: &mut DBTransaction) -> Result<u32, UtilError> {
 		let mut ops = 0;
 		for (key, (value, rc)) in self.overlay.drain() {
 			if rc != 0 { ops += 1 }

--- a/util/src/journaldb/overlayrecentdb.rs
+++ b/util/src/journaldb/overlayrecentdb.rs
@@ -222,7 +222,7 @@ impl JournalDB for OverlayRecentDB {
 		.or_else(|| self.backing.get_by_prefix(self.column, &key[0..DB_PREFIX_LEN]).map(|b| b.to_vec()))
 	}
 
-	fn commit(&mut self, batch: &DBTransaction, now: u64, id: &H256, end: Option<(u64, H256)>) -> Result<u32, UtilError> {
+	fn commit(&mut self, batch: &mut DBTransaction, now: u64, id: &H256, end: Option<(u64, H256)>) -> Result<u32, UtilError> {
 		// record new commit's details.
 		trace!("commit: #{} ({}), end era: {:?}", now, id, end);
 		let mut journal_overlay = self.journal_overlay.write();
@@ -314,7 +314,7 @@ impl JournalDB for OverlayRecentDB {
 		self.journal_overlay.write().pending_overlay.clear();
 	}
 
-	fn inject(&mut self, batch: &DBTransaction) -> Result<u32, UtilError> {
+	fn inject(&mut self, batch: &mut DBTransaction) -> Result<u32, UtilError> {
 		let mut ops = 0;
 		for (key, (value, rc)) in self.transaction_overlay.drain() {
 			if rc != 0 { ops += 1 }

--- a/util/src/journaldb/refcounteddb.rs
+++ b/util/src/journaldb/refcounteddb.rs
@@ -108,7 +108,7 @@ impl JournalDB for RefCountedDB {
 		self.backing.get_by_prefix(self.column, &id[0..DB_PREFIX_LEN]).map(|b| b.to_vec())
 	}
 
-	fn commit(&mut self, batch: &DBTransaction, now: u64, id: &H256, end: Option<(u64, H256)>) -> Result<u32, UtilError> {
+	fn commit(&mut self, batch: &mut DBTransaction, now: u64, id: &H256, end: Option<(u64, H256)>) -> Result<u32, UtilError> {
 		// journal format:
 		// [era, 0] => [ id, [insert_0, ...], [remove_0, ...] ]
 		// [era, 1] => [ id, [insert_0, ...], [remove_0, ...] ]
@@ -181,11 +181,11 @@ impl JournalDB for RefCountedDB {
 			}
 		}
 
-		let r = try!(self.forward.commit_to_batch(&batch));
+		let r = try!(self.forward.commit_to_batch(batch));
 		Ok(r)
 	}
 
-	fn inject(&mut self, batch: &DBTransaction) -> Result<u32, UtilError> {
+	fn inject(&mut self, batch: &mut DBTransaction) -> Result<u32, UtilError> {
 		self.inserts.clear();
 		for remove in self.removes.drain(..) {
 			self.forward.remove(&remove);

--- a/util/src/journaldb/traits.rs
+++ b/util/src/journaldb/traits.rs
@@ -37,7 +37,7 @@ pub trait JournalDB: HashDB {
 
 	/// Commit all recent insert operations and canonical historical commits' removals from the
 	/// old era to the backing database, reverting any non-canonical historical commit's inserts.
-	fn commit(&mut self, batch: &DBTransaction, now: u64, id: &H256, end: Option<(u64, H256)>) -> Result<u32, UtilError>;
+	fn commit(&mut self, batch: &mut DBTransaction, now: u64, id: &H256, end: Option<(u64, H256)>) -> Result<u32, UtilError>;
 
 	/// Commit all queued insert and delete operations without affecting any journalling -- this requires that all insertions
 	/// and deletions are indeed canonical and will likely lead to an invalid database if that assumption is violated.
@@ -46,7 +46,7 @@ pub trait JournalDB: HashDB {
 	/// by any previous `commit` operations. Essentially, this means that `inject` can be used
 	/// either to restore a state to a fresh database, or to insert data which may only be journalled
 	/// from this point onwards.
-	fn inject(&mut self, batch: &DBTransaction) -> Result<u32, UtilError>;
+	fn inject(&mut self, batch: &mut DBTransaction) -> Result<u32, UtilError>;
 
 	/// State data query
 	fn state(&self, _id: &H256) -> Option<Bytes>;
@@ -64,8 +64,8 @@ pub trait JournalDB: HashDB {
 	/// Commit all changes in a single batch
 	#[cfg(test)]
 	fn commit_batch(&mut self, now: u64, id: &H256, end: Option<(u64, H256)>) -> Result<u32, UtilError> {
-		let batch = self.backing().transaction();
-		let res = try!(self.commit(&batch, now, id, end));
+		let mut batch = self.backing().transaction();
+		let res = try!(self.commit(&mut batch, now, id, end));
 		let result = self.backing().write(batch).map(|_| res).map_err(Into::into);
 		self.flush();
 		result
@@ -74,8 +74,8 @@ pub trait JournalDB: HashDB {
 	/// Inject all changes in a single batch.
 	#[cfg(test)]
 	fn inject_batch(&mut self) -> Result<u32, UtilError> {
-		let batch = self.backing().transaction();
-		let res = try!(self.inject(&batch));
+		let mut batch = self.backing().transaction();
+		let res = try!(self.inject(&mut batch));
 		self.backing().write(batch).map(|_| res).map_err(Into::into)
 	}
 }

--- a/util/src/migration/mod.rs
+++ b/util/src/migration/mod.rs
@@ -72,7 +72,7 @@ impl Batch {
 	pub fn commit(&mut self, dest: &mut Database) -> Result<(), Error> {
 		if self.inner.is_empty() { return Ok(()) }
 
-		let transaction = DBTransaction::new(dest);
+		let mut transaction = DBTransaction::new(dest);
 
 		for keypair in &self.inner {
 			transaction.put(self.column, &keypair.0, &keypair.1);

--- a/util/src/migration/tests.rs
+++ b/util/src/migration/tests.rs
@@ -35,7 +35,7 @@ fn db_path(path: &Path) -> PathBuf {
 fn make_db(path: &Path, pairs: BTreeMap<Vec<u8>, Vec<u8>>) {
 	let db = Database::open_default(path.to_str().unwrap()).expect("failed to open temp database");
 	{
-		let transaction = db.transaction();
+		let mut transaction = db.transaction();
 		for (k, v) in pairs {
 			transaction.put(None, &k, &v);
 		}


### PR DESCRIPTION
Locking on every single batch operation didn't seem right. When we do need to split batches across threads, I would still suggest not doing so in a locking manner. It would be faster to give each thread its own owned batch and provide a function for combining batches before writing into the backing database.