### PR TITLE
registry dapp: fix propTypes

### DIFF
--- a/js/src/dapps/registry/Application/application.js
+++ b/js/src/dapps/registry/Application/application.js
@@ -29,7 +29,7 @@ export default class Application extends Component {
     contract: nullable(PropTypes.object.isRequired),
     fee: nullable(PropTypes.object.isRequired),
     lookup: PropTypes.object.isRequired,
-    events: PropTypes.array.isRequired,
+    events: PropTypes.object.isRequired,
     register: PropTypes.object.isRequired
   };
 

--- a/js/src/dapps/registry/Application/application.js
+++ b/js/src/dapps/registry/Application/application.js
@@ -11,6 +11,8 @@ import Lookup from '../Lookup';
 import Register from '../register';
 import Events from '../events';
 
+const nullable = (type) => React.PropTypes.oneOfType([ React.PropTypes.oneOf([ null ]), type ]);
+
 export default class Application extends Component {
   static childContextTypes = {
     muiTheme: PropTypes.object.isRequired,
@@ -24,8 +26,8 @@ export default class Application extends Component {
     actions: PropTypes.object.isRequired,
     accounts: PropTypes.object.isRequired,
     contacts: PropTypes.object.isRequired,
-    contract: PropTypes.object.isRequired,
-    fee: PropTypes.object.isRequired,
+    contract: nullable(PropTypes.object.isRequired),
+    fee: nullable(PropTypes.object.isRequired),
     lookup: PropTypes.object.isRequired,
     events: PropTypes.array.isRequired,
     register: PropTypes.object.isRequired

--- a/js/src/dapps/registry/Container.js
+++ b/js/src/dapps/registry/Container.js
@@ -5,14 +5,16 @@ import { bindActionCreators } from 'redux';
 import Application from './Application';
 import * as actions from './actions';
 
+const nullable = (type) => React.PropTypes.oneOfType([ React.PropTypes.oneOf([ null ]), type ]);
+
 class Container extends Component {
   static propTypes = {
     actions: PropTypes.object.isRequired,
     accounts: PropTypes.object.isRequired,
     contacts: PropTypes.object.isRequired,
-    contract: PropTypes.object.isRequired,
-    owner: PropTypes.string.isRequired,
-    fee: PropTypes.object.isRequired,
+    contract: nullable(PropTypes.object.isRequired),
+    owner: nullable(PropTypes.string.isRequired),
+    fee: nullable(PropTypes.object.isRequired),
     lookup: PropTypes.object.isRequired,
     events: PropTypes.array.isRequired
   };

--- a/js/src/dapps/registry/Container.js
+++ b/js/src/dapps/registry/Container.js
@@ -16,7 +16,7 @@ class Container extends Component {
     owner: nullable(PropTypes.string.isRequired),
     fee: nullable(PropTypes.object.isRequired),
     lookup: PropTypes.object.isRequired,
-    events: PropTypes.array.isRequired
+    events: PropTypes.object.isRequired
   };
 
   componentDidMount () {

--- a/js/src/dapps/registry/Lookup/lookup.js
+++ b/js/src/dapps/registry/Lookup/lookup.js
@@ -7,13 +7,15 @@ import renderAddress from '../ui/address.js';
 
 import styles from './lookup.css';
 
+const nullable = (type) => React.PropTypes.oneOfType([ React.PropTypes.oneOf([ null ]), type ]);
+
 export default class Lookup extends Component {
 
   static propTypes = {
     actions: PropTypes.object.isRequired,
     name: PropTypes.string.isRequired,
     entry: PropTypes.string.isRequired,
-    result: PropTypes.string.isRequired,
+    result: nullable(PropTypes.string.isRequired),
     accounts: PropTypes.object.isRequired,
     contacts: PropTypes.object.isRequired
   }


### PR DESCRIPTION
This PR addresses #2192.

I'm not entirely happy, as I put more noise (`nullable()`) inside to make React happy.

There is a [discussion on nullable types in React](https://github.com/facebook/react/issues/2166). This is also [where the workaround I used if from](https://github.com/facebook/react/issues/2166#issuecomment-63986511). Unfortunately, [gaearon](https://github.com/gaearon) [commented](https://github.com/facebook/react/issues/2166#issuecomment-169143702) this:

> I wouldn't expect there to be further changes to PropTypes. Flow has become much more mature recently, and from what I heard from the React team, it is the longer term solution to type checking. This puts PropTypes into the same "compatibility" bucket in terms of priorities—like createClass or React addons, they are still supported, but only with bugfixes and performance improvements, without adding new features or changing the API.