### PR TITLE
Remove panickers from trie iterators

### DIFF
--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -144,7 +144,9 @@ pub struct Client {
 	factories: Factories,
 }
 
-const HISTORY: u64 = 1200;
+/// The pruning constant -- how old blocks must be before we
+/// assume finality of a given candidate.
+pub const HISTORY: u64 = 1200;
 
 /// Append a path element to the given path and return the string.
 pub fn append_path<P>(path: P, item: &str) -> String where P: AsRef<Path> {

--- a/ethcore/src/snapshot/account.rs
+++ b/ethcore/src/snapshot/account.rs
@@ -92,7 +92,8 @@ impl Account {
 
 		let mut pairs = Vec::new();
 
-		for (k, v) in db.iter() {
+		for item in try!(db.iter()) {
+			let (k, v) = try!(item);
 			pairs.push((k, v));
 		}
 

--- a/ethcore/src/snapshot/mod.rs
+++ b/ethcore/src/snapshot/mod.rs
@@ -358,7 +358,8 @@ pub fn chunk_state<'a>(db: &HashDB, root: &H256, writer: &Mutex<SnapshotWriter +
 	let mut used_code = HashSet::new();
 
 	// account_key here is the address' hash.
-	for (account_key, account_data) in account_trie.iter() {
+	for item in try!(account_trie.iter()) {
+		let (account_key, account_data) = try!(item);
 		let account = Account::from_thin_rlp(account_data);
 		let account_key_hash = H256::from_slice(&account_key);
 

--- a/ethcore/src/snapshot/tests/helpers.rs
+++ b/ethcore/src/snapshot/tests/helpers.rs
@@ -52,8 +52,9 @@ impl StateProducer {
 		// modify existing accounts.
 		let mut accounts_to_modify: Vec<_> = {
 			let trie = TrieDB::new(&*db, &self.state_root).unwrap();
-			let temp = trie.iter() // binding required due to complicated lifetime stuff
+			let temp = trie.iter().unwrap() // binding required due to complicated lifetime stuff
 				.filter(|_| rng.gen::<f32>() < ACCOUNT_CHURN)
+				.map(Result::unwrap)
 				.map(|(k, v)| (H256::from_slice(&k), v.to_owned()))
 				.collect();
 

--- a/util/src/trie/mod.rs
+++ b/util/src/trie/mod.rs
@@ -72,11 +72,11 @@ impl fmt::Display for TrieError {
 	}
 }
 
-/// Trie-Item type.
-pub type TrieItem<'a> = (Vec<u8>, &'a [u8]);
-
 /// Trie result type. Boxed to avoid copying around extra space for `H256`s on successful queries.
 pub type Result<T> = ::std::result::Result<T, Box<TrieError>>;
+
+/// Trie-Item type.
+pub type TrieItem<'a> = Result<(Vec<u8>, &'a [u8])>;
 
 /// A key-value datastore implemented as a database-backed modified Merkle tree.
 pub trait Trie {
@@ -102,7 +102,7 @@ pub trait Trie {
 		where 'a: 'b, R: Recorder;
 
 	/// Returns an iterator over elements of trie.
-	fn iter<'a>(&'a self) -> Box<Iterator<Item = TrieItem> + 'a>;
+	fn iter<'a>(&'a self) -> Result<Box<Iterator<Item = TrieItem> + 'a>>;
 }
 
 /// A key-value datastore implemented as a database-backed modified Merkle tree.
@@ -193,7 +193,7 @@ impl<'db> Trie for TrieKinds<'db> {
 		wrapper!(self, get_recorded, key, r)
 	}
 
-	fn iter<'a>(&'a self) -> Box<Iterator<Item = TrieItem> + 'a> {
+	fn iter<'a>(&'a self) -> Result<Box<Iterator<Item = TrieItem> + 'a>> {
 		wrapper!(self, iter,)
 	}
 }

--- a/util/src/trie/sectriedb.rs
+++ b/util/src/trie/sectriedb.rs
@@ -49,8 +49,8 @@ impl<'db> SecTrieDB<'db> {
 }
 
 impl<'db> Trie for SecTrieDB<'db> {
-	fn iter<'a>(&'a self) -> Box<Iterator<Item = TrieItem> + 'a> {
-		Box::new(TrieDB::iter(&self.raw))
+	fn iter<'a>(&'a self) -> super::Result<Box<Iterator<Item = TrieItem> + 'a>> {
+		TrieDB::iter(&self.raw)
 	}
 
 	fn root(&self) -> &H256 { self.raw.root() }


### PR DESCRIPTION
Makes use of it to detect when a prematurely-started periodic snapshot has failed because the state it was snapshotting got pruned out.

