### PR TITLE
contract view (developer-centric)

### DIFF
--- a/js/src/api/contract/contract.js
+++ b/js/src/api/contract/contract.js
@@ -300,6 +300,9 @@ export default class Contract {
       .uninstallFilter(this._subscriptions[subscriptionId].filterId)
       .then(() => {
         delete this._subscriptions[subscriptionId];
+      })
+      .catch((error) => {
+        console.error('unsubscribe', error);
       });
   }
 
@@ -315,10 +318,14 @@ export default class Contract {
       )
       .then((logsArray) => {
         logsArray.forEach((logs, idx) => {
+          if (!logs || !logs.length) {
+            return;
+          }
+
           try {
             subscriptions[idx].callback(null, this.parseEventLogs(logs));
           } catch (error) {
-            subscriptions[idx].callback(error);
+            this.unsubscribe(idx);
             console.error('_sendSubscriptionChanges', error);
           }
         });

--- a/js/src/api/contract/contract.js
+++ b/js/src/api/contract/contract.js
@@ -217,7 +217,7 @@ export default class Contract {
   }
 
   _bindFunction = (func) => {
-    func.call = (options, values) => {
+    func.call = (options, values = []) => {
       return this._api.eth
         .call(this._encodeOptions(func, this._addOptionsTo(options), values))
         .then((encoded) => func.decodeOutput(encoded))
@@ -226,12 +226,12 @@ export default class Contract {
     };
 
     if (!func.constant) {
-      func.postTransaction = (options, values) => {
+      func.postTransaction = (options, values = []) => {
         return this._api.eth
           .postTransaction(this._encodeOptions(func, this._addOptionsTo(options), values));
       };
 
-      func.estimateGas = (options, values) => {
+      func.estimateGas = (options, values = []) => {
         return this._api.eth
           .estimateGas(this._encodeOptions(func, this._addOptionsTo(options), values));
       };

--- a/js/src/modals/AddAddress/addAddress.js
+++ b/js/src/modals/AddAddress/addAddress.js
@@ -22,6 +22,10 @@ import { Button, Modal, Form, Input, InputAddress } from '../../ui';
 import { ERRORS, validateAddress, validateName } from '../../util/validation';
 
 export default class AddAddress extends Component {
+  static contextTypes = {
+    api: PropTypes.object.isRequired
+  }
+
   static propTypes = {
     contacts: PropTypes.object.isRequired,
     onClose: PropTypes.func
@@ -125,9 +129,20 @@ export default class AddAddress extends Component {
   }
 
   onAdd = () => {
+    const { api } = this.context;
     const { address, name, description } = this.state;
 
-    this.props.onClose(address, name, description);
+    Promise.all([
+      api.personal.setAccountName(address, name),
+      api.personal.setAccountMeta(address, {
+        description,
+        deleted: false
+      })
+    ]).catch((error) => {
+      console.error('onAdd', error);
+    });
+
+    this.props.onClose();
   }
 
   onClose = () => {

--- a/js/src/modals/AddContract/addContract.js
+++ b/js/src/modals/AddContract/addContract.js
@@ -1,0 +1,161 @@
+// Copyright 2015, 2016 Ethcore (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+import React, { Component, PropTypes } from 'react';
+import ContentAdd from 'material-ui/svg-icons/content/add';
+import ContentClear from 'material-ui/svg-icons/content/clear';
+
+import { Button, Modal, Form, Input, InputAddress } from '../../ui';
+import { ERRORS, validateAbi, validateAddress, validateName } from '../../util/validation';
+
+export default class AddContract extends Component {
+  static contextTypes = {
+    api: PropTypes.object.isRequired
+  }
+
+  static propTypes = {
+    contracts: PropTypes.object.isRequired,
+    onClose: PropTypes.func
+  };
+
+  state = {
+    abi: '',
+    abiError: ERRORS.invalidAbi,
+    abiParsed: null,
+    address: '',
+    addressError: ERRORS.invalidAddress,
+    name: '',
+    nameError: ERRORS.invalidName,
+    description: ''
+  };
+
+  render () {
+    return (
+      <Modal
+        visible
+        actions={ this.renderDialogActions() }
+        title='watch contract'>
+        { this.renderFields() }
+      </Modal>
+    );
+  }
+
+  renderDialogActions () {
+    const { addressError, nameError } = this.state;
+    const hasError = !!(addressError || nameError);
+
+    return ([
+      <Button
+        icon={ <ContentClear /> }
+        label='Cancel'
+        onClick={ this.onClose } />,
+      <Button
+        icon={ <ContentAdd /> }
+        label='Add Contract'
+        disabled={ hasError }
+        onClick={ this.onAdd } />
+    ]);
+  }
+
+  renderFields () {
+    const { abi, abiError, address, addressError, description, name, nameError } = this.state;
+
+    return (
+      <Form>
+        <InputAddress
+          label='network address'
+          hint='the network address for the contract'
+          error={ addressError }
+          value={ address }
+          onSubmit={ this.onEditAddress } />
+        <Input
+          label='contract name'
+          hint='a descriptive name for the contract'
+          error={ nameError }
+          value={ name }
+          onSubmit={ this.onEditName } />
+        <Input
+          multiLine
+          rows={ 1 }
+          label='(optional) contract description'
+          hint='an expanded description for the entry'
+          value={ description }
+          onSubmit={ this.onEditDescription } />
+        <Input
+          label='contract abi'
+          hint='the abi for the contract'
+          error={ abiError }
+          value={ abi }
+          onSubmit={ this.onEditAbi } />
+      </Form>
+    );
+  }
+
+  onEditAbi = (abi) => {
+    const { api } = this.context;
+
+    this.setState(validateAbi(abi, api));
+  }
+
+  onEditAddress = (_address) => {
+    const { contracts } = this.props;
+    let { address, addressError } = validateAddress(_address);
+
+    if (!addressError) {
+      const contract = contracts[address];
+
+      if (contract && !contract.meta.deleted) {
+        addressError = ERRORS.duplicateAddress;
+      }
+    }
+
+    this.setState({
+      address,
+      addressError
+    });
+  }
+
+  onEditDescription = (description) => {
+    this.setState({ description });
+  }
+
+  onEditName = (name) => {
+    this.setState(validateName(name));
+  }
+
+  onAdd = () => {
+    const { api } = this.context;
+    const { abiParsed, address, name, description } = this.state;
+
+    Promise.all([
+      api.personal.setAccountName(address, name),
+      api.personal.setAccountMeta(address, {
+        contract: true,
+        deleted: false,
+        abi: abiParsed,
+        description
+      })
+    ]).catch((error) => {
+      console.error('onAdd', error);
+    });
+
+    this.props.onClose();
+  }
+
+  onClose = () => {
+    this.props.onClose();
+  }
+}

--- a/js/src/modals/AddContract/index.js
+++ b/js/src/modals/AddContract/index.js
@@ -1,0 +1,17 @@
+// Copyright 2015, 2016 Ethcore (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+export default from './addContract';

--- a/js/src/modals/DeployContract/deployContract.js
+++ b/js/src/modals/DeployContract/deployContract.js
@@ -22,6 +22,7 @@ import ContentClear from 'material-ui/svg-icons/content/clear';
 
 import { newError } from '../../redux/actions';
 import { Button, IdentityIcon, Modal } from '../../ui';
+import { ERRORS, validateAbi, validateCode, validateName } from '../../util/validation';
 
 import BusyStep from './BusyStep';
 import CompletedStep from './CompletedStep';
@@ -43,16 +44,16 @@ class DeployContract extends Component {
 
   state = {
     abi: '',
-    abiError: 'Invalid or empty ABI',
+    abiError: ERRORS.invalidAbi,
     code: '',
-    codeError: 'Invalid or empty contract code',
+    codeError: ERRORS.invalidCode,
     deployState: '',
     description: '',
     descriptionError: null,
     fromAddress: Object.keys(this.props.accounts)[0],
     fromAddressError: null,
     name: '',
-    nameError: 'Contract name needs to be >2 charaters',
+    nameError: ERRORS.invalidName,
     step: 0,
     deployError: null
   }
@@ -163,37 +164,19 @@ class DeployContract extends Component {
   }
 
   onNameChange = (name) => {
-    const nameError = name && name.length > 2
-      ? null
-      : 'specify a valid name, >2 characters';
-
-    this.setState({ name, nameError });
+    this.setState(validateName(name));
   }
 
   onAbiChange = (abi) => {
     const { api } = this.context;
 
-    try {
-      const parsedAbi = JSON.parse(abi);
-
-      if (!api.util.isArray(parsedAbi) || !parsedAbi.length) {
-        throw new Error();
-      }
-
-      this.setState({ parsedAbi, abi, abiError: null });
-    } catch (error) {
-      console.error(error);
-      this.setState({ abi, abiError: 'ABI needs to be a valid JSON array' });
-    }
+    this.setState(validateAbi(abi, api));
   }
 
   onCodeChange = (code) => {
     const { api } = this.context;
-    const codeError = api.util.isHex(code) && code.length
-      ? null
-      : 'provide the valid compiled hex string of the contract code';
 
-    this.setState({ code, codeError });
+    this.setState(validateCode(code, api));
   }
 
   onDeployStart = () => {

--- a/js/src/modals/ExecuteContract/CompletedStep/completedStep.js
+++ b/js/src/modals/ExecuteContract/CompletedStep/completedStep.js
@@ -14,22 +14,16 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-import AddAddress from './AddAddress';
-import AddContract from './AddContract';
-import CreateAccount from './CreateAccount';
-import DeployContract from './DeployContract';
-import ExecuteContract from './ExecuteContract';
-import FirstRun from './FirstRun';
-import Shapeshift from './Shapeshift';
-import Transfer from './Transfer';
+import React, { Component } from 'react';
 
-export {
-  AddAddress,
-  AddContract,
-  CreateAccount,
-  DeployContract,
-  ExecuteContract,
-  FirstRun,
-  Shapeshift,
-  Transfer
-};
+import styles from '../executeContract.css';
+
+export default class CompletedStep extends Component {
+  render () {
+    return (
+      <div className={ styles.modalcenter }>
+        Your contract execution call has been submitted. Please visit the <a href='/#/signer'>Parity Signer</a> for authentication. Once executed, any events created by the transaction will be visible in the logs.
+      </div>
+    );
+  }
+}

--- a/js/src/modals/ExecuteContract/CompletedStep/index.js
+++ b/js/src/modals/ExecuteContract/CompletedStep/index.js
@@ -14,22 +14,4 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-import AddAddress from './AddAddress';
-import AddContract from './AddContract';
-import CreateAccount from './CreateAccount';
-import DeployContract from './DeployContract';
-import ExecuteContract from './ExecuteContract';
-import FirstRun from './FirstRun';
-import Shapeshift from './Shapeshift';
-import Transfer from './Transfer';
-
-export {
-  AddAddress,
-  AddContract,
-  CreateAccount,
-  DeployContract,
-  ExecuteContract,
-  FirstRun,
-  Shapeshift,
-  Transfer
-};
+export default from './completedStep';

--- a/js/src/modals/ExecuteContract/DetailsStep/detailsStep.js
+++ b/js/src/modals/ExecuteContract/DetailsStep/detailsStep.js
@@ -1,0 +1,166 @@
+// Copyright 2015, 2016 Ethcore (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+import React, { Component, PropTypes } from 'react';
+import { MenuItem } from 'material-ui';
+
+import { AddressSelect, Form, Input, InputAddressSelect, Select } from '../../../ui';
+
+import styles from '../executeContract.css';
+
+export default class DetailsStep extends Component {
+  static propTypes = {
+    accounts: PropTypes.object.isRequired,
+    contract: PropTypes.object.isRequired,
+    amount: PropTypes.string,
+    amountError: PropTypes.string,
+    fromAddress: PropTypes.string,
+    fromAddressError: PropTypes.string,
+    onFromAddressChange: PropTypes.func,
+    func: PropTypes.object,
+    funcError: PropTypes.string,
+    onFuncChange: PropTypes.func,
+    values: PropTypes.array.isRequired,
+    valuesError: PropTypes.array.isRequired,
+    onValueChange: PropTypes.func.isRequired
+  }
+
+  render () {
+    const { accounts, amount, amountError, fromAddress, fromAddressError, onFromAddressChange } = this.props;
+
+    return (
+      <Form>
+        <AddressSelect
+          label='from account'
+          hint='the account to transact with'
+          value={ fromAddress }
+          error={ fromAddressError }
+          accounts={ accounts }
+          onChange={ onFromAddressChange } />
+        { this.renderFunctionSelect() }
+        { this.renderParameters() }
+        <Input
+          label='transaction value (in ΞTH)'
+          hint='the amount to send to with the transaction'
+          value={ amount }
+          error={ amountError }
+          onSubmit={ this.onChangeAmount } />
+      </Form>
+    );
+  }
+
+  renderFunctionSelect () {
+    const { func, funcError, contract } = this.props;
+
+    if (!func) {
+      return null;
+    }
+
+    const functions = contract.functions
+      .filter((func) => !func.constant)
+      .sort((a, b) => a.name.localeCompare(b.name))
+      .map((func) => {
+        const params = func.inputs
+          .map((input, index) => {
+            return (
+              <span key={ input.name }>
+                <span>{ index ? ', ' : '' }</span>
+                <span className={ styles.paramname }>{ input.name }: </span>
+                <span>{ input.kind.type }</span>
+              </span>
+            );
+          });
+        const name = (
+          <div>
+            <span>{ func.name }</span>
+            <span className={ styles.paramname }>(</span>
+            { params }
+            <span className={ styles.paramname }>)</span>
+          </div>
+        );
+
+        return (
+          <MenuItem
+            key={ func.signature }
+            value={ func.signature }
+            label={ func.name }>
+            { name }
+          </MenuItem>
+        );
+      });
+
+    return (
+      <Select
+        label='function to execute'
+        hint='the function to call on the contract'
+        error={ funcError }
+        onChange={ this.onFuncChange }
+        value={ func.signature }>
+        { functions }
+      </Select>
+    );
+  }
+
+  renderParameters () {
+    const { accounts, func, values, valuesError, onValueChange } = this.props;
+
+    if (!func) {
+      return null;
+    }
+
+    return func.inputs.map((input, index) => {
+      const onChange = (event, value) => onValueChange(event, index, value);
+      const onSubmit = (value) => onValueChange(null, index, value);
+      const label = `${input.name}: ${input.kind.type}`;
+      let inputbox;
+
+      switch (input.kind.type) {
+        case 'address':
+          inputbox = (
+            <InputAddressSelect
+              accounts={ accounts }
+              editing
+              label={ label }
+              value={ values[index] }
+              error={ valuesError[index] }
+              onChange={ onChange } />
+          );
+          break;
+
+        default:
+          inputbox = (
+            <Input
+              label={ label }
+              value={ values[index] }
+              error={ valuesError[index] }
+              onSubmit={ onSubmit } />
+          );
+      }
+
+      return (
+        <div className={ styles.funcparams } key={ index }>
+          { inputbox }
+        </div>
+      );
+    });
+  }
+
+  onFuncChange = (event, index, signature) => {
+    const { contract, onFuncChange } = this.props;
+
+    onFuncChange(event, contract.functions.find((fn) => fn.signature === signature));
+  }
+}

--- a/js/src/modals/ExecuteContract/DetailsStep/index.js
+++ b/js/src/modals/ExecuteContract/DetailsStep/index.js
@@ -14,22 +14,4 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-import AddAddress from './AddAddress';
-import AddContract from './AddContract';
-import CreateAccount from './CreateAccount';
-import DeployContract from './DeployContract';
-import ExecuteContract from './ExecuteContract';
-import FirstRun from './FirstRun';
-import Shapeshift from './Shapeshift';
-import Transfer from './Transfer';
-
-export {
-  AddAddress,
-  AddContract,
-  CreateAccount,
-  DeployContract,
-  ExecuteContract,
-  FirstRun,
-  Shapeshift,
-  Transfer
-};
+export default from './detailsStep';

--- a/js/src/modals/ExecuteContract/executeContract.css
+++ b/js/src/modals/ExecuteContract/executeContract.css
@@ -1,0 +1,32 @@
+/* Copyright 2015, 2016 Ethcore (UK) Ltd.
+/* This file is part of Parity.
+/*
+/* Parity is free software: you can redistribute it and/or modify
+/* it under the terms of the GNU General Public License as published by
+/* the Free Software Foundation, either version 3 of the License, or
+/* (at your option) any later version.
+/*
+/* Parity is distributed in the hope that it will be useful,
+/* but WITHOUT ANY WARRANTY; without even the implied warranty of
+/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+/* GNU General Public License for more details.
+/*
+/* You should have received a copy of the GNU General Public License
+/* along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+.modalbody,
+.modalcenter {
+  padding: 1.5em 1.5em 0 1.5em;
+}
+
+.modalcenter {
+  text-align: center;
+}
+
+.funcparams {
+  padding-left: 3em;
+}
+
+.paramname {
+  color: #aaa;
+}

--- a/js/src/modals/ExecuteContract/executeContract.js
+++ b/js/src/modals/ExecuteContract/executeContract.js
@@ -1,0 +1,225 @@
+// Copyright 2015, 2016 Ethcore (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+
+import { newError } from '../../redux/actions';
+
+import ActionDoneAll from 'material-ui/svg-icons/action/done-all';
+import ContentClear from 'material-ui/svg-icons/content/clear';
+
+import { Button, IdentityIcon, Modal } from '../../ui';
+
+import CompletedStep from './CompletedStep';
+import DetailsStep from './DetailsStep';
+
+const steps = ['function execute', 'completed'];
+
+class ExecuteContract extends Component {
+  static contextTypes = {
+    api: PropTypes.object.isRequired
+  }
+
+  static propTypes = {
+    fromAddress: PropTypes.string,
+    accounts: PropTypes.object,
+    contract: PropTypes.object,
+    onClose: PropTypes.func.isRequired,
+    onFromAddressChange: PropTypes.func.isRequired,
+    newError: PropTypes.func
+  }
+
+  state = {
+    amount: '0',
+    amountError: null,
+    func: null,
+    funcError: null,
+    values: [],
+    valuesError: [],
+    step: 0,
+    sending: false
+  }
+
+  componentDidMount () {
+    const { contract } = this.props;
+    const functions = contract.functions
+      .filter((func) => !func.constant)
+      .sort((a, b) => a.name.localeCompare(b.name));
+
+    this.onFuncChange(null, functions[0]);
+  }
+
+  render () {
+    const { step } = this.state;
+
+    return (
+      <Modal
+        actions={ this.renderDialogActions() }
+        current={ step }
+        steps={ steps }
+        waiting={ [1] }
+        visible>
+        { this.renderStep() }
+      </Modal>
+    );
+  }
+
+  renderDialogActions () {
+    const { onClose, fromAddress } = this.props;
+    const { step, sending } = this.state;
+
+    switch (step) {
+      case 0:
+        return [
+          <Button
+            key='cancel'
+            label='Cancel'
+            icon={ <ContentClear /> }
+            onClick={ onClose } />,
+          <Button
+            key='postTransaction'
+            label='post transaction'
+            disabled={ sending }
+            icon={ <IdentityIcon address={ fromAddress } button /> }
+            onClick={ this.postTransaction } />
+        ];
+
+      case 1:
+        return [
+          <Button
+            key='close'
+            label='close'
+            icon={ <ActionDoneAll /> }
+            onClick={ onClose } />
+        ];
+    }
+  }
+
+  renderStep () {
+    const { onFromAddressChange } = this.props;
+    const { step } = this.state;
+
+    switch (step) {
+      case 0:
+        return (
+          <DetailsStep
+            { ...this.props }
+            { ...this.state }
+            onFromAddressChange={ onFromAddressChange }
+            onFuncChange={ this.onFuncChange }
+            onValueChange={ this.onValueChange } />
+        );
+      case 1:
+        return (
+          <CompletedStep />
+        );
+    }
+  }
+
+  onAmountChange = (event, amount) => {
+    this.setState({
+      amount
+    });
+  }
+
+  onFuncChange = (event, func) => {
+    const values = func.inputs.map((input) => {
+      switch (input.kind.type) {
+        case 'address':
+          return '0x';
+
+        case 'bytes':
+          return '0x';
+
+        case 'uint':
+          return '0';
+
+        default:
+          return '';
+      }
+    });
+
+    console.log('onFuncChange', func, values);
+
+    this.setState({
+      func,
+      values
+    });
+  }
+
+  onValueChange = (event, index, _value) => {
+    const { func, values, valuesError } = this.state;
+    const input = func.inputs.find((input, _index) => index === _index);
+    let value;
+    let valueError;
+
+    switch (input.kind.type) {
+      default:
+        value = _value;
+        valueError = null;
+        break;
+    }
+
+    values[index] = value;
+    valuesError[index] = valueError;
+
+    this.setState({
+      values,
+      valuesError
+    });
+  }
+
+  postTransaction = () => {
+    const { api } = this.context;
+    const { fromAddress, newError } = this.props;
+    const { amount, func, values } = this.state;
+    const options = {
+      from: fromAddress,
+      value: api.util.toWei(amount || 0)
+    };
+
+    this.setState({
+      sending: true,
+      step: 1
+    });
+
+    func
+      .estimateGas(options, values)
+      .then((gas) => {
+        options.gas = gas.mul(1.2).toFixed(0);
+        return func.postTransaction(options, values);
+      })
+      .catch((error) => {
+        console.error('postTransaction', error);
+        newError(error);
+      });
+  }
+}
+
+function mapStateToProps (state) {
+  return {};
+}
+
+function mapDispatchToProps (dispatch) {
+  return bindActionCreators({ newError }, dispatch);
+}
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(ExecuteContract);

--- a/js/src/modals/ExecuteContract/index.js
+++ b/js/src/modals/ExecuteContract/index.js
@@ -14,22 +14,4 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-import AddAddress from './AddAddress';
-import AddContract from './AddContract';
-import CreateAccount from './CreateAccount';
-import DeployContract from './DeployContract';
-import ExecuteContract from './ExecuteContract';
-import FirstRun from './FirstRun';
-import Shapeshift from './Shapeshift';
-import Transfer from './Transfer';
-
-export {
-  AddAddress,
-  AddContract,
-  CreateAccount,
-  DeployContract,
-  ExecuteContract,
-  FirstRun,
-  Shapeshift,
-  Transfer
-};
+export default from './executeContract';

--- a/js/src/modals/index.js
+++ b/js/src/modals/index.js
@@ -15,6 +15,7 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 import AddAddress from './AddAddress';
+import AddContract from './AddContract';
 import CreateAccount from './CreateAccount';
 import DeployContract from './DeployContract';
 import FirstRun from './FirstRun';
@@ -23,6 +24,7 @@ import Transfer from './Transfer';
 
 export {
   AddAddress,
+  AddContract,
   CreateAccount,
   DeployContract,
   FirstRun,

--- a/js/src/ui/Form/InputAddress/inputAddress.js
+++ b/js/src/ui/Form/InputAddress/inputAddress.js
@@ -28,11 +28,12 @@ export default class InputAddress extends Component {
     label: PropTypes.string,
     hint: PropTypes.string,
     value: PropTypes.string,
-    onChange: PropTypes.func
+    onChange: PropTypes.func,
+    onSubmit: PropTypes.func
   };
 
   render () {
-    const { disabled, error, label, hint, value, onChange } = this.props;
+    const { disabled, error, label, hint, value, onChange, onSubmit } = this.props;
 
     return (
       <div className={ styles.container }>
@@ -43,7 +44,8 @@ export default class InputAddress extends Component {
           hint={ hint }
           error={ error }
           value={ value }
-          onChange={ onChange } />
+          onChange={ onChange }
+          onSubmit={ onSubmit } />
         { this.renderIcon() }
       </div>
     );

--- a/js/src/ui/Form/InputAddressSelect/inputAddressSelect.js
+++ b/js/src/ui/Form/InputAddressSelect/inputAddressSelect.js
@@ -29,6 +29,7 @@ class InputAddressSelect extends Component {
     accounts: PropTypes.object,
     contacts: PropTypes.object,
     disabled: PropTypes.bool,
+    editing: PropTypes.bool,
     error: PropTypes.string,
     label: PropTypes.string,
     hint: PropTypes.string,
@@ -37,7 +38,7 @@ class InputAddressSelect extends Component {
   };
 
   state = {
-    editing: false,
+    editing: this.props.editing || false,
     entries: []
   }
 

--- a/js/src/ui/Form/Select/select.js
+++ b/js/src/ui/Form/Select/select.js
@@ -40,9 +40,7 @@ export default class Select extends Component {
     onChange: PropTypes.func,
     onKeyDown: PropTypes.func,
     type: PropTypes.string,
-    value: PropTypes.oneOfType([
-      PropTypes.number, PropTypes.string
-    ])
+    value: PropTypes.any
   }
 
   render () {

--- a/js/src/util/validation.js
+++ b/js/src/util/validation.js
@@ -20,8 +20,32 @@ export const ERRORS = {
   invalidAddress: 'address is an invalid network address',
   duplicateAddress: 'the address is already in your address book',
   invalidChecksum: 'address has failed the checksum formatting',
-  invalidName: 'name should not be blank and longer than 2'
+  invalidName: 'name should not be blank and longer than 2',
+  invalidAbi: 'abi should be a valid JSON array',
+  invalidCode: 'code should be the compiled hex string'
 };
+
+export function validateAbi (abi, api) {
+  let abiError = null;
+  let abiParsed = null;
+
+  try {
+    abiParsed = JSON.parse(abi);
+
+    if (!api.util.isArray(abiParsed) || !abiParsed.length) {
+      abiError = ERRORS.inavlidAbi;
+    }
+  } catch (error) {
+    console.error(error);
+    abiError = ERRORS.invalidAbi;
+  }
+
+  return {
+    abi,
+    abiError,
+    abiParsed
+  };
+}
 
 export function validateAddress (address) {
   let addressError = null;
@@ -37,6 +61,21 @@ export function validateAddress (address) {
   return {
     address,
     addressError
+  };
+}
+
+export function validateCode (code, api) {
+  let codeError = null;
+
+  if (!code.length) {
+    codeError = ERRORS.invalidCode;
+  } else if (!api.util.isHex(code)) {
+    codeError = ERRORS.invalidCode;
+  }
+
+  return {
+    code,
+    codeError
   };
 }
 

--- a/js/src/views/Accounts/List/list.js
+++ b/js/src/views/Accounts/List/list.js
@@ -25,7 +25,7 @@ export default class List extends Component {
   static propTypes = {
     accounts: PropTypes.object,
     balances: PropTypes.object,
-    contact: PropTypes.bool,
+    link: PropTypes.string,
     empty: PropTypes.bool
   };
 
@@ -38,7 +38,7 @@ export default class List extends Component {
   }
 
   renderAccounts () {
-    const { accounts, balances, contact, empty } = this.props;
+    const { accounts, balances, link, empty } = this.props;
 
     if (empty) {
       return (
@@ -59,7 +59,7 @@ export default class List extends Component {
           className={ styles.account }
           key={ address }>
           <Summary
-            contact={ contact }
+            link={ link }
             account={ account }
             balance={ balance } />
         </div>

--- a/js/src/views/Accounts/Summary/summary.js
+++ b/js/src/views/Accounts/Summary/summary.js
@@ -27,7 +27,7 @@ export default class Summary extends Component {
   static propTypes = {
     account: PropTypes.object.isRequired,
     balance: PropTypes.object.isRequired,
-    contact: PropTypes.bool,
+    link: PropTypes.string,
     children: PropTypes.node
   }
 
@@ -36,13 +36,13 @@ export default class Summary extends Component {
   }
 
   render () {
-    const { account, balance, children, contact } = this.props;
+    const { account, balance, children, link } = this.props;
 
     if (!account) {
       return null;
     }
 
-    const viewLink = `/${contact ? 'address' : 'account'}/${account.address}`;
+    const viewLink = `/${link || 'account'}/${account.address}`;
 
     return (
       <Container>

--- a/js/src/views/Address/Delete/delete.js
+++ b/js/src/views/Address/Delete/delete.js
@@ -1,0 +1,113 @@
+// Copyright 2015, 2016 Ethcore (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+import React, { Component, PropTypes } from 'react';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
+
+import { ConfirmDialog, IdentityIcon } from '../../../ui';
+import { newError } from '../../../redux/actions';
+
+import styles from '../address.css';
+
+class Delete extends Component {
+  static contextTypes = {
+    api: PropTypes.object.isRequired,
+    router: PropTypes.object
+  }
+
+  static propTypes = {
+    address: PropTypes.string,
+    account: PropTypes.object,
+    route: PropTypes.string.isRequired,
+    visible: PropTypes.bool,
+    onClose: PropTypes.func,
+    newError: PropTypes.func
+  }
+
+  render () {
+    const { account, visible } = this.props;
+
+    if (!visible) {
+      return null;
+    }
+
+    return (
+      <ConfirmDialog
+        className={ styles.delete }
+        title='confirm removal'
+        visible
+        onDeny={ this.closeDeleteDialog }
+        onConfirm={ this.onDeleteConfirmed }>
+        <div className={ styles.hero }>
+          Are you sure you want to remove the following address from your addressbook?
+        </div>
+        <div className={ styles.info }>
+          <IdentityIcon
+            className={ styles.icon }
+            address={ account.address } />
+          <div className={ styles.nameinfo }>
+            <div className={ styles.header }>
+              { account.name || 'Unnamed' }
+            </div>
+            <div className={ styles.address }>
+              { account.address }
+            </div>
+          </div>
+        </div>
+        <div className={ styles.description }>
+          { account.meta.description }
+        </div>
+      </ConfirmDialog>
+    );
+  }
+
+  onDeleteConfirmed = () => {
+    const { api, router } = this.context;
+    const { account, route, newError } = this.props;
+
+    account.meta.deleted = true;
+
+    api.personal
+      .setAccountMeta(account.address, account.meta)
+      .then(() => {
+        router.push(route);
+        this.closeDeleteDialog();
+      })
+      .catch((error) => {
+        console.error('onDeleteConfirmed', error);
+        newError(new Error(`Deletion failed: ${error.message}`));
+        this.closeDeleteDialog();
+      });
+  }
+
+  closeDeleteDialog = () => {
+    this.props.onClose();
+  }
+}
+
+function mapStateToProps (state) {
+  return {};
+}
+
+function mapDispatchToProps (dispatch) {
+  return bindActionCreators({ newError }, dispatch);
+}
+
+export default connect(
+  mapStateToProps,
+  mapDispatchToProps
+)(Delete);

--- a/js/src/views/Address/Delete/index.js
+++ b/js/src/views/Address/Delete/index.js
@@ -1,0 +1,17 @@
+// Copyright 2015, 2016 Ethcore (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+export default from './delete';

--- a/js/src/views/Address/address.js
+++ b/js/src/views/Address/address.js
@@ -19,11 +19,11 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import ActionDelete from 'material-ui/svg-icons/action/delete';
 
-import { newError } from '../../redux/actions';
-import { Actionbar, Button, ConfirmDialog, IdentityIcon, Page } from '../../ui';
+import { Actionbar, Button, Page } from '../../ui';
 
 import Header from '../Account/Header';
 import Transactions from '../Account/Transactions';
+import Delete from './Delete';
 
 import styles from './address.css';
 
@@ -47,6 +47,7 @@ class Address extends Component {
   render () {
     const { contacts, balances, isTest } = this.props;
     const { address } = this.props.params;
+    const { showDeleteDialog } = this.state;
 
     const contact = (contacts || {})[address];
     const balance = (balances || {})[address];
@@ -58,7 +59,11 @@ class Address extends Component {
     return (
       <div className={ styles.address }>
         { this.renderActionbar(contact) }
-        { this.renderDeleteConfirm() }
+        <Delete
+          account={ contact }
+          visible={ showDeleteDialog }
+          route='/addresses'
+          onClose={ this.closeDeleteDialog } />
         <Page>
           <Header
             isTest={ isTest }
@@ -83,67 +88,8 @@ class Address extends Component {
     return (
       <Actionbar
         title='Address Information'
-        buttons={ contact.meta.deleted ? [] : buttons } />
+        buttons={ !contact || contact.meta.deleted ? [] : buttons } />
     );
-  }
-
-  renderDeleteConfirm () {
-    const { contacts } = this.props;
-    const { showDeleteDialog } = this.state;
-
-    if (!showDeleteDialog) {
-      return;
-    }
-
-    const { address } = this.props.params;
-    const contact = contacts[address];
-
-    return (
-      <ConfirmDialog
-        className={ styles.delete }
-        title='confirm removal'
-        visible
-        onDeny={ this.closeDeleteDialog }
-        onConfirm={ this.onDeleteConfirmed }>
-        <div className={ styles.hero }>
-          Are you sure you want to remove the following address from your addressbook?
-        </div>
-        <div className={ styles.info }>
-          <IdentityIcon
-            className={ styles.icon }
-            address={ address } />
-          <div className={ styles.nameinfo }>
-            <div className={ styles.header }>
-              { contact.name || 'Unnamed' }
-            </div>
-            <div className={ styles.address }>
-              { address }
-            </div>
-          </div>
-        </div>
-        <div className={ styles.description }>
-          { contact.meta.description }
-        </div>
-      </ConfirmDialog>
-    );
-  }
-
-  onDeleteConfirmed = () => {
-    const { api, router } = this.context;
-    const { contacts } = this.props;
-    const { address } = this.props.params;
-    const contact = (contacts || {})[address];
-
-    this.closeDeleteDialog();
-    contact.meta.deleted = true;
-
-    api.personal
-      .setAccountMeta(address, contact.meta)
-      .then(() => router.push('/addresses'))
-      .catch((error) => {
-        console.error('onDeleteConfirmed', error);
-        newError(new Error(`Deletion failed: ${error.message}`));
-      });
   }
 
   closeDeleteDialog = () => {
@@ -168,7 +114,7 @@ function mapStateToProps (state) {
 }
 
 function mapDispatchToProps (dispatch) {
-  return bindActionCreators({ newError }, dispatch);
+  return bindActionCreators({}, dispatch);
 }
 
 export default connect(

--- a/js/src/views/Addresses/addresses.js
+++ b/js/src/views/Addresses/addresses.js
@@ -49,7 +49,7 @@ class Addresses extends Component {
         { this.renderAddAddress() }
         <Page>
           <List
-            contact
+            link='address'
             accounts={ contacts }
             balances={ balances }
             empty={ !hasContacts } />

--- a/js/src/views/Addresses/addresses.js
+++ b/js/src/views/Addresses/addresses.js
@@ -96,21 +96,8 @@ class Addresses extends Component {
     });
   }
 
-  onCloseAdd = (address, name, description) => {
-    const { api } = this.context;
-
-    this.setState({
-      showAdd: false
-    });
-
-    if (address) {
-      Promise.all([
-        api.personal.setAccountName(address, name),
-        api.personal.setAccountMeta(address, { description })
-      ]).catch((error) => {
-        console.error('updateDetails', error);
-      });
-    }
+  onCloseAdd = () => {
+    this.setState({ showAdd: false });
   }
 }
 

--- a/js/src/views/Contract/contract.css
+++ b/js/src/views/Contract/contract.css
@@ -28,3 +28,42 @@
   position: relative;
   margin-top: 0.5em;
 }
+
+.events {
+  width: 100%;
+  border: none;
+  border-spacing: 0;
+}
+
+.event {
+  vertical-align: top;
+  line-height: 26px;
+}
+
+.event td {
+  vertical-align: top;
+  padding: 1em 0.5em;
+}
+
+.txhash {
+  text-overflow: ellipsis;
+}
+
+.key {
+  text-align: right;
+  color: #aaa;
+}
+
+.value {
+}
+
+.event td div {
+  white-space: nowrap;
+}
+
+.mined {
+}
+
+.pending {
+  opacity: 0.5;
+}

--- a/js/src/views/Contract/contract.css
+++ b/js/src/views/Contract/contract.css
@@ -14,6 +14,9 @@
 /* You should have received a copy of the GNU General Public License
 /* along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 */
+.contract {
+}
+
 .methods {
   display: flex;
   flex-wrap: wrap;

--- a/js/src/views/Contract/contract.js
+++ b/js/src/views/Contract/contract.js
@@ -91,7 +91,6 @@ export default class Contract extends Component {
             account={ contract }
             balance={ balance } />
           { this.renderQueries() }
-          { this.renderFunctions() }
           { this.renderEvents() }
         </Page>
       </div>

--- a/js/src/views/Contracts/contracts.js
+++ b/js/src/views/Contracts/contracts.js
@@ -51,7 +51,7 @@ class Contracts extends Component {
         { this.renderDeployContract() }
         <Page>
           <List
-            contact
+            link='contract'
             accounts={ contracts }
             balances={ balances }
             empty={ !hasContracts } />

--- a/js/src/views/Contracts/contracts.js
+++ b/js/src/views/Contracts/contracts.js
@@ -20,7 +20,7 @@ import { bindActionCreators } from 'redux';
 import ContentAdd from 'material-ui/svg-icons/content/add';
 
 import { Actionbar, Button, Page } from '../../ui';
-import { DeployContract } from '../../modals';
+import { AddContract, DeployContract } from '../../modals';
 
 import List from '../Accounts/List';
 
@@ -39,6 +39,7 @@ class Contracts extends Component {
   }
 
   state = {
+    addContract: false,
     deployContract: false
   }
 
@@ -48,6 +49,8 @@ class Contracts extends Component {
     return (
       <div className={ styles.contracts }>
         { this.renderActionbar() }
+        { this.renderAddContract() }
+        { this.renderAddContract() }
         { this.renderDeployContract() }
         <Page>
           <List
@@ -63,6 +66,11 @@ class Contracts extends Component {
   renderActionbar () {
     const buttons = [
       <Button
+        key='addContract'
+        icon={ <ContentAdd /> }
+        label='watch contract'
+        onClick={ this.onAddContract } />,
+      <Button
         key='deployContract'
         icon={ <ContentAdd /> }
         label='deploy contract'
@@ -74,6 +82,21 @@ class Contracts extends Component {
         className={ styles.toolbar }
         title='Contracts'
         buttons={ buttons } />
+    );
+  }
+
+  renderAddContract () {
+    const { contracts } = this.props;
+    const { addContract } = this.state;
+
+    if (!addContract) {
+      return null;
+    }
+
+    return (
+      <AddContract
+        contracts={ contracts }
+        onClose={ this.onAddContractClose } />
     );
   }
 
@@ -98,6 +121,14 @@ class Contracts extends Component {
 
   onDeployContract = () => {
     this.setState({ deployContract: true });
+  }
+
+  onAddContractClose = () => {
+    this.setState({ addContract: false });
+  }
+
+  onAddContract = () => {
+    this.setState({ addContract: true });
   }
 }
 


### PR DESCRIPTION
PR in action -

https://youtu.be/6nSVK6xY2QE

Expanding the parts needed to deploy and manage our own contracts. Still (as per the original PR for contracts), not intended to be completely user-friendly and shippable. Just enough to make it tick so we can cover the higher-priority issues elsewhere. (Not dirty, but definitely quick in MVP fashion.)

Contains -

- [x] ability to add watched contracts (in addition to earlier deploy)
- [x] ability to remove deployed/watched contracts (ala addressbook removal)
- [x] generic view of events log (incl. pending events)
- [x] ability to send transactions to deployed contracts

Linked to -

https://github.com/ethcore/parity/issues/2255
https://github.com/ethcore/parity/issues/2256