### PR TITLE
New signer token RPC & Initial signer connection without token.

### DIFF
--- a/devtools/src/http_client.rs
+++ b/devtools/src/http_client.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
+use std::time::Duration;
 use std::io::{Read, Write};
 use std::str::{self, Lines};
 use std::net::{TcpStream, SocketAddr};
@@ -43,10 +44,11 @@ pub fn read_block(lines: &mut Lines, all: bool) -> String {
 
 pub fn request(address: &SocketAddr, request: &str) -> Response {
 	let mut req = TcpStream::connect(address).unwrap();
+	req.set_read_timeout(Some(Duration::from_secs(1))).unwrap();
 	req.write_all(request.as_bytes()).unwrap();
 
 	let mut response = String::new();
-	req.read_to_string(&mut response).unwrap();
+	let _ = req.read_to_string(&mut response);
 
 	let mut lines = response.lines();
 	let status = lines.next().unwrap().to_owned();

--- a/devtools/src/random_path.rs
+++ b/devtools/src/random_path.rs
@@ -23,7 +23,8 @@ use std::ops::{Deref, DerefMut};
 use rand::random;
 
 pub struct RandomTempPath {
-	path: PathBuf
+	path: PathBuf,
+	pub panic_on_drop_failure: bool,
 }
 
 pub fn random_filename() -> String {
@@ -39,7 +40,8 @@ impl RandomTempPath {
 		let mut dir = env::temp_dir();
 		dir.push(random_filename());
 		RandomTempPath {
-			path: dir.clone()
+			path: dir.clone(),
+			panic_on_drop_failure: true,
 		}
 	}
 
@@ -48,7 +50,8 @@ impl RandomTempPath {
 		dir.push(random_filename());
 		fs::create_dir_all(dir.as_path()).unwrap();
 		RandomTempPath {
-			path: dir.clone()
+			path: dir.clone(),
+			panic_on_drop_failure: true,
 		}
 	}
 
@@ -72,12 +75,20 @@ impl AsRef<Path> for RandomTempPath {
 		self.as_path()
 	}
 }
+impl Deref for RandomTempPath {
+	type Target = Path;
+	fn deref(&self) -> &Self::Target {
+		self.as_path()
+	}
+}
 
 impl Drop for RandomTempPath {
 	fn drop(&mut self) {
 		if let Err(_) = fs::remove_dir_all(&self) {
 			if let Err(e) = fs::remove_file(&self) {
-				panic!("Failed to remove temp directory. Here's what prevented this from happening:  ({})", e);
+				if self.panic_on_drop_failure {
+					panic!("Failed to remove temp directory. Here's what prevented this from happening:  ({})", e);
+				}
 			}
 		}
 	}

--- a/parity/run.rs
+++ b/parity/run.rs
@@ -206,9 +206,10 @@ pub fn execute(cmd: RunCmd) -> Result<(), String> {
 	}
 
 	// set up dependencies for rpc servers
+	let signer_path = cmd.signer_conf.signer_path.clone();
 	let deps_for_rpc_apis = Arc::new(rpc_apis::Dependencies {
 		signer_port: cmd.signer_port,
-		signer_queue: Arc::new(rpc_apis::ConfirmationsQueue::default()),
+		signer_service: Arc::new(rpc_apis::SignerService::new(move || signer::new_token(signer_path.clone()))),
 		client: client.clone(),
 		sync: sync_provider.clone(),
 		net: manage_network.clone(),

--- a/parity/signer.rs
+++ b/parity/signer.rs
@@ -90,7 +90,7 @@ fn do_start(conf: Configuration, deps: Dependencies) -> Result<SignerServer, Str
 
 	let start_result = {
 		let server = signer::ServerBuilder::new(
-			deps.apis.signer_queue.clone(),
+			deps.apis.signer_service.queue(),
 			codes_path(conf.signer_path),
 		);
 		if conf.skip_origin_validation {

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -53,7 +53,7 @@ use self::jsonrpc_core::{IoHandler, IoDelegate};
 
 pub use jsonrpc_http_server::{ServerBuilder, Server, RpcServerError};
 pub mod v1;
-pub use v1::{SigningQueue, ConfirmationsQueue, NetworkSettings};
+pub use v1::{SigningQueue, SignerService, ConfirmationsQueue, NetworkSettings};
 
 /// An object that can be extended with `IoDelegates`
 pub trait Extendable {

--- a/rpc/src/v1/helpers/errors.rs
+++ b/rpc/src/v1/helpers/errors.rs
@@ -139,6 +139,13 @@ pub fn no_author() -> Error {
 	}
 }
 
+pub fn token(e: String) -> Error {
+	Error {
+		code: ErrorCode::ServerError(codes::UNKNOWN_ERROR),
+		message: "There was an error when saving your authorization tokens.".into(),
+		data: Some(Value::String(e)),
+	}
+}
 
 pub fn signer_disabled() -> Error {
 	Error {

--- a/rpc/src/v1/helpers/mod.rs
+++ b/rpc/src/v1/helpers/mod.rs
@@ -21,6 +21,7 @@ pub mod params;
 mod poll_manager;
 mod poll_filter;
 mod requests;
+mod signer;
 mod signing_queue;
 mod network_settings;
 
@@ -28,4 +29,5 @@ pub use self::poll_manager::PollManager;
 pub use self::poll_filter::PollFilter;
 pub use self::requests::{TransactionRequest, FilledTransactionRequest, ConfirmationRequest, ConfirmationPayload, CallRequest};
 pub use self::signing_queue::{ConfirmationsQueue, ConfirmationPromise, ConfirmationResult, SigningQueue, QueueEvent};
+pub use self::signer::SignerService;
 pub use self::network_settings::NetworkSettings;

--- a/rpc/src/v1/helpers/signer.rs
+++ b/rpc/src/v1/helpers/signer.rs
@@ -1,0 +1,61 @@
+// Copyright 2015, 2016 Ethcore (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+use std::sync::Arc;
+use std::ops::Deref;
+use v1::helpers::signing_queue::{ConfirmationsQueue};
+
+/// Manages communication with Signer crate
+pub struct SignerService {
+	queue: Arc<ConfirmationsQueue>,
+	generate_new_token: Box<Fn() -> Result<String, String> + Send + Sync + 'static>,
+}
+
+impl SignerService {
+
+	/// Creates new Signer Service given function to generate new tokens.
+	pub fn new<F>(new_token: F) -> Self
+		where F: Fn() -> Result<String, String> + Send + Sync + 'static {
+		SignerService {
+			queue: Arc::new(ConfirmationsQueue::default()),
+			generate_new_token: Box::new(new_token),
+		}
+	}
+
+	/// Generates new token.
+	pub fn generate_token(&self) -> Result<String, String> {
+		(self.generate_new_token)()
+	}
+
+	/// Returns a reference to `ConfirmationsQueue`
+	pub fn queue(&self) -> Arc<ConfirmationsQueue> {
+		self.queue.clone()
+	}
+
+	#[cfg(test)]
+	/// Creates new Signer Service for tests.
+	pub fn new_test() -> Self {
+		SignerService::new(|| Ok("new_token".into()))
+	}
+}
+
+impl Deref for SignerService {
+	type Target = ConfirmationsQueue;
+	fn deref(&self) -> &Self::Target {
+		&self.queue
+	}
+}
+

--- a/rpc/src/v1/impls/personal_signer.rs
+++ b/rpc/src/v1/impls/personal_signer.rs
@@ -43,7 +43,7 @@ impl<C: 'static, M: 'static> SignerClient<C, M> where C: MiningBlockChainClient,
 		client: &Arc<C>,
 		miner: &Arc<M>,
 		signer: &Arc<SignerService>,
-		) -> Self {
+	) -> Self {
 		SignerClient {
 			signer: Arc::downgrade(signer),
 			accounts: Arc::downgrade(store),

--- a/rpc/src/v1/impls/personal_signer.rs
+++ b/rpc/src/v1/impls/personal_signer.rs
@@ -23,13 +23,13 @@ use ethcore::client::MiningBlockChainClient;
 use ethcore::miner::MinerService;
 use v1::traits::PersonalSigner;
 use v1::types::{TransactionModification, ConfirmationRequest, U256};
-use v1::helpers::{errors, SigningQueue, ConfirmationsQueue, ConfirmationPayload};
+use v1::helpers::{errors, SignerService, SigningQueue, ConfirmationPayload};
 use v1::helpers::params::expect_no_params;
 use v1::helpers::dispatch::{unlock_sign_and_dispatch, signature_with_password};
 
 /// Transactions confirmation (personal) rpc implementation.
 pub struct SignerClient<C, M> where C: MiningBlockChainClient, M: MinerService {
-	queue: Weak<ConfirmationsQueue>,
+	signer: Weak<SignerService>,
 	accounts: Weak<AccountProvider>,
 	client: Weak<C>,
 	miner: Weak<M>,
@@ -38,9 +38,14 @@ pub struct SignerClient<C, M> where C: MiningBlockChainClient, M: MinerService {
 impl<C: 'static, M: 'static> SignerClient<C, M> where C: MiningBlockChainClient, M: MinerService {
 
 	/// Create new instance of signer client.
-	pub fn new(store: &Arc<AccountProvider>, client: &Arc<C>, miner: &Arc<M>, queue: &Arc<ConfirmationsQueue>) -> Self {
+	pub fn new(
+		store: &Arc<AccountProvider>,
+		client: &Arc<C>,
+		miner: &Arc<M>,
+		signer: &Arc<SignerService>,
+		) -> Self {
 		SignerClient {
-			queue: Arc::downgrade(queue),
+			signer: Arc::downgrade(signer),
 			accounts: Arc::downgrade(store),
 			client: Arc::downgrade(client),
 			miner: Arc::downgrade(miner),
@@ -59,8 +64,8 @@ impl<C: 'static, M: 'static> PersonalSigner for SignerClient<C, M> where C: Mini
 	fn requests_to_confirm(&self, params: Params) -> Result<Value, Error> {
 		try!(self.active());
 		try!(expect_no_params(params));
-		let queue = take_weak!(self.queue);
-		Ok(to_value(&queue.requests().into_iter().map(From::from).collect::<Vec<ConfirmationRequest>>()))
+		let signer = take_weak!(self.signer);
+		Ok(to_value(&signer.requests().into_iter().map(From::from).collect::<Vec<ConfirmationRequest>>()))
 	}
 
 	fn confirm_request(&self, params: Params) -> Result<Value, Error> {
@@ -71,11 +76,11 @@ impl<C: 'static, M: 'static> PersonalSigner for SignerClient<C, M> where C: Mini
 			|(id, modification, pass)| {
 				let id = id.into();
 				let accounts = take_weak!(self.accounts);
-				let queue = take_weak!(self.queue);
+				let signer = take_weak!(self.signer);
 				let client = take_weak!(self.client);
 				let miner = take_weak!(self.miner);
 
-				queue.peek(&id).map(|confirmation| {
+				signer.peek(&id).map(|confirmation| {
 					let result = match confirmation.payload {
 						ConfirmationPayload::Transaction(mut request) => {
 							// apply modification
@@ -90,7 +95,7 @@ impl<C: 'static, M: 'static> PersonalSigner for SignerClient<C, M> where C: Mini
 						}
 					};
 					if let Ok(ref response) = result {
-						queue.request_confirmed(id, Ok(response.clone()));
+						signer.request_confirmed(id, Ok(response.clone()));
 					}
 					result
 				}).unwrap_or_else(|| Err(errors::invalid_params("Unknown RequestID", id)))
@@ -102,11 +107,20 @@ impl<C: 'static, M: 'static> PersonalSigner for SignerClient<C, M> where C: Mini
 		try!(self.active());
 		from_params::<(U256, )>(params).and_then(
 			|(id, )| {
-				let queue = take_weak!(self.queue);
-				let res = queue.request_rejected(id.into());
+				let signer = take_weak!(self.signer);
+				let res = signer.request_rejected(id.into());
 				Ok(to_value(&res.is_some()))
 			}
 		)
+	}
+
+	fn generate_token(&self, params: Params) -> Result<Value, Error> {
+		try!(self.active());
+		try!(expect_no_params(params));
+		let signer = take_weak!(self.signer);
+		signer.generate_token()
+			.map(|token| to_value(&token))
+			.map_err(|e| errors::token(e))
 	}
 }
 

--- a/rpc/src/v1/mod.rs
+++ b/rpc/src/v1/mod.rs
@@ -28,4 +28,4 @@ pub mod types;
 
 pub use self::traits::{Web3, Eth, EthFilter, EthSigning, Personal, PersonalSigner, Net, Ethcore, EthcoreSet, Traces, Rpc};
 pub use self::impls::*;
-pub use self::helpers::{SigningQueue, ConfirmationsQueue, NetworkSettings};
+pub use self::helpers::{SigningQueue, SignerService, ConfirmationsQueue, NetworkSettings};

--- a/rpc/src/v1/tests/mocked/ethcore.rs
+++ b/rpc/src/v1/tests/mocked/ethcore.rs
@@ -22,7 +22,7 @@ use ethcore::client::{TestBlockChainClient};
 
 use jsonrpc_core::IoHandler;
 use v1::{Ethcore, EthcoreClient};
-use v1::helpers::{ConfirmationsQueue, NetworkSettings};
+use v1::helpers::{SignerService, NetworkSettings};
 use v1::tests::helpers::{TestSyncProvider, Config, TestMinerService};
 use super::manage_network::TestManageNetwork;
 
@@ -262,8 +262,8 @@ fn rpc_ethcore_unsigned_transactions_count() {
 	let sync = sync_provider();
 	let net = network_service();
 	let io = IoHandler::new();
-	let queue = Arc::new(ConfirmationsQueue::default());
-	let ethcore = EthcoreClient::new(&client, &miner, &sync, &net, logger(), settings(), Some(queue)).to_delegate();
+	let signer = Arc::new(SignerService::new_test());
+	let ethcore = EthcoreClient::new(&client, &miner, &sync, &net, logger(), settings(), Some(signer)).to_delegate();
 	io.add_delegate(ethcore);
 
 	let request = r#"{"jsonrpc": "2.0", "method": "ethcore_unsignedTransactionsCount", "params":[], "id": 1}"#;

--- a/rpc/src/v1/tests/mocked/personal_signer.rs
+++ b/rpc/src/v1/tests/mocked/personal_signer.rs
@@ -23,10 +23,10 @@ use ethcore::client::TestBlockChainClient;
 use ethcore::transaction::{Transaction, Action};
 use v1::{SignerClient, PersonalSigner};
 use v1::tests::helpers::TestMinerService;
-use v1::helpers::{SigningQueue, ConfirmationsQueue, FilledTransactionRequest, ConfirmationPayload};
+use v1::helpers::{SigningQueue, SignerService, FilledTransactionRequest, ConfirmationPayload};
 
 struct PersonalSignerTester {
-	queue: Arc<ConfirmationsQueue>,
+	signer: Arc<SignerService>,
 	accounts: Arc<AccountProvider>,
 	io: IoHandler,
 	miner: Arc<TestMinerService>,
@@ -49,16 +49,16 @@ fn miner_service() -> Arc<TestMinerService> {
 }
 
 fn signer_tester() -> PersonalSignerTester {
-	let queue = Arc::new(ConfirmationsQueue::default());
+	let signer = Arc::new(SignerService::new_test());
 	let accounts = accounts_provider();
 	let client = blockchain_client();
 	let miner = miner_service();
 
 	let io = IoHandler::new();
-	io.add_delegate(SignerClient::new(&accounts, &client, &miner, &queue).to_delegate());
+	io.add_delegate(SignerClient::new(&accounts, &client, &miner, &signer).to_delegate());
 
 	PersonalSignerTester {
-		queue: queue,
+		signer: signer,
 		accounts: accounts,
 		io: io,
 		miner: miner,
@@ -71,7 +71,7 @@ fn signer_tester() -> PersonalSignerTester {
 fn should_return_list_of_items_to_confirm() {
 	// given
 	let tester = signer_tester();
-	tester.queue.add_request(ConfirmationPayload::Transaction(FilledTransactionRequest {
+	tester.signer.add_request(ConfirmationPayload::Transaction(FilledTransactionRequest {
 		from: Address::from(1),
 		to: Some(Address::from_str("d46e8dd67c5d32be8058bb8eb970870f07244567").unwrap()),
 		gas_price: U256::from(10_000),
@@ -80,7 +80,7 @@ fn should_return_list_of_items_to_confirm() {
 		data: vec![],
 		nonce: None,
 	})).unwrap();
-	tester.queue.add_request(ConfirmationPayload::Sign(1.into(), 5.into())).unwrap();
+	tester.signer.add_request(ConfirmationPayload::Sign(1.into(), 5.into())).unwrap();
 
 	// when
 	let request = r#"{"jsonrpc":"2.0","method":"personal_requestsToConfirm","params":[],"id":1}"#;
@@ -100,7 +100,7 @@ fn should_return_list_of_items_to_confirm() {
 fn should_reject_transaction_from_queue_without_dispatching() {
 	// given
 	let tester = signer_tester();
-	tester.queue.add_request(ConfirmationPayload::Transaction(FilledTransactionRequest {
+	tester.signer.add_request(ConfirmationPayload::Transaction(FilledTransactionRequest {
 		from: Address::from(1),
 		to: Some(Address::from_str("d46e8dd67c5d32be8058bb8eb970870f07244567").unwrap()),
 		gas_price: U256::from(10_000),
@@ -109,7 +109,7 @@ fn should_reject_transaction_from_queue_without_dispatching() {
 		data: vec![],
 		nonce: None,
 	})).unwrap();
-	assert_eq!(tester.queue.requests().len(), 1);
+	assert_eq!(tester.signer.requests().len(), 1);
 
 	// when
 	let request = r#"{"jsonrpc":"2.0","method":"personal_rejectRequest","params":["0x1"],"id":1}"#;
@@ -117,7 +117,7 @@ fn should_reject_transaction_from_queue_without_dispatching() {
 
 	// then
 	assert_eq!(tester.io.handle_request_sync(&request), Some(response.to_owned()));
-	assert_eq!(tester.queue.requests().len(), 0);
+	assert_eq!(tester.signer.requests().len(), 0);
 	assert_eq!(tester.miner.imported_transactions.lock().len(), 0);
 }
 
@@ -125,7 +125,7 @@ fn should_reject_transaction_from_queue_without_dispatching() {
 fn should_not_remove_transaction_if_password_is_invalid() {
 	// given
 	let tester = signer_tester();
-	tester.queue.add_request(ConfirmationPayload::Transaction(FilledTransactionRequest {
+	tester.signer.add_request(ConfirmationPayload::Transaction(FilledTransactionRequest {
 		from: Address::from(1),
 		to: Some(Address::from_str("d46e8dd67c5d32be8058bb8eb970870f07244567").unwrap()),
 		gas_price: U256::from(10_000),
@@ -134,7 +134,7 @@ fn should_not_remove_transaction_if_password_is_invalid() {
 		data: vec![],
 		nonce: None,
 	})).unwrap();
-	assert_eq!(tester.queue.requests().len(), 1);
+	assert_eq!(tester.signer.requests().len(), 1);
 
 	// when
 	let request = r#"{"jsonrpc":"2.0","method":"personal_confirmRequest","params":["0x1",{},"xxx"],"id":1}"#;
@@ -142,15 +142,15 @@ fn should_not_remove_transaction_if_password_is_invalid() {
 
 	// then
 	assert_eq!(tester.io.handle_request_sync(&request), Some(response.to_owned()));
-	assert_eq!(tester.queue.requests().len(), 1);
+	assert_eq!(tester.signer.requests().len(), 1);
 }
 
 #[test]
 fn should_not_remove_sign_if_password_is_invalid() {
 	// given
 	let tester = signer_tester();
-	tester.queue.add_request(ConfirmationPayload::Sign(0.into(), 5.into())).unwrap();
-	assert_eq!(tester.queue.requests().len(), 1);
+	tester.signer.add_request(ConfirmationPayload::Sign(0.into(), 5.into())).unwrap();
+	assert_eq!(tester.signer.requests().len(), 1);
 
 	// when
 	let request = r#"{"jsonrpc":"2.0","method":"personal_confirmRequest","params":["0x1",{},"xxx"],"id":1}"#;
@@ -158,7 +158,7 @@ fn should_not_remove_sign_if_password_is_invalid() {
 
 	// then
 	assert_eq!(tester.io.handle_request_sync(&request), Some(response.to_owned()));
-	assert_eq!(tester.queue.requests().len(), 1);
+	assert_eq!(tester.signer.requests().len(), 1);
 }
 
 #[test]
@@ -167,7 +167,7 @@ fn should_confirm_transaction_and_dispatch() {
 	let tester = signer_tester();
 	let address = tester.accounts.new_account("test").unwrap();
 	let recipient = Address::from_str("d46e8dd67c5d32be8058bb8eb970870f07244567").unwrap();
-	tester.queue.add_request(ConfirmationPayload::Transaction(FilledTransactionRequest {
+	tester.signer.add_request(ConfirmationPayload::Transaction(FilledTransactionRequest {
 		from: address,
 		to: Some(recipient),
 		gas_price: U256::from(10_000),
@@ -189,7 +189,7 @@ fn should_confirm_transaction_and_dispatch() {
 	let signature = tester.accounts.sign(address, t.hash()).unwrap();
 	let t = t.with_signature(signature);
 
-	assert_eq!(tester.queue.requests().len(), 1);
+	assert_eq!(tester.signer.requests().len(), 1);
 
 	// when
 	let request = r#"{
@@ -202,7 +202,24 @@ fn should_confirm_transaction_and_dispatch() {
 
 	// then
 	assert_eq!(tester.io.handle_request_sync(&request), Some(response.to_owned()));
-	assert_eq!(tester.queue.requests().len(), 0);
+	assert_eq!(tester.signer.requests().len(), 0);
 	assert_eq!(tester.miner.imported_transactions.lock().len(), 1);
 }
 
+#[test]
+fn should_generate_new_token() {
+	// given
+	let tester = signer_tester();
+
+	// when
+	let request = r#"{
+		"jsonrpc":"2.0",
+		"method":"personal_generateAuthorizationToken",
+		"params":[],
+		"id":1
+	}"#;
+	let response = r#"{"jsonrpc":"2.0","result":"new_token","id":1}"#;
+
+	// then
+	assert_eq!(tester.io.handle_request_sync(&request), Some(response.to_owned()));
+}

--- a/rpc/src/v1/traits/personal.rs
+++ b/rpc/src/v1/traits/personal.rs
@@ -92,12 +92,16 @@ pub trait PersonalSigner: Sized + Send + Sync + 'static {
 	/// Reject the confirmation request.
 	fn reject_request(&self, _: Params) -> Result<Value, Error>;
 
+	/// Generates new authorization token.
+	fn generate_token(&self, _: Params) -> Result<Value, Error>;
+
 	/// Should be used to convert object to io delegate.
 	fn to_delegate(self) -> IoDelegate<Self> {
 		let mut delegate = IoDelegate::new(Arc::new(self));
 		delegate.add_method("personal_requestsToConfirm", PersonalSigner::requests_to_confirm);
 		delegate.add_method("personal_confirmRequest", PersonalSigner::confirm_request);
 		delegate.add_method("personal_rejectRequest", PersonalSigner::reject_request);
+		delegate.add_method("personal_generateAuthorizationToken", PersonalSigner::generate_token);
 		delegate
 	}
 }

--- a/signer/src/authcode_store.rs
+++ b/signer/src/authcode_store.rs
@@ -48,6 +48,7 @@ impl TimeProvider for DefaultTimeProvider {
 /// No of seconds the hash is valid
 const TIME_THRESHOLD: u64 = 7;
 const TOKEN_LENGTH: usize = 16;
+const INITIAL_TOKEN: &'static str = "initial";
 
 /// Manages authorization codes for `SignerUIs`
 pub struct AuthCodes<T: TimeProvider = DefaultTimeProvider> {
@@ -98,7 +99,7 @@ impl<T: TimeProvider> AuthCodes<T> {
 	}
 
 	/// Checks if given hash is correct identifier of `SignerUI`
-	pub fn is_valid(&self, hash: &H256, time: u64) -> bool {
+	pub fn is_valid(&mut self, hash: &H256, time: u64) -> bool {
 		let now = self.now.now();
 		// check time
 		if time >= now + TIME_THRESHOLD || time <= now - TIME_THRESHOLD {
@@ -106,9 +107,21 @@ impl<T: TimeProvider> AuthCodes<T> {
 			return false;
 		}
 
+		let as_token = |code| format!("{}:{}", code, time).sha3();
+
+		// Check if it's the initial token.
+		if self.is_empty() {
+			let initial = &as_token(INITIAL_TOKEN) == hash;
+			// Initial token can be used only once.
+			if initial {
+				let _ = self.generate_new();
+			}
+			return initial;
+		}
+
 		// look for code
 		self.codes.iter()
-			.any(|code| &format!("{}:{}", code, time).sha3() == hash)
+			.any(|code| &as_token(code) == hash)
 	}
 
 	/// Generates and returns a new code that can be used by `SignerUIs`
@@ -124,6 +137,11 @@ impl<T: TimeProvider> AuthCodes<T> {
 		self.codes.push(code);
 		Ok(readable_code)
 	}
+
+	/// Returns true if there are no tokens in this store
+	pub fn is_empty(&self) -> bool {
+		self.codes.is_empty()
+	}
 }
 
 
@@ -138,11 +156,27 @@ mod tests {
 	}
 
 	#[test]
+	fn should_return_true_if_code_is_initial_and_store_is_empty() {
+			// given
+		let code = "initial";
+		let time = 99;
+		let mut codes = AuthCodes::new(vec![], || 100);
+
+		// when
+		let res1 = codes.is_valid(&generate_hash(code, time), time);
+		let res2 = codes.is_valid(&generate_hash(code, time), time);
+
+		// then
+		assert_eq!(res1, true);
+		assert_eq!(res2, false);
+	}
+
+	#[test]
 	fn should_return_true_if_hash_is_valid() {
 		// given
 		let code = "23521352asdfasdfadf";
 		let time = 99;
-		let codes = AuthCodes::new(vec![code.into()], || 100);
+		let mut codes = AuthCodes::new(vec![code.into()], || 100);
 
 		// when
 		let res = codes.is_valid(&generate_hash(code, time), time);
@@ -156,7 +190,7 @@ mod tests {
 		// given
 		let code = "23521352asdfasdfadf";
 		let time = 99;
-		let codes = AuthCodes::new(vec!["1".into()], || 100);
+		let mut codes = AuthCodes::new(vec!["1".into()], || 100);
 
 		// when
 		let res = codes.is_valid(&generate_hash(code, time), time);
@@ -171,7 +205,7 @@ mod tests {
 		let code = "23521352asdfasdfadf";
 		let time = 107;
 		let time2 = 93;
-		let codes = AuthCodes::new(vec![code.into()], || 100);
+		let mut codes = AuthCodes::new(vec![code.into()], || 100);
 
 		// when
 		let res1 = codes.is_valid(&generate_hash(code, time), time);

--- a/signer/src/authcode_store.rs
+++ b/signer/src/authcode_store.rs
@@ -157,7 +157,7 @@ mod tests {
 
 	#[test]
 	fn should_return_true_if_code_is_initial_and_store_is_empty() {
-			// given
+		// given
 		let code = "initial";
 		let time = 99;
 		let mut codes = AuthCodes::new(vec![], || 100);

--- a/signer/src/lib.rs
+++ b/signer/src/lib.rs
@@ -34,7 +34,7 @@
 //!
 //! use std::sync::Arc;
 //! use ethcore_signer::ServerBuilder;
-//! use ethcore_rpc::ConfirmationsQueue;
+//! use ethcore_rpc::SignerService;
 //!
 //!	fn main() {
 //!	 let queue = Arc::new(ConfirmationsQueue::default());

--- a/signer/src/lib.rs
+++ b/signer/src/lib.rs
@@ -34,7 +34,7 @@
 //!
 //! use std::sync::Arc;
 //! use ethcore_signer::ServerBuilder;
-//! use ethcore_rpc::SignerService;
+//! use ethcore_rpc::ConfirmationsQueue;
 //!
 //!	fn main() {
 //!	 let queue = Arc::new(ConfirmationsQueue::default());

--- a/signer/src/ws_server/mod.rs
+++ b/signer/src/ws_server/mod.rs
@@ -180,7 +180,6 @@ impl Drop for Server {
 		self.queue.finish();
 		self.broadcaster_handle.take().unwrap().join().unwrap();
 		self.handle.take().unwrap().join().unwrap();
-
 	}
 }
 

--- a/signer/src/ws_server/session.rs
+++ b/signer/src/ws_server/session.rs
@@ -59,7 +59,7 @@ fn origin_is_allowed(self_origin: &str, header: Option<&[u8]>) -> bool {
 	}
 }
 
-fn auth_is_valid(codes: &Path, protocols: ws::Result<Vec<&str>>) -> bool {
+fn auth_is_valid(codes_path: &Path, protocols: ws::Result<Vec<&str>>) -> bool {
 	match protocols {
 		Ok(ref protocols) if protocols.len() == 1 => {
 			protocols.iter().any(|protocol| {
@@ -69,8 +69,15 @@ fn auth_is_valid(codes: &Path, protocols: ws::Result<Vec<&str>>) -> bool {
 
 				if let (Some(auth), Some(time)) = (auth, time) {
 					// Check if the code is valid
-					AuthCodes::from_file(codes)
-						.map(|codes| codes.is_valid(&auth, time))
+					AuthCodes::from_file(codes_path)
+						.map(|mut codes| {
+							let res = codes.is_valid(&auth, time);
+							// make sure to save back authcodes - it might have been modified
+							if let Err(e) = codes.to_file(codes_path) {
+								warn!(target: "signer", "Couldn't save authorization codes to file.");
+							}
+							res
+						})
 						.unwrap_or(false)
 				} else {
 					false

--- a/signer/src/ws_server/session.rs
+++ b/signer/src/ws_server/session.rs
@@ -73,7 +73,7 @@ fn auth_is_valid(codes_path: &Path, protocols: ws::Result<Vec<&str>>) -> bool {
 						.map(|mut codes| {
 							let res = codes.is_valid(&auth, time);
 							// make sure to save back authcodes - it might have been modified
-							if let Err(e) = codes.to_file(codes_path) {
+							if let Err(_) = codes.to_file(codes_path) {
 								warn!(target: "signer", "Couldn't save authorization codes to file.");
 							}
 							res


### PR DESCRIPTION
1. `personal_generateAuthorizationToken` RPC method available only over Signer's WebSocket connection.
2. When there are no tokens generated (store is empty = i.e. first run) single WebSocket connection will be allowed to access using special token with value `initial`.

Closes #1999 