### PR TITLE
Add a few tests for the snapshot service

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,6 +569,7 @@ name = "ethkey"
 version = "0.2.0"
 dependencies = [
  "bigint 0.1.0",
+ "docopt 0.6.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "eth-secp256k1 0.5.4 (git+https://github.com/ethcore/rust-secp256k1)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -580,6 +581,7 @@ dependencies = [
 name = "ethstore"
 version = "0.1.0"
 dependencies = [
+ "docopt 0.6.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethcrypto 0.1.0",
  "ethkey 0.2.0",
  "itertools 0.4.13 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -673,6 +673,8 @@ impl Client {
 impl snapshot::DatabaseRestore for Client {
 	/// Restart the client with a new backend
 	fn restore_db(&self, new_db: &str) -> Result<(), EthcoreError> {
+		trace!(target: "snapshot", "Replacing client database with {:?}", new_db);
+
 		let _import_lock = self.import_lock.lock();
 		let mut state_db = self.state_db.write();
 		let mut chain = self.chain.write();

--- a/ethcore/src/service.rs
+++ b/ethcore/src/service.rs
@@ -94,7 +94,6 @@ impl ClientService {
 			pruning: pruning,
 			channel: io_service.channel(),
 			snapshot_root: snapshot_path.into(),
-			client_db: client_path.into(),
 			db_restore: client.clone(),
 		};
 		let snapshot = Arc::new(try!(SnapshotService::new(snapshot_params)));

--- a/ethcore/src/snapshot/service.rs
+++ b/ethcore/src/snapshot/service.rs
@@ -187,9 +187,6 @@ pub struct ServiceParams {
 	/// The directory to put snapshots in.
 	/// Usually "<chain hash>/snapshot"
 	pub snapshot_root: PathBuf,
-	/// The client's database directory.
-	/// Usually "<chain hash>/<pruning>/db".
-	pub client_db: PathBuf,
 	/// A handle for database restoration.
 	pub db_restore: Arc<DatabaseRestore>,
 }
@@ -198,7 +195,6 @@ pub struct ServiceParams {
 /// This controls taking snapshots and restoring from them.
 pub struct Service {
 	restoration: Mutex<Option<Restoration>>,
-	client_db: PathBuf,
 	snapshot_root: PathBuf,
 	db_config: DatabaseConfig,
 	io_channel: Channel,
@@ -219,7 +215,6 @@ impl Service {
 	pub fn new(params: ServiceParams) -> Result<Self, Error> {
 		let mut service = Service {
 			restoration: Mutex::new(None),
-			client_db: params.client_db,
 			snapshot_root: params.snapshot_root,
 			db_config: params.db_config,
 			io_channel: params.channel,
@@ -301,7 +296,6 @@ impl Service {
 	fn replace_client_db(&self) -> Result<(), Error> {
 		let our_db = self.restoration_db();
 
-		trace!(target: "snapshot", "replacing {:?} with {:?}", self.client_db, our_db);
 		try!(self.db_restore.restore_db(our_db.to_str().unwrap()));
 		Ok(())
 	}
@@ -585,7 +579,6 @@ mod tests {
 			pruning: Algorithm::Archive,
 			channel: service.channel(),
 			snapshot_root: dir,
-			client_db: client_db,
 			db_restore: Arc::new(NoopDBRestore),
 		};
 

--- a/ethcore/src/snapshot/service.rs
+++ b/ethcore/src/snapshot/service.rs
@@ -296,7 +296,7 @@ impl Service {
 	fn replace_client_db(&self) -> Result<(), Error> {
 		let our_db = self.restoration_db();
 
-		try!(self.db_restore.restore_db(our_db.to_string_lossy()));
+		try!(self.db_restore.restore_db(&*our_db.to_string_lossy()));
 		Ok(())
 	}
 
@@ -517,12 +517,6 @@ impl SnapshotService for Service {
 	fn abort_restore(&self) {
 		*self.restoration.lock() = None;
 		*self.status.lock() = RestorationStatus::Inactive;
-		if let Err(e) = fs::remove_dir_all(&self.restoration_dir()) {
-			match e.kind() {
-				ErrorKind::NotFound => {},
-				_ => warn!("encountered error {} while deleting snapshot restoration dir.", e),
-			}
-		}
 	}
 
 	fn restore_state_chunk(&self, hash: H256, chunk: Bytes) {

--- a/ethcore/src/snapshot/service.rs
+++ b/ethcore/src/snapshot/service.rs
@@ -296,7 +296,7 @@ impl Service {
 	fn replace_client_db(&self) -> Result<(), Error> {
 		let our_db = self.restoration_db();
 
-		try!(self.db_restore.restore_db(our_db.to_str().unwrap()));
+		try!(self.db_restore.restore_db(our_db.to_string_lossy()));
 		Ok(())
 	}
 

--- a/ethcore/src/snapshot/tests/mod.rs
+++ b/ethcore/src/snapshot/tests/mod.rs
@@ -18,6 +18,7 @@
 
 mod blocks;
 mod state;
+mod service;
 
 pub mod helpers;
 

--- a/ethcore/src/snapshot/tests/service.rs
+++ b/ethcore/src/snapshot/tests/service.rs
@@ -1,0 +1,96 @@
+// Copyright 2015, 2016 Ethcore (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Tests for the snapshot service.
+
+use std::sync::Arc;
+
+use client::{BlockChainClient, Client};
+use ids::BlockID;
+use snapshot::service::{Service, ServiceParams};
+use snapshot::SnapshotService;
+use spec::Spec;
+use tests::helpers::generate_dummy_client_with_spec_and_data;
+
+use devtools::RandomTempPath;
+use io::IoChannel;
+use util::kvdb::DatabaseConfig;
+
+#[test]
+fn restored_is_equivalent() {
+	const NUM_BLOCKS: u32 = 400;
+	const TX_PER: usize = 5;
+
+	let gas_prices = vec![1.into(), 2.into(), 3.into(), 999.into()];
+
+	let client = generate_dummy_client_with_spec_and_data(Spec::new_null, NUM_BLOCKS, TX_PER, &gas_prices);
+
+	let path = RandomTempPath::create_dir();
+	let mut path = path.as_path().clone();
+	let mut client_db = path.clone();
+
+	client_db.push("client_db");
+	path.push("snapshot");
+
+	let db_config = DatabaseConfig::with_columns(::db::NUM_COLUMNS);
+
+	let spec = Spec::new_null();
+	let client2 = Client::new(
+		Default::default(),
+		&spec,
+		&client_db,
+		Arc::new(::miner::Miner::with_spec(&spec)),
+		IoChannel::disconnected(),
+		&db_config,
+	).unwrap();
+
+	let service_params = ServiceParams {
+		engine: spec.engine.clone(),
+		genesis_block: spec.genesis_block(),
+		db_config: db_config,
+		pruning: ::util::journaldb::Algorithm::Archive,
+		channel: IoChannel::disconnected(),
+		snapshot_root: path,
+		db_restore: client2.clone(),
+	};
+
+	let service = Service::new(service_params).unwrap();
+	service.take_snapshot(&client, NUM_BLOCKS as u64).unwrap();
+
+	let manifest = service.manifest().unwrap();
+
+	service.init_restore(manifest.clone()).unwrap();
+	assert!(service.init_restore(manifest.clone()).is_ok());
+
+	for hash in manifest.state_hashes {
+		let chunk = service.chunk(hash).unwrap();
+		service.feed_state_chunk(hash, &chunk);
+	}
+
+	for hash in manifest.block_hashes {
+		let chunk = service.chunk(hash).unwrap();
+		service.feed_block_chunk(hash, &chunk);
+	}
+
+	assert_eq!(service.status(), ::snapshot::RestorationStatus::Inactive);
+
+	for x in 0..NUM_BLOCKS {
+		let block1 = client.block(BlockID::Number(x as u64)).unwrap();
+		let block2 = client2.block(BlockID::Number(x as u64)).unwrap();
+
+		assert_eq!(block1, block2);
+	}
+}

--- a/ethcore/src/snapshot/tests/service.rs
+++ b/ethcore/src/snapshot/tests/service.rs
@@ -129,13 +129,15 @@ fn guards_delete_folders() {
 		state_root: Default::default(),
 	};
 
-	service.init_restore(manifest).unwrap();
+	service.init_restore(manifest.clone()).unwrap();
+	assert!(path.exists());
 
+	service.abort_restore();
+	assert!(!path.exists());
+
+	service.init_restore(manifest.clone()).unwrap();
 	assert!(path.exists());
 
 	drop(service);
-
 	assert!(!path.exists());
 }
-
-#[test]


### PR DESCRIPTION
Also removes the `client_db` field from it as that's been superseded by the `DatabaseRestore` trait.