### PR TITLE
Disable ArchiveDB counter check

### DIFF
--- a/util/src/journaldb/archivedb.rs
+++ b/util/src/journaldb/archivedb.rs
@@ -163,7 +163,6 @@ impl JournalDB for ArchiveDB {
 		for i in self.overlay.drain().into_iter() {
 			let (key, (value, rc)) = i;
 			if rc > 0 {
-				assert!(rc == 1);
 				batch.put(self.column, &key, &value);
 				inserts += 1;
 			}
@@ -192,7 +191,6 @@ impl JournalDB for ArchiveDB {
 		for i in self.overlay.drain().into_iter() {
 			let (key, (value, rc)) = i;
 			if rc > 0 {
-				assert!(rc == 1);
 				if try!(self.backing.get(self.column, &key)).is_some() {
 					return Err(BaseDataError::AlreadyExists(key).into());
 				}


### PR DESCRIPTION
In some rare cases it is possible for the same trie node to added twice in the same block. E.g.:
Transaction A adds a storage value for contract C at address 0 to 1. The nodes for this changes are committed to transaction memory overlay. Reference counter is set to 1.
Transaction B resets the same storage value to 0. Storage key is marked as modified in the account  state cache.
Transaction B immediately changes the value back to 1. Storage key is reset to original value but still marked as modified.
Transaction B gets committed and the node gets re-inserted with counter set to 2.

I've considered keeping the original value in the state cache to detect such cases but this complicates the code and seems too expensive for such a rare case.

Fixes #2012