### PR TITLE
Various state copy optimizations

### DIFF
--- a/ethcore/src/block.rs
+++ b/ethcore/src/block.rs
@@ -391,7 +391,9 @@ impl ClosedBlock {
 	pub fn lock(mut self) -> LockedBlock {
 		// finalize the changes made by the engine.
 		self.block.state.clear_snapshot();
-		self.block.state.commit();
+		if let Err(e) = self.block.state.commit() {
+			warn!("Error committing closed block's state: {:?}", e);
+		}
 
 		LockedBlock {
 			block: self.block,

--- a/ethcore/src/ethereum/ethash.rs
+++ b/ethcore/src/ethereum/ethash.rs
@@ -167,9 +167,7 @@ impl Engine for Ethash {
 		for u in fields.uncles.iter() {
 			fields.state.add_balance(u.author(), &(reward * U256::from(8 + u.number() - current_number) / U256::from(8)));
 		}
-		if let Err(e) = fields.state.commit() {
-			warn!("Encountered error on state commit: {}", e);
-		}
+
 	}
 
 	fn verify_block_basic(&self, header: &Header, _block: Option<&[u8]>) -> result::Result<(), Error> {

--- a/ethcore/src/state/mod.rs
+++ b/ethcore/src/state/mod.rs
@@ -420,10 +420,27 @@ impl fmt::Debug for State {
 
 impl Clone for State {
 	fn clone(&self) -> State {
+		let cache = {
+			let mut cache = HashMap::new();
+			for (key, val) in self.cache.borrow().iter() {
+				let key = key.clone();
+				match *val {
+					Some(ref acc) if acc.is_dirty() => {
+						cache.insert(key, Some(acc.clone()));
+					},
+					None => {
+						cache.insert(key, None);
+					},
+					_ => {},
+				}
+			}
+			cache
+		};
+
 		State {
 			db: self.db.boxed_clone(),
 			root: self.root.clone(),
-			cache: RefCell::new(self.cache.borrow().clone()),
+			cache: RefCell::new(cache),
 			snapshots: RefCell::new(self.snapshots.borrow().clone()),
 			account_start_nonce: self.account_start_nonce.clone(),
 			factories: self.factories.clone(),


### PR DESCRIPTION
Summary of changes:
  - only copy dirty cache values in `State::clone` (merged to beta in #2173 )
  - use snapshots for closing and reopening blocks instead of `State::clone`