### PR TITLE
contract events, indexed string fix

### DIFF
--- a/js/src/abi/decoder/decoder.js
+++ b/js/src/abi/decoder/decoder.js
@@ -101,7 +101,7 @@ export default class Decoder {
         if (param.indexed) {
           taken = Decoder.takeBytes(slices, offset, 32);
 
-          return new DecodeResult(new Token(param.type, taken.bytes), taken.newOffset);
+          return new DecodeResult(new Token('fixedBytes', taken.bytes), offset + 1);
         }
 
         lengthOffset = asU32(Decoder.peek(slices, offset)).div(32).toNumber();

--- a/js/src/abi/decoder/decoder.js
+++ b/js/src/abi/decoder/decoder.js
@@ -98,6 +98,12 @@ export default class Decoder {
         return new DecodeResult(new Token(param.type, taken.bytes), offset + 1);
 
       case 'string':
+        if (param.indexed) {
+          taken = Decoder.takeBytes(slices, offset, 32);
+
+          return new DecodeResult(new Token(param.type, taken.bytes), taken.newOffset);
+        }
+
         lengthOffset = asU32(Decoder.peek(slices, offset)).div(32).toNumber();
         length = asU32(Decoder.peek(slices, lengthOffset)).toNumber();
         taken = Decoder.takeBytes(slices, lengthOffset + 1, length);

--- a/js/src/abi/decoder/decoder.spec.js
+++ b/js/src/abi/decoder/decoder.spec.js
@@ -166,6 +166,12 @@ describe('abi/decoder/Decoder', () => {
         Decoder.decodeParam(new ParamType('string'), [padU32(0x20), padU32(9), string1], 0).token
       ).to.deep.equal(tokenString1);
     });
+
+    it('decodes string (indexed)', () => {
+      expect(
+        Decoder.decodeParam(new ParamType('string', null, 0, true), [bytes1], 0)
+      ).to.deep.equal(Decoder.decodeParam(new ParamType('fixedBytes', null, 32, true), [bytes1], 0));
+    });
   });
 
   describe('decode', () => {

--- a/js/src/abi/spec/event/event.spec.js
+++ b/js/src/abi/spec/event/event.spec.js
@@ -46,7 +46,7 @@ describe('abi/spec/event/Event', () => {
 
   describe('inputParamTypes', () => {
     it('returns all the types', () => {
-      expect(event.inputParamTypes()).to.deep.equal([new ParamType('bool'), new ParamType('uint', null, 256)]);
+      expect(event.inputParamTypes()).to.deep.equal([new ParamType('bool'), new ParamType('uint', null, 256, true)]);
     });
   });
 
@@ -86,9 +86,9 @@ describe('abi/spec/event/Event', () => {
       expect(decoded.address).to.equal('0x4444444444444444444444444444444444444444');
       expect(decoded.params).to.deep.equal([
         new DecodedLogParam('a', new ParamType('int', null, 256), new Token('int', new BigNumber(3))),
-        new DecodedLogParam('b', new ParamType('int', null, 256), new Token('int', new BigNumber(2))),
+        new DecodedLogParam('b', new ParamType('int', null, 256, true), new Token('int', new BigNumber(2))),
         new DecodedLogParam('c', new ParamType('address'), new Token('address', '0x2222222222222222222222222222222222222222')),
-        new DecodedLogParam('d', new ParamType('address'), new Token('address', '0x1111111111111111111111111111111111111111'))
+        new DecodedLogParam('d', new ParamType('address', null, 0, true), new Token('address', '0x1111111111111111111111111111111111111111'))
       ]);
     });
 

--- a/js/src/abi/spec/event/eventParam.js
+++ b/js/src/abi/spec/event/eventParam.js
@@ -17,10 +17,10 @@
 import { toParamType } from '../paramType/format';
 
 export default class EventParam {
-  constructor (name, type, indexed) {
+  constructor (name, type, indexed = false) {
     this._name = name;
-    this._kind = toParamType(type);
-    this._indexed = !!indexed;
+    this._indexed = indexed;
+    this._kind = toParamType(type, indexed);
   }
 
   get name () {

--- a/js/src/abi/spec/event/eventParam.spec.js
+++ b/js/src/abi/spec/event/eventParam.spec.js
@@ -18,12 +18,15 @@ import EventParam from './eventParam';
 
 describe('abi/spec/event/EventParam', () => {
   describe('constructor', () => {
-    const param = new EventParam('foo', 'uint', true);
-
     it('sets the properties', () => {
+      const param = new EventParam('foo', 'uint', true);
       expect(param.name).to.equal('foo');
       expect(param.kind.type).to.equal('uint');
       expect(param.indexed).to.be.true;
+    });
+
+    it('uses defaults for indexed', () => {
+      expect(new EventParam('foo', 'uint').indexed).to.be.false;
     });
   });
 

--- a/js/src/abi/spec/paramType/format.js
+++ b/js/src/abi/spec/paramType/format.js
@@ -16,17 +16,17 @@
 
 import ParamType from './paramType';
 
-export function toParamType (type) {
+export function toParamType (type, indexed = false) {
   if (type[type.length - 1] === ']') {
     const last = type.lastIndexOf('[');
     const length = type.substr(last + 1, type.length - last - 2);
     const subtype = toParamType(type.substr(0, last));
 
     if (length.length === 0) {
-      return new ParamType('array', subtype);
+      return new ParamType('array', subtype, 0, indexed);
     }
 
-    return new ParamType('fixedArray', subtype, parseInt(length, 10));
+    return new ParamType('fixedArray', subtype, parseInt(length, 10), indexed);
   }
 
   switch (type) {
@@ -34,19 +34,19 @@ export function toParamType (type) {
     case 'bool':
     case 'bytes':
     case 'string':
-      return new ParamType(type);
+      return new ParamType(type, null, 0, indexed);
 
     case 'int':
     case 'uint':
-      return new ParamType(type, null, 256);
+      return new ParamType(type, null, 256, indexed);
 
     default:
       if (type.indexOf('uint') === 0) {
-        return new ParamType('uint', null, parseInt(type.substr(4), 10));
+        return new ParamType('uint', null, parseInt(type.substr(4), 10), indexed);
       } else if (type.indexOf('int') === 0) {
-        return new ParamType('int', null, parseInt(type.substr(3), 10));
+        return new ParamType('int', null, parseInt(type.substr(3), 10), indexed);
       } else if (type.indexOf('bytes') === 0) {
-        return new ParamType('fixedBytes', null, parseInt(type.substr(5), 10));
+        return new ParamType('fixedBytes', null, parseInt(type.substr(5), 10), indexed);
       }
 
       throw new Error(`Cannot convert ${type} to valid ParamType`);

--- a/js/src/abi/spec/paramType/format.js
+++ b/js/src/abi/spec/paramType/format.js
@@ -16,7 +16,7 @@
 
 import ParamType from './paramType';
 
-export function toParamType (type, indexed = false) {
+export function toParamType (type, indexed) {
   if (type[type.length - 1] === ']') {
     const last = type.lastIndexOf('[');
     const length = type.substr(last + 1, type.length - last - 2);

--- a/js/src/abi/spec/paramType/paramType.js
+++ b/js/src/abi/spec/paramType/paramType.js
@@ -17,7 +17,7 @@
 import TYPES from './types';
 
 export default class ParamType {
-  constructor (type, subtype, length, indexed) {
+  constructor (type, subtype = null, length = 0, indexed = false) {
     ParamType.validateType(type);
 
     this._type = type;

--- a/js/src/abi/spec/paramType/paramType.js
+++ b/js/src/abi/spec/paramType/paramType.js
@@ -17,12 +17,13 @@
 import TYPES from './types';
 
 export default class ParamType {
-  constructor (type, subtype, length) {
+  constructor (type, subtype, length, indexed) {
     ParamType.validateType(type);
 
     this._type = type;
     this._subtype = subtype;
     this._length = length;
+    this._indexed = indexed;
   }
 
   get type () {
@@ -35,6 +36,10 @@ export default class ParamType {
 
   get length () {
     return this._length;
+  }
+
+  get indexed () {
+    return this._indexed;
   }
 
   static validateType (type) {

--- a/js/src/abi/spec/paramType/paramType.spec.js
+++ b/js/src/abi/spec/paramType/paramType.spec.js
@@ -75,5 +75,13 @@ describe('abi/spec/paramType/ParamType', () => {
     it('sets the length of the object', () => {
       expect((new ParamType('array', 'bool', 1)).length).to.equal(1);
     });
+
+    it('sets the index of the object', () => {
+      expect((new ParamType('array', 'bool', 1, true)).indexed).to.be.true;
+    });
+
+    it('sets default values where none supplied', () => {
+      expect(Object.values(new ParamType('string'))).to.deep.equal(['string', null, 0, false]);
+    });
   });
 });


### PR DESCRIPTION
When an event has an indexed string parameter, the actual string value does not get returned as part of the event, rather the sha3 appears in-place. Decode this properly returning the bytes32 value as part of the actual log.