### PR TITLE
re-add lodash plugin to babel config

### DIFF
--- a/js/.babelrc
+++ b/js/.babelrc
@@ -1,5 +1,5 @@
 {
   "presets": ["es2017", "es2016", "es2015", "stage-0", "react"],
-  "plugins": ["transform-runtime", "transform-decorators-legacy", "transform-class-properties"],
+  "plugins": ["transform-runtime", "transform-decorators-legacy", "transform-class-properties", "lodash"],
   "retainLines": true
 }


### PR DESCRIPTION
#2083 dropped `babel-plugin-lodash`, which cherry-picks only parts of lodash. The results in a bundle that is `500k` smaller.