### PR TITLE
registry: show shortened hashes

### DIFF
--- a/js/src/dapps/registry/events/events.js
+++ b/js/src/dapps/registry/events/events.js
@@ -12,10 +12,17 @@ const inlineButton = {
   marginRight: '1em'
 };
 
+const renderHash = (hash) => {
+  const shortened = hash.length > (2 + 9 + 9)
+    ? hash.substr(2, 9) + '...' + hash.slice(-9)
+    : hash.slice(2);
+  return (<abbr title={ hash }>{ shortened }</abbr>);
+};
+
 const renderOwner = (owner) => (
   <span className={ styles.owner }>
     <IdentityIcon inline center address={ owner } />
-    <code>{ owner }</code>
+    <code>{ renderHash(owner) }</code>
   </span>
 );
 
@@ -34,7 +41,7 @@ const renderReserved = (e) => (
     { ' ' }
     <abbr title={ e.transaction }>reserved</abbr>
     { ' ' }
-    <code>{ bytesToHex(e.parameters.name) }</code>
+    <code>{ renderHash(bytesToHex(e.parameters.name)) }</code>
     { ' ' }
     { renderTimestamp(e.timestamp) }
   </p>
@@ -46,7 +53,7 @@ const renderDropped = (e) => (
     { ' ' }
     <abbr title={ e.transaction }>dropped</abbr>
     { ' ' }
-    <code>{ bytesToHex(e.parameters.name) }</code>
+    <code>{ renderHash(bytesToHex(e.parameters.name)) }</code>
     { ' ' }
     { renderTimestamp(e.timestamp) }
   </p>


### PR DESCRIPTION
This PR addresses #2186.

I kept the long hash in the lookup component, because getting the full address is the key functionality.

Will repair the `IdentityIcon`s as part of #2185.