### PR TITLE
gavcoin global import of parity api 

### DIFF
--- a/js/src/api/api.js
+++ b/js/src/api/api.js
@@ -4,6 +4,7 @@ import Contract from './contract/index';
 import { Db, Eth, Ethcore, Net, Personal, Shh, Trace, Web3 } from './rpc/index';
 import Subscriptions from './subscriptions/index';
 import format from './format/index';
+import util from './util/index';
 import { isFunction } from './util/types';
 
 export default class Api {
@@ -58,6 +59,10 @@ export default class Api {
 
   get format () {
     return format;
+  }
+
+  get util () {
+    return util;
   }
 
   newContract (abi, address) {

--- a/js/src/api/util/identity.js
+++ b/js/src/api/util/identity.js
@@ -2,7 +2,7 @@ import blockies from 'blockies';
 
 export function createIdentityImg (address, scale = 7) {
   return blockies({
-    seed: address,
+    seed: (address || '').toLowerCase(),
     size: 8,
     scale
   }).toDataURL();

--- a/js/src/api/util/identity.js
+++ b/js/src/api/util/identity.js
@@ -1,0 +1,9 @@
+import blockies from 'blockies';
+
+export function createIdentityImg (address, scale = 7) {
+  return blockies({
+    seed: address,
+    size: 8,
+    scale
+  }).toDataURL();
+}

--- a/js/src/api/util/index.js
+++ b/js/src/api/util/index.js
@@ -1,0 +1,5 @@
+import { createIdentityImg } from './identity';
+
+export default {
+  createIdentityImg
+};

--- a/js/src/dapps/gavcoin/AccountSelector/AccountItem/accountItem.js
+++ b/js/src/dapps/gavcoin/AccountSelector/AccountItem/accountItem.js
@@ -1,8 +1,8 @@
 import React, { Component, PropTypes } from 'react';
 
-import styles from './accountItem.css';
+import IdentityIcon from '../../IdentityIcon';
 
-const { IdentityIcon } = window.parity.react;
+import styles from './accountItem.css';
 
 export default class AccountItem extends Component {
   static propTypes = {
@@ -31,9 +31,7 @@ export default class AccountItem extends Component {
     return (
       <div className={ styles.account }>
         <div className={ styles.image }>
-          <IdentityIcon
-            inline center
-            address={ account.address } />
+          <IdentityIcon address={ account.address } />
         </div>
         <div className={ styles.details }>
           <div className={ styles.name }>

--- a/js/src/dapps/gavcoin/AccountSelectorText/accountSelectorText.js
+++ b/js/src/dapps/gavcoin/AccountSelectorText/accountSelectorText.js
@@ -1,9 +1,8 @@
 import React, { Component, PropTypes } from 'react';
 import { TextField } from 'material-ui';
 
+import IdentityIcon from '../IdentityIcon';
 import AccountSelector from '../AccountSelector';
-
-const { IdentityIcon } = window.parity.react;
 
 import styles from './accountSelectorText.css';
 
@@ -77,9 +76,7 @@ export default class AccountSelectorText extends Component {
 
     return (
       <div className={ styles.addricon }>
-        <IdentityIcon
-          inline center
-          address={ account.address } />
+        <IdentityIcon address={ account.address } />
       </div>
     );
   }

--- a/js/src/dapps/gavcoin/Accounts/accounts.js
+++ b/js/src/dapps/gavcoin/Accounts/accounts.js
@@ -1,8 +1,7 @@
 import React, { Component, PropTypes } from 'react';
-
 import { Chip } from 'material-ui';
 
-const { IdentityIcon } = window.parity.react;
+import IdentityIcon from '../IdentityIcon';
 
 import styles from './accounts.css';
 
@@ -44,9 +43,7 @@ export default class Accounts extends Component {
           <Chip
             className={ styles.account }
             key={ account.address }>
-            <IdentityIcon
-              inline center
-              address={ account.address } />
+            <IdentityIcon address={ account.address } />
             <span className={ styles.name }>
               { account.name }
             </span>

--- a/js/src/dapps/gavcoin/Actions/ActionBuyIn/actionBuyIn.js
+++ b/js/src/dapps/gavcoin/Actions/ActionBuyIn/actionBuyIn.js
@@ -3,13 +3,12 @@ import React, { Component, PropTypes } from 'react';
 
 import { Dialog, FlatButton, TextField } from 'material-ui';
 
+import { api } from '../../parity';
 import AccountSelector from '../../AccountSelector';
 import StepComplete from '../StepComplete';
 import { ERRORS, validateAccount, validatePositiveNumber } from '../validation';
 
 import styles from '../actions.css';
-
-const { api } = window.parity;
 
 const NAME_ID = ' ';
 

--- a/js/src/dapps/gavcoin/Actions/ActionRefund/actionRefund.js
+++ b/js/src/dapps/gavcoin/Actions/ActionRefund/actionRefund.js
@@ -3,13 +3,12 @@ import React, { Component, PropTypes } from 'react';
 
 import { Dialog, FlatButton, TextField } from 'material-ui';
 
+import { api } from '../../parity';
 import AccountSelector from '../../AccountSelector';
 import StepComplete from '../StepComplete';
 import { ERRORS, validateAccount, validatePositiveNumber } from '../validation';
 
 import styles from '../actions.css';
-
-const { api } = window.parity;
 
 const DIVISOR = 10 ** 6;
 const NAME_ID = ' ';

--- a/js/src/dapps/gavcoin/Actions/validation.js
+++ b/js/src/dapps/gavcoin/Actions/validation.js
@@ -1,6 +1,6 @@
 import BigNumber from 'bignumber.js';
 
-const { api } = window.parity;
+import { api } from '../parity';
 
 export const ERRORS = {
   invalidAccount: 'please select an account to transact with',

--- a/js/src/dapps/gavcoin/Application/application.js
+++ b/js/src/dapps/gavcoin/Application/application.js
@@ -6,6 +6,8 @@ import lightBaseTheme from 'material-ui/styles/baseThemes/lightBaseTheme';
 
 const muiTheme = getMuiTheme(lightBaseTheme);
 
+import { api } from '../parity';
+
 import registryAbi from '../abi/registry.json';
 import gavcoinAbi from '../abi/gavcoin.json';
 
@@ -14,8 +16,6 @@ import Actions, { ActionBuyIn, ActionRefund, ActionTransfer } from '../Actions';
 import Events from '../Events';
 import Loading from '../Loading';
 import Status from '../Status';
-
-const { api } = window.parity;
 
 const DIVISOR = 10 ** 6;
 

--- a/js/src/dapps/gavcoin/Events/Event/event.js
+++ b/js/src/dapps/gavcoin/Events/Event/event.js
@@ -1,10 +1,9 @@
 import React, { Component, PropTypes } from 'react';
 
+import IdentityIcon from '../../IdentityIcon';
 import { formatBlockNumber, formatCoins, formatEth } from '../../format';
 
 import styles from '../events.css';
-
-const { IdentityIcon } = window.parity.react;
 
 const EMPTY_COLUMN = (
   <td></td>
@@ -55,7 +54,7 @@ export default class Event extends Component {
 
     return (
       <td className={ styles.account }>
-        <IdentityIcon inline center address={ address } />
+        <IdentityIcon address={ address } />
         { this.renderAddressName(address) }
       </td>
     );

--- a/js/src/dapps/gavcoin/Events/events.js
+++ b/js/src/dapps/gavcoin/Events/events.js
@@ -1,13 +1,13 @@
 import React, { Component, PropTypes } from 'react';
 
+import { api } from '../parity';
+
 import EventBuyin from './EventBuyin';
 import EventNewTranch from './EventNewTranch';
 import EventRefund from './EventRefund';
 import EventTransfer from './EventTransfer';
 
 import styles from './events.css';
-
-const { api } = window.parity;
 
 export default class Events extends Component {
   static childContextTypes = {

--- a/js/src/dapps/gavcoin/IdentityIcon/identityIcon.css
+++ b/js/src/dapps/gavcoin/IdentityIcon/identityIcon.css
@@ -1,0 +1,6 @@
+.icon {
+  width: 32px;
+  height: 32px;
+  border-radius: 50%;
+  margin-right: 0.5em;
+}

--- a/js/src/dapps/gavcoin/IdentityIcon/identityIcon.js
+++ b/js/src/dapps/gavcoin/IdentityIcon/identityIcon.js
@@ -1,0 +1,20 @@
+import React, { Component, PropTypes } from 'react';
+
+import { api } from '../parity';
+import styles from './identityIcon.css';
+
+export default class IdentityIcon extends Component {
+  static propTypes = {
+    address: PropTypes.string.isRequired
+  }
+
+  render () {
+    const { address } = this.props;
+
+    return (
+      <img
+        className={ styles.icon }
+        src={ api.util.createIdentityImg(address, 4) } />
+    );
+  }
+}

--- a/js/src/dapps/gavcoin/IdentityIcon/index.js
+++ b/js/src/dapps/gavcoin/IdentityIcon/index.js
@@ -1,0 +1,1 @@
+export default from './identityIcon';

--- a/js/src/dapps/gavcoin/format/index.js
+++ b/js/src/dapps/gavcoin/format/index.js
@@ -1,6 +1,6 @@
 import BigNumber from 'bignumber.js';
 
-const { api } = window.parity;
+import { api } from '../parity';
 
 const DIVISOR = 10 ** 6;
 const ZERO = new BigNumber(0);

--- a/js/src/dapps/gavcoin/parity.js
+++ b/js/src/dapps/gavcoin/parity.js
@@ -1,0 +1,5 @@
+const { api } = window.parity;
+
+export {
+  api
+};

--- a/js/src/ui/IdentityIcon/identityIcon.js
+++ b/js/src/ui/IdentityIcon/identityIcon.js
@@ -1,9 +1,12 @@
 import React, { Component, PropTypes } from 'react';
-import blockies from 'blockies';
 
 import styles from './identityIcon.css';
 
 export default class IdentityIcon extends Component {
+  static contextTypes = {
+    api: PropTypes.object.isRequired
+  }
+
   static propTypes = {
     address: PropTypes.string,
     className: PropTypes.string,
@@ -18,7 +21,9 @@ export default class IdentityIcon extends Component {
   }
 
   componentDidMount () {
-    this.updateIcon(this.props.address);
+    const { address } = this.props;
+
+    this.updateIcon(address);
   }
 
   componentWillReceiveProps (newProps) {
@@ -32,6 +37,7 @@ export default class IdentityIcon extends Component {
   }
 
   updateIcon (_address) {
+    const { api } = this.context;
     const { tokens, inline } = this.props;
     const token = (tokens || {})[_address];
 
@@ -43,14 +49,8 @@ export default class IdentityIcon extends Component {
       return;
     }
 
-    const address = _address.toLowerCase();
-
     this.setState({
-      iconsrc: blockies({
-        seed: address,
-        size: 8,
-        scale: inline ? 4 : 7
-      }).toDataURL()
+      iconsrc: api.util.createIdentityImg(_address, inline ? 4 : 7)
     });
   }
 


### PR DESCRIPTION
Use `import { api } from './parity';` instead of `const { api } = window.parity;` as mentioned in https://github.com/ethcore/parity/pull/2077

Expand API interface slightly to give direct access to create IdentityIcon images via blockies, for use in the dapps at will.