### PR TITLE
Enable sealing if Engine provides internal sealing given author

### DIFF
--- a/ethcore/src/engines/basic_authority.rs
+++ b/ethcore/src/engines/basic_authority.rs
@@ -99,7 +99,7 @@ impl Engine for BasicAuthority {
 	/// This assumes that all uncles are valid uncles (i.e. of at least one generation before the current).
 	fn on_close_block(&self, _block: &mut ExecutedBlock) {}
 
-	fn seals_internally(&self) -> bool { true }
+	fn seals_internally(&self, _author: &Address) -> bool { true }
 
 	/// Attempt to seal the block internally.
 	///

--- a/ethcore/src/engines/basic_authority.rs
+++ b/ethcore/src/engines/basic_authority.rs
@@ -99,7 +99,9 @@ impl Engine for BasicAuthority {
 	/// This assumes that all uncles are valid uncles (i.e. of at least one generation before the current).
 	fn on_close_block(&self, _block: &mut ExecutedBlock) {}
 
-	fn seals_internally(&self, _author: &Address) -> bool { true }
+	fn is_sealer(&self, author: &Address) -> Option<bool> {
+		Some(self.our_params.authorities.contains(author))
+	}
 
 	/// Attempt to seal the block internally.
 	///
@@ -258,5 +260,15 @@ mod tests {
 		let b = b.close_and_lock();
 		let seal = engine.generate_seal(b.block(), Some(&tap)).unwrap();
 		assert!(b.try_seal(engine, seal).is_ok());
+	}
+
+	#[test]
+	fn seals_internally() {
+		let tap = AccountProvider::transient_provider();
+		let authority = tap.insert_account("".sha3(), "").unwrap();
+
+		let engine = new_test_authority().engine;
+		assert!(!engine.is_sealer(&Address::default()).unwrap());
+		assert!(engine.is_sealer(&authority).unwrap());
 	}
 }

--- a/ethcore/src/engines/instant_seal.rs
+++ b/ethcore/src/engines/instant_seal.rs
@@ -58,7 +58,7 @@ impl Engine for InstantSeal {
 		Schedule::new_homestead()
 	}
 
-	fn seals_internally(&self) -> bool { true }
+	fn seals_internally(&self, _author: &Address) -> bool { true }
 
 	fn generate_seal(&self, _block: &ExecutedBlock, _accounts: Option<&AccountProvider>) -> Option<Vec<Bytes>> {
 		Some(Vec::new())

--- a/ethcore/src/engines/instant_seal.rs
+++ b/ethcore/src/engines/instant_seal.rs
@@ -58,7 +58,7 @@ impl Engine for InstantSeal {
 		Schedule::new_homestead()
 	}
 
-	fn seals_internally(&self, _author: &Address) -> bool { true }
+	fn is_sealer(&self, _author: &Address) -> Option<bool> { Some(true) }
 
 	fn generate_seal(&self, _block: &ExecutedBlock, _accounts: Option<&AccountProvider>) -> Option<Vec<Bytes>> {
 		Some(Vec::new())

--- a/ethcore/src/engines/mod.rs
+++ b/ethcore/src/engines/mod.rs
@@ -72,8 +72,10 @@ pub trait Engine : Sync + Send {
 	fn on_close_block(&self, _block: &mut ExecutedBlock) {}
 
 	/// If Some(true) this author is able to generate seals, generate_seal has to be implemented.
-	/// None indicates that this engine does not seal internally regardless of author (e.g. PoW).
+	/// None indicates that this Engine never seals internally regardless of author (e.g. PoW).
 	fn is_sealer(&self, _author: &Address) -> Option<bool> { None }
+	/// Checks if default address is able to seal.
+	fn is_default_sealer(&self) -> Option<bool> { self.is_sealer(&Default::default()) }
 	/// Attempt to seal the block internally.
 	///
 	/// If `Some` is returned, then you get a valid seal.

--- a/ethcore/src/engines/mod.rs
+++ b/ethcore/src/engines/mod.rs
@@ -72,7 +72,7 @@ pub trait Engine : Sync + Send {
 	fn on_close_block(&self, _block: &mut ExecutedBlock) {}
 
 	/// If true, generate_seal has to be implemented.
-	fn seals_internally(&self) -> bool { false }
+	fn seals_internally(&self, _author: &Address) -> bool { false }
 	/// Attempt to seal the block internally.
 	///
 	/// If `Some` is returned, then you get a valid seal.

--- a/ethcore/src/engines/mod.rs
+++ b/ethcore/src/engines/mod.rs
@@ -71,8 +71,9 @@ pub trait Engine : Sync + Send {
 	/// Block transformation functions, after the transactions.
 	fn on_close_block(&self, _block: &mut ExecutedBlock) {}
 
-	/// If true, generate_seal has to be implemented.
-	fn seals_internally(&self, _author: &Address) -> bool { false }
+	/// If Some(true) this author is able to generate seals, generate_seal has to be implemented.
+	/// None indicates that this engine does not seal internally regardless of author (e.g. PoW).
+	fn is_sealer(&self, _author: &Address) -> Option<bool> { None }
 	/// Attempt to seal the block internally.
 	///
 	/// If `Some` is returned, then you get a valid seal.

--- a/ethcore/src/miner/miner.rs
+++ b/ethcore/src/miner/miner.rs
@@ -224,7 +224,7 @@ impl Miner {
 
 	/// Creates new instance of a miner Arc.
 	pub fn new(options: MinerOptions, gas_pricer: GasPricer, spec: &Spec, accounts: Option<Arc<AccountProvider>>) -> Arc<Miner> {
-		Arc::new_raw(Miner::new(options, gas_pricer, spec, accounts)
+		Arc::new(Miner::new_raw(options, gas_pricer, spec, accounts))
 	}
 
 	fn forced_sealing(&self) -> bool {


### PR DESCRIPTION
Does not change any PoW logic (just adds a test).
Given `Engine` which does internal sealing check if sealing should be enabled. For `BasicAuthority` this means adding `--author` option with authority address to issue blocks, no `--force-sealing` necessary.