### PR TITLE
always process trie death row on commit, add more tracing

### DIFF
--- a/ethcore/src/block.rs
+++ b/ethcore/src/block.rs
@@ -498,7 +498,7 @@ pub fn enact(
 	{
 		if ::log::max_log_level() >= ::log::LogLevel::Trace {
 			let s = try!(State::from_existing(db.boxed_clone(), parent.state_root().clone(), engine.account_start_nonce(), factories.clone()));
-			trace!("enact(): root={}, author={}, author_balance={}\n", s.root(), header.author(), s.balance(&header.author()));
+			trace!(target: "enact", "num={}, root={}, author={}, author_balance={}\n", header.number(), s.root(), header.author(), s.balance(&header.author()));
 		}
 	}
 


### PR DESCRIPTION
When a trie is "obliterated" by a removal -- such that it only has an empty root node remaining, the root node handle was replaced with `NodeHandle::Hash(SHA3_NULL_RLP)`. However, the commit process would only enact deletions if the node handle type was in-memory. Future insertions could then lead to double-insertions of trie nodes into the backing database.

Also boxes branch children to reduce memory churn.