### PR TITLE
IPC tweaks

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -381,6 +381,7 @@ name = "ethcore-ipc-nano"
 version = "1.4.0"
 dependencies = [
  "ethcore-ipc 1.4.0",
+ "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "nanomsg 0.5.1 (git+https://github.com/ethcore/nanomsg.rs.git)",
 ]

--- a/db/src/database.rs
+++ b/db/src/database.rs
@@ -460,7 +460,7 @@ mod client_tests {
 		crossbeam::scope(move |scope| {
 			let stop = Arc::new(AtomicBool::new(false));
 			run_worker(scope, stop.clone(), url);
-			let client = nanoipc::init_client::<DatabaseClient<_>>(url).unwrap();
+			let client = nanoipc::generic_client::<DatabaseClient<_>>(url).unwrap();
 			client.open_default(path.as_str().to_owned()).unwrap();
 			client.put("xxx".as_bytes(), "1".as_bytes()).unwrap();
 			client.close().unwrap();
@@ -477,7 +477,7 @@ mod client_tests {
 		crossbeam::scope(move |scope| {
 			let stop = Arc::new(AtomicBool::new(false));
 			run_worker(scope, stop.clone(), url);
-			let client = nanoipc::init_client::<DatabaseClient<_>>(url).unwrap();
+			let client = nanoipc::generic_client::<DatabaseClient<_>>(url).unwrap();
 
 			client.open_default(path.as_str().to_owned()).unwrap();
 			client.put("xxx".as_bytes(), "1".as_bytes()).unwrap();
@@ -498,7 +498,7 @@ mod client_tests {
 		crossbeam::scope(move |scope| {
 			let stop = Arc::new(AtomicBool::new(false));
 			run_worker(scope, stop.clone(), url);
-			let client = nanoipc::init_client::<DatabaseClient<_>>(url).unwrap();
+			let client = nanoipc::generic_client::<DatabaseClient<_>>(url).unwrap();
 
 			client.open_default(path.as_str().to_owned()).unwrap();
 			assert!(client.get("xxx".as_bytes()).unwrap().is_none());
@@ -516,7 +516,7 @@ mod client_tests {
 		crossbeam::scope(move |scope| {
 			let stop = Arc::new(AtomicBool::new(false));
 			run_worker(scope, stop.clone(), url);
-			let client = nanoipc::init_client::<DatabaseClient<_>>(url).unwrap();
+			let client = nanoipc::generic_client::<DatabaseClient<_>>(url).unwrap();
 			client.open_default(path.as_str().to_owned()).unwrap();
 
 			let transaction = DBTransaction::new();
@@ -541,7 +541,7 @@ mod client_tests {
 			let stop = StopGuard::new();
 			run_worker(&scope, stop.share(), url);
 
-			let client = nanoipc::init_client::<DatabaseClient<_>>(url).unwrap();
+			let client = nanoipc::generic_client::<DatabaseClient<_>>(url).unwrap();
 
 			client.open_default(path.as_str().to_owned()).unwrap();
 			let mut batch = Vec::new();

--- a/db/src/lib.rs.in
+++ b/db/src/lib.rs.in
@@ -66,13 +66,13 @@ pub fn extras_service_url(db_path: &str) -> Result<String, ::std::io::Error> {
 
 pub fn blocks_client(db_path: &str) -> Result<DatabaseConnection, ServiceError> {
 	let url = try!(blocks_service_url(db_path));
-	let client = try!(nanoipc::init_client::<DatabaseClient<_>>(&url));
+	let client = try!(nanoipc::generic_client::<DatabaseClient<_>>(&url));
 	Ok(client)
 }
 
 pub fn extras_client(db_path: &str) -> Result<DatabaseConnection, ServiceError> {
 	let url = try!(extras_service_url(db_path));
-	let client = try!(nanoipc::init_client::<DatabaseClient<_>>(&url));
+	let client = try!(nanoipc::generic_client::<DatabaseClient<_>>(&url));
 	Ok(client)
 }
 

--- a/ethcore/src/tests/rpc.rs
+++ b/ethcore/src/tests/rpc.rs
@@ -51,7 +51,7 @@ fn can_handshake() {
 		let stop_guard = StopGuard::new();
 		let socket_path = "ipc:///tmp/parity-client-rpc-10.ipc";
 		run_test_worker(scope, stop_guard.share(), socket_path);
-		let remote_client = nanoipc::init_client::<RemoteClient<_>>(socket_path).unwrap();
+		let remote_client = nanoipc::generic_client::<RemoteClient<_>>(socket_path).unwrap();
 
 		assert!(remote_client.handshake().is_ok());
 	})
@@ -63,7 +63,7 @@ fn can_query_block() {
 		let stop_guard = StopGuard::new();
 		let socket_path = "ipc:///tmp/parity-client-rpc-20.ipc";
 		run_test_worker(scope, stop_guard.share(), socket_path);
-		let remote_client = nanoipc::init_client::<RemoteClient<_>>(socket_path).unwrap();
+		let remote_client = nanoipc::generic_client::<RemoteClient<_>>(socket_path).unwrap();
 
 		let non_existant_block = remote_client.block_header(BlockID::Number(999));
 

--- a/ipc/hypervisor/src/lib.rs
+++ b/ipc/hypervisor/src/lib.rs
@@ -240,7 +240,7 @@ mod tests {
 		::std::thread::spawn(move || {
 			while !hypervisor_ready.load(Ordering::Relaxed) { }
 
-			let client = nanoipc::init_client::<HypervisorServiceClient<_>>(url).unwrap();
+			let client = nanoipc::fast_client::<HypervisorServiceClient<_>>(url).unwrap();
 			client.handshake().unwrap();
 			client.module_ready(test_module_id);
 		});

--- a/ipc/hypervisor/src/service.rs.in
+++ b/ipc/hypervisor/src/service.rs.in
@@ -110,7 +110,7 @@ impl HypervisorService {
 		let modules = self.modules.read().unwrap();
 		modules.get(&module_id).map(|module| {
 			trace!(target: "hypervisor", "Sending shutdown to {}({})", module_id, &module.control_url);
-			let client = nanoipc::init_client::<ControlServiceClient<_>>(&module.control_url).unwrap();
+			let client = nanoipc::fast_client::<ControlServiceClient<_>>(&module.control_url).unwrap();
 			client.shutdown();
 			trace!(target: "hypervisor", "Sent shutdown to {}", module_id);
 		});

--- a/ipc/nano/Cargo.toml
+++ b/ipc/nano/Cargo.toml
@@ -10,4 +10,4 @@ license = "GPL-3.0"
 ethcore-ipc = { path = "../rpc" }
 nanomsg = { git = "https://github.com/ethcore/nanomsg.rs.git" }
 log = "0.3"
-
+lazy_static = "0.2"

--- a/parity/boot.rs
+++ b/parity/boot.rs
@@ -63,7 +63,7 @@ pub fn payload<B: ipc::BinaryConvertable>() -> Result<B, BootError> {
 }
 
 pub fn register(hv_url: &str, control_url: &str, module_id: IpcModuleId) -> GuardedSocket<HypervisorServiceClient<NanoSocket>>{
-	let hypervisor_client = nanoipc::init_client::<HypervisorServiceClient<_>>(hv_url).unwrap();
+	let hypervisor_client = nanoipc::fast_client::<HypervisorServiceClient<_>>(hv_url).unwrap();
 	hypervisor_client.handshake().unwrap();
 	hypervisor_client.module_ready(module_id, control_url.to_owned());
 
@@ -73,7 +73,7 @@ pub fn register(hv_url: &str, control_url: &str, module_id: IpcModuleId) -> Guar
 pub fn dependency<C: WithSocket<NanoSocket>>(url: &str)
 	-> Result<GuardedSocket<C>, BootError>
 {
-	nanoipc::init_client::<C>(url).map_err(|socket_err| BootError::DependencyConnect(socket_err))
+	nanoipc::generic_client::<C>(url).map_err(|socket_err| BootError::DependencyConnect(socket_err))
 }
 
 pub fn main_thread() -> Arc<AtomicBool> {

--- a/parity/io_handler.rs
+++ b/parity/io_handler.rs
@@ -15,6 +15,7 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
 use ethcore::client::Client;
 use ethcore::service::ClientIoMessage;
 use ethsync::{SyncProvider, ManageNetwork};
@@ -31,6 +32,7 @@ pub struct ClientIoHandler {
 	pub net: Arc<ManageNetwork>,
 	pub accounts: Arc<AccountProvider>,
 	pub info: Arc<Informant>,
+	pub shutdown: Arc<AtomicBool>
 }
 
 impl IoHandler<ClientIoMessage> for ClientIoHandler {
@@ -39,7 +41,7 @@ impl IoHandler<ClientIoMessage> for ClientIoHandler {
 	}
 
 	fn timeout(&self, _io: &IoContext<ClientIoMessage>, timer: TimerToken) {
-		if let INFO_TIMER = timer {
+		if timer == INFO_TIMER && !self.shutdown.load(Ordering::SeqCst) {
 			self.info.tick();
 		}
 	}

--- a/parity/modules.rs
+++ b/parity/modules.rs
@@ -68,7 +68,7 @@ mod ipc_deps {
 	pub use ethsync::{SyncClient, NetworkManagerClient, ServiceConfiguration};
 	pub use ethcore::client::ChainNotifyClient;
 	pub use hypervisor::{SYNC_MODULE_ID, BootArgs, HYPERVISOR_IPC_URL};
-	pub use nanoipc::{GuardedSocket, NanoSocket, init_client};
+	pub use nanoipc::{GuardedSocket, NanoSocket, generic_client, fast_client};
 	pub use ipc::IpcSocket;
 	pub use ipc::binary::serialize;
 }
@@ -130,11 +130,11 @@ pub fn sync
 	hypervisor.start();
 	hypervisor.wait_for_startup();
 
-	let sync_client = init_client::<SyncClient<_>>(
+	let sync_client = generic_client::<SyncClient<_>>(
 		&service_urls::with_base(&hypervisor.io_path, service_urls::SYNC)).unwrap();
-	let notify_client = init_client::<ChainNotifyClient<_>>(
+	let notify_client = generic_client::<ChainNotifyClient<_>>(
 		&service_urls::with_base(&hypervisor.io_path, service_urls::SYNC_NOTIFY)).unwrap();
-	let manage_client = init_client::<NetworkManagerClient<_>>(
+	let manage_client = generic_client::<NetworkManagerClient<_>>(
 		&service_urls::with_base(&hypervisor.io_path, service_urls::NETWORK_MANAGER)).unwrap();
 
 	*hypervisor_ref = Some(hypervisor);

--- a/parity/run.rs
+++ b/parity/run.rs
@@ -246,8 +246,9 @@ pub fn execute(cmd: RunCmd) -> Result<(), String> {
 		sync: sync_provider.clone(),
 		net: manage_network.clone(),
 		accounts: account_provider.clone(),
+		shutdown: Default::default(),
 	});
-	service.register_io_handler(io_handler).expect("Error registering IO handler");
+	service.register_io_handler(io_handler.clone()).expect("Error registering IO handler");
 
 	// start ui
 	if cmd.ui {
@@ -259,6 +260,11 @@ pub fn execute(cmd: RunCmd) -> Result<(), String> {
 
 	// Handle exit
 	wait_for_exit(panic_handler, http_server, ipc_server, dapps_server, signer_server);
+
+	// to make sure timer does not spawn requests while shutdown is in progress
+	io_handler.shutdown.store(true, ::std::sync::atomic::Ordering::SeqCst);
+	// just Arc is dropping here, to allow other reference release in its default time
+	drop(io_handler);
 
 	// hypervisor should be shutdown first while everything still works and can be
 	// terminated gracefully


### PR DESCRIPTION
- no timeouts for heavy services (can be forced with env var `PARITY_IPC_DEBUG`)
- disable client timer early to stop requests during shutdown (not ideal solution, should be in while designing general one)