### PR TITLE
limit number of event logs returned

### DIFF
--- a/js/src/api/format/input.js
+++ b/js/src/api/format/input.js
@@ -71,6 +71,10 @@ export function inFilter (options) {
           options[key] = inBlockNumber(options[key]);
           break;
 
+        case 'limit':
+          options[key] = inNumber10(options[key]);
+          break;
+
         case 'topics':
           options[key] = inTopics(options[key]);
       }

--- a/js/src/api/format/input.spec.js
+++ b/js/src/api/format/input.spec.js
@@ -133,13 +133,15 @@ describe('api/format/input', () => {
           address: address,
           fromBlock: 'latest',
           toBlock: 0x101,
-          extraData: 'someExtraStuffInHere'
+          extraData: 'someExtraStuffInHere',
+          limit: 50
         })
       ).to.deep.equal({
         address: address,
         fromBlock: 'latest',
         toBlock: '0x101',
-        extraData: 'someExtraStuffInHere'
+        extraData: 'someExtraStuffInHere',
+        limit: '50'
       });
     });
   });

--- a/js/src/dapps/gavcoin/Events/events.js
+++ b/js/src/dapps/gavcoin/Events/events.js
@@ -113,7 +113,8 @@ export default class Events extends Component {
 
     const options = {
       fromBlock: 0,
-      toBlock: 'pending'
+      toBlock: 'pending',
+      limit: 50
     };
 
     contract.subscribe(null, options, (error, _logs) => {

--- a/js/src/dapps/registry/events/actions.js
+++ b/js/src/dapps/registry/events/actions.js
@@ -10,7 +10,7 @@ export const subscribe = (name, from = 0, to = 'pending') =>
   (dispatch, getState) => {
     const { contract } = getState();
     if (!contract) return;
-    const opt = { fromBlock: from, toBlock: to };
+    const opt = { fromBlock: from, toBlock: to, limit: 50 };
 
     dispatch(start(name, from, to));
 

--- a/js/src/dapps/tokenreg/Status/actions.js
+++ b/js/src/dapps/tokenreg/Status/actions.js
@@ -87,7 +87,8 @@ export const subscribeEvents = () => (dispatch, getState) => {
   contract
     .subscribe(null, {
       fromBlock: 'latest',
-      toBlock: 'pending'
+      toBlock: 'pending',
+      limit: 50
     }, (error, logs) => {
       if (error) {
         console.error('setupFilters', error);

--- a/js/src/jsonrpc/interfaces/eth.js
+++ b/js/src/jsonrpc/interfaces/eth.js
@@ -769,6 +769,11 @@ export default {
           type: Array,
           desc: 'Array of 32 Bytes `DATA` topics. Topics are order-dependent. Each topic can also be an array of DATA with \'or\' options.',
           optional: true
+        },
+        limit: {
+          type: Number,
+          desc: 'The maximum number of entries to retrieve (latest first)',
+          optional: true
         }
       }
     }],


### PR DESCRIPTION
- add API support for the filter (limited formatted as decimal)
- dapps all have 50 limit as a start

Needs Parity with https://github.com/ethcore/parity/pull/2180 included