### PR TITLE
registry dapp: show DataChanged events

### DIFF
--- a/js/src/dapps/registry/events/events.css
+++ b/js/src/dapps/registry/events/events.css
@@ -6,7 +6,7 @@
   margin: 0 .5em;
 }
 
-.reserved, .dropped {
+.reserved, .dropped, .dataChanged {
   margin: .5em 0;
   display: flex;
   justify-content: space-between;

--- a/js/src/dapps/registry/events/reducers.js
+++ b/js/src/dapps/registry/events/reducers.js
@@ -1,11 +1,13 @@
 const initialState = {
   subscriptions: {
     Reserved: null,
-    Dropped: null
+    Dropped: null,
+    DataChanged: null
   },
   pending: {
     Reserved: false,
-    Dropped: false
+    Dropped: false,
+    DataChanged: false
   },
   events: []
 };


### PR DESCRIPTION
This PR addresses #2232.

> The rendering code expects the events to have a `plainKey` property, which has been introduced in ethcore/contracts#df32dce .

Therefore, you won't see any `DataChanged` events that happend until the deployment of ethcore/contracts#df32dce .