### PR TITLE
Canonical state cache

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -260,6 +260,7 @@ dependencies = [
  "hyper 0.9.4 (git+https://github.com/ethcore/hyper)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "lru-cache 0.0.7 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 0.2.11 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rayon 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -739,9 +740,22 @@ version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
+name = "linked-hash-map"
+version = "0.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
 name = "log"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
+
+[[package]]
+name = "lru-cache"
+version = "0.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+dependencies = [
+ "linked-hash-map 0.0.9 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "matches"

--- a/ethcore/Cargo.toml
+++ b/ethcore/Cargo.toml
@@ -35,6 +35,7 @@ ethcore-ipc = { path = "../ipc/rpc" }
 ethstore = { path = "../ethstore" }
 ethcore-ipc-nano = { path = "../ipc/nano" }
 rand = "0.3"
+lru-cache = "0.0.7"
 
 [dependencies.hyper]
 git = "https://github.com/ethcore/hyper"

--- a/ethcore/src/account.rs
+++ b/ethcore/src/account.rs
@@ -250,7 +250,8 @@ impl Account {
 					Some(x) => {
 						self.code_cache = x.to_vec();
 						self.code_size = Some(x.len() as u64);
-						true },
+						true
+					},
 					_ => {
 						warn!("Failed reverse get of {}", h);
 						false
@@ -269,7 +270,8 @@ impl Account {
 				Some(ref h) if h != &SHA3_EMPTY => match db.get(h) {
 					Some(x) => {
 						self.code_size = Some(x.len() as u64);
-						true },
+						true
+					},
 					_ => {
 						warn!("Failed reverse get of {}", h);
 						false
@@ -344,7 +346,7 @@ impl Account {
 			(true, true) => {
 				self.code_hash = Some(SHA3_EMPTY);
 				self.code_size = Some(0);
-			}
+			},
 			(true, false) => {
 				self.code_hash = Some(db.insert(&self.code_cache));
 				self.code_size = Some(self.code_cache.len() as u64);

--- a/ethcore/src/account.rs
+++ b/ethcore/src/account.rs
@@ -167,18 +167,15 @@ impl Account {
 				entry.insert(value);
 				self.filth = Filth::Dirty;
 			},
-			_ => (),
+			_ => {},
 		}
 	}
 
 	/// Get (and cache) the contents of the trie's storage at `key`.
 	/// Takes modifed storage into account.
 	pub fn storage_at(&self, db: &AccountDB, key: &H256) -> H256 {
-		if let Some(value) = self.storage_changes.get(key) {
-			return value.clone()
-		}
-		if let Some(value) = self.storage_cache.borrow_mut().get_mut(key) {
-			return value.clone()
+		if let Some(value) = self.cached_storage_at(key) {
+			return value;
 		}
 		let db = SecTrieDB::new(db, &self.storage_root)
 			.expect("Account storage_root initially set to zero (valid) and only altered by SecTrieDBMut. \

--- a/ethcore/src/account.rs
+++ b/ethcore/src/account.rs
@@ -36,6 +36,8 @@ pub struct Account {
 	storage_overlay: RefCell<HashMap<H256, (Filth, H256)>>,
 	// Code hash of the account. If None, means that it's a contract whose code has not yet been set.
 	code_hash: Option<H256>,
+	// Size of the accoun code.
+	code_size: Option<u64>,
 	// Code cache of the account.
 	code_cache: Bytes,
 	// Account is new or has been modified
@@ -54,6 +56,7 @@ impl Account {
 			storage_root: SHA3_NULL_RLP,
 			storage_overlay: RefCell::new(storage.into_iter().map(|(k, v)| (k, (Filth::Dirty, v))).collect()),
 			code_hash: Some(code.sha3()),
+			code_size: Some(code.len() as u64),
 			code_cache: code,
 			filth: Filth::Dirty,
 			address_hash: Cell::new(None),
@@ -68,7 +71,8 @@ impl Account {
 			storage_root: SHA3_NULL_RLP,
 			storage_overlay: RefCell::new(pod.storage.into_iter().map(|(k, v)| (k, (Filth::Dirty, v))).collect()),
 			code_hash: pod.code.as_ref().map(|c| c.sha3()),
-			code_cache: pod.code.as_ref().map_or_else(|| { warn!("POD account with unknown code is being created! Assuming no code."); vec![] }, |c| c.clone()),
+			code_size: Some(pod.code.as_ref().map_or(0, |c| c.len() as u64)),
+			code_cache: pod.code.map_or_else(|| { warn!("POD account with unknown code is being created! Assuming no code."); vec![] }, |c| c),
 			filth: Filth::Dirty,
 			address_hash: Cell::new(None),
 		}
@@ -83,6 +87,7 @@ impl Account {
 			storage_overlay: RefCell::new(HashMap::new()),
 			code_hash: Some(SHA3_EMPTY),
 			code_cache: vec![],
+			code_size: Some(0),
 			filth: Filth::Dirty,
 			address_hash: Cell::new(None),
 		}
@@ -98,6 +103,7 @@ impl Account {
 			storage_overlay: RefCell::new(HashMap::new()),
 			code_hash: Some(r.val_at(3)),
 			code_cache: vec![],
+			code_size: None,
 			filth: Filth::Clean,
 			address_hash: Cell::new(None),
 		}
@@ -113,6 +119,7 @@ impl Account {
 			storage_overlay: RefCell::new(HashMap::new()),
 			code_hash: None,
 			code_cache: vec![],
+			code_size: None,
 			filth: Filth::Dirty,
 			address_hash: Cell::new(None),
 		}
@@ -123,12 +130,14 @@ impl Account {
 	pub fn init_code(&mut self, code: Bytes) {
 		assert!(self.code_hash.is_none());
 		self.code_cache = code;
+		self.code_size = Some(self.code_cache.len() as u64);
 		self.filth = Filth::Dirty;
 	}
 
 	/// Reset this account's code to the given code.
 	pub fn reset_code(&mut self, code: Bytes) {
 		self.code_hash = None;
+		self.code_size = Some(0);
 		self.init_code(code);
 	}
 
@@ -196,6 +205,12 @@ impl Account {
 		}
 	}
 
+	/// returns the account's code size. If `None` then the code cache or code size cache isn't available -
+	/// get someone who knows to call `note_code`.
+	pub fn code_size(&self) -> Option<u64> {
+		self.code_size.clone()
+	}
+
 	#[cfg(test)]
 	/// Provide a byte array which hashes to the `code_hash`. returns the hash as a result.
 	pub fn note_code(&mut self, code: Bytes) -> Result<(), H256> {
@@ -203,6 +218,7 @@ impl Account {
 		match self.code_hash {
 			Some(ref i) if h == *i => {
 				self.code_cache = code;
+				self.code_size = Some(self.code_cache.len() as u64);
 				Ok(())
 			},
 			_ => Err(h)
@@ -231,7 +247,29 @@ impl Account {
 		self.is_cached() ||
 			match self.code_hash {
 				Some(ref h) => match db.get(h) {
-					Some(x) => { self.code_cache = x.to_vec(); true },
+					Some(x) => {
+						self.code_cache = x.to_vec();
+						self.code_size = Some(x.len() as u64);
+						true },
+					_ => {
+						warn!("Failed reverse get of {}", h);
+						false
+					},
+				},
+				_ => false,
+			}
+	}
+
+	/// Provide a database to get `code_size`. Should not be called if it is a contract without code.
+	pub fn cache_code_size(&mut self, db: &AccountDB) -> bool {
+		// TODO: fill out self.code_cache;
+		trace!("Account::cache_code_size: ic={}; self.code_hash={:?}, self.code_cache={}", self.is_cached(), self.code_hash, self.code_cache.pretty());
+		self.code_size.is_some() ||
+			match self.code_hash {
+				Some(ref h) if h != &SHA3_EMPTY => match db.get(h) {
+					Some(x) => {
+						self.code_size = Some(x.len() as u64);
+						true },
 					_ => {
 						warn!("Failed reverse get of {}", h);
 						false
@@ -303,9 +341,13 @@ impl Account {
 	pub fn commit_code(&mut self, db: &mut AccountDBMut) {
 		trace!("Commiting code of {:?} - {:?}, {:?}", self, self.code_hash.is_none(), self.code_cache.is_empty());
 		match (self.code_hash.is_none(), self.code_cache.is_empty()) {
-			(true, true) => self.code_hash = Some(SHA3_EMPTY),
+			(true, true) => {
+				self.code_hash = Some(SHA3_EMPTY);
+				self.code_size = Some(0);
+			}
 			(true, false) => {
 				self.code_hash = Some(db.insert(&self.code_cache));
+				self.code_size = Some(self.code_cache.len() as u64);
 			},
 			(false, _) => {},
 		}
@@ -317,7 +359,7 @@ impl Account {
 		stream.append(&self.nonce);
 		stream.append(&self.balance);
 		stream.append(&self.storage_root);
-		stream.append(self.code_hash.as_ref().expect("Cannot form RLP of contract account without code."));
+		stream.append(self.code_hash.as_ref().unwrap_or(&SHA3_EMPTY));
 		stream.out()
 	}
 }
@@ -415,6 +457,7 @@ mod tests {
 		let mut db = AccountDBMut::new(&mut db, &Address::new());
 		a.init_code(vec![0x55, 0x44, 0xffu8]);
 		assert_eq!(a.code_hash(), SHA3_EMPTY);
+		assert_eq!(a.code_size(), Some(3));
 		a.commit_code(&mut db);
 		assert_eq!(a.code_hash().hex(), "af231e631776a517ca23125370d542873eca1fb4d613ed9b5d5335a46ae5b7eb");
 	}

--- a/ethcore/src/account.rs
+++ b/ethcore/src/account.rs
@@ -20,11 +20,13 @@ use std::collections::hash_map::Entry;
 use util::*;
 use pod_account::*;
 use account_db::*;
+use lru_cache::LruCache;
 
-use std::cell::{Ref, RefCell, Cell};
+use std::cell::{RefCell, Cell};
+
+const STORAGE_CACHE_ITEMS: usize = 4096;
 
 /// Single account in the system.
-#[derive(Clone)]
 pub struct Account {
 	// Balance of the account.
 	balance: U256,
@@ -32,8 +34,12 @@ pub struct Account {
 	nonce: U256,
 	// Trie-backed storage.
 	storage_root: H256,
-	// Overlay on trie-backed storage - tuple is (<clean>, <value>).
-	storage_overlay: RefCell<HashMap<H256, (Filth, H256)>>,
+	// LRU Cache of the trie-backed storage.
+	// This is limited to `STORAGE_CACHE_ITEMS` recent queries
+	storage_cache: RefCell<LruCache<H256, H256>>,
+	// Modified storage. Accumulates changes to storage made in `set_storage`
+	// Takes precedence over `storage_cache`.
+	storage_changes: HashMap<H256, H256>,
 	// Code hash of the account. If None, means that it's a contract whose code has not yet been set.
 	code_hash: Option<H256>,
 	// Size of the accoun code.
@@ -54,7 +60,8 @@ impl Account {
 			balance: balance,
 			nonce: nonce,
 			storage_root: SHA3_NULL_RLP,
-			storage_overlay: RefCell::new(storage.into_iter().map(|(k, v)| (k, (Filth::Dirty, v))).collect()),
+			storage_cache: Self::empty_storage_cache(),
+			storage_changes: storage,
 			code_hash: Some(code.sha3()),
 			code_size: Some(code.len() as u64),
 			code_cache: code,
@@ -63,13 +70,18 @@ impl Account {
 		}
 	}
 
+	fn empty_storage_cache() -> RefCell<LruCache<H256, H256>> {
+		RefCell::new(LruCache::new(STORAGE_CACHE_ITEMS))
+	}
+
 	/// General constructor.
 	pub fn from_pod(pod: PodAccount) -> Account {
 		Account {
 			balance: pod.balance,
 			nonce: pod.nonce,
 			storage_root: SHA3_NULL_RLP,
-			storage_overlay: RefCell::new(pod.storage.into_iter().map(|(k, v)| (k, (Filth::Dirty, v))).collect()),
+			storage_cache: Self::empty_storage_cache(),
+			storage_changes: pod.storage.into_iter().collect(),
 			code_hash: pod.code.as_ref().map(|c| c.sha3()),
 			code_size: Some(pod.code.as_ref().map_or(0, |c| c.len() as u64)),
 			code_cache: pod.code.map_or_else(|| { warn!("POD account with unknown code is being created! Assuming no code."); vec![] }, |c| c),
@@ -84,7 +96,8 @@ impl Account {
 			balance: balance,
 			nonce: nonce,
 			storage_root: SHA3_NULL_RLP,
-			storage_overlay: RefCell::new(HashMap::new()),
+			storage_cache: Self::empty_storage_cache(),
+			storage_changes: HashMap::new(),
 			code_hash: Some(SHA3_EMPTY),
 			code_cache: vec![],
 			code_size: Some(0),
@@ -100,7 +113,8 @@ impl Account {
 			nonce: r.val_at(0),
 			balance: r.val_at(1),
 			storage_root: r.val_at(2),
-			storage_overlay: RefCell::new(HashMap::new()),
+			storage_cache: Self::empty_storage_cache(),
+			storage_changes: HashMap::new(),
 			code_hash: Some(r.val_at(3)),
 			code_cache: vec![],
 			code_size: None,
@@ -116,7 +130,8 @@ impl Account {
 			balance: balance,
 			nonce: nonce,
 			storage_root: SHA3_NULL_RLP,
-			storage_overlay: RefCell::new(HashMap::new()),
+			storage_cache: Self::empty_storage_cache(),
+			storage_changes: HashMap::new(),
 			code_hash: None,
 			code_cache: vec![],
 			code_size: None,
@@ -143,13 +158,13 @@ impl Account {
 
 	/// Set (and cache) the contents of the trie's storage at `key` to `value`.
 	pub fn set_storage(&mut self, key: H256, value: H256) {
-		match self.storage_overlay.borrow_mut().entry(key) {
-			Entry::Occupied(ref mut entry) if entry.get().1 != value => {
-				entry.insert((Filth::Dirty, value));
+		match self.storage_changes.entry(key) {
+			Entry::Occupied(ref mut entry) if entry.get() != &value => {
+				entry.insert(value);
 				self.filth = Filth::Dirty;
 			},
 			Entry::Vacant(entry) => {
-				entry.insert((Filth::Dirty, value));
+				entry.insert(value);
 				self.filth = Filth::Dirty;
 			},
 			_ => (),
@@ -157,19 +172,38 @@ impl Account {
 	}
 
 	/// Get (and cache) the contents of the trie's storage at `key`.
+	/// Takes modifed storage into account.
 	pub fn storage_at(&self, db: &AccountDB, key: &H256) -> H256 {
-		self.storage_overlay.borrow_mut().entry(key.clone()).or_insert_with(||{
-			let db = SecTrieDB::new(db, &self.storage_root)
-				.expect("Account storage_root initially set to zero (valid) and only altered by SecTrieDBMut. \
-				SecTrieDBMut would not set it to an invalid state root. Therefore the root is valid and DB creation \
-				using it will not fail.");
+		if let Some(value) = self.storage_changes.get(key) {
+			return value.clone()
+		}
+		if let Some(value) = self.storage_cache.borrow_mut().get_mut(key) {
+			return value.clone()
+		}
+		let db = SecTrieDB::new(db, &self.storage_root)
+			.expect("Account storage_root initially set to zero (valid) and only altered by SecTrieDBMut. \
+			SecTrieDBMut would not set it to an invalid state root. Therefore the root is valid and DB creation \
+			using it will not fail.");
 
-			let item: U256 = match db.get(key){
-				Ok(x) => x.map_or_else(U256::zero, decode),
-				Err(e) => panic!("Encountered potential DB corruption: {}", e),
-			};
-			(Filth::Clean, item.into())
-		}).1.clone()
+		let item: U256 = match db.get(key){
+			Ok(x) => x.map_or_else(U256::zero, decode),
+			Err(e) => panic!("Encountered potential DB corruption: {}", e),
+		};
+		let value: H256 = item.into();
+		self.storage_cache.borrow_mut().insert(key.clone(), value.clone());
+		value
+	}
+
+	/// Get cached storage value if any. Returns `None` if the
+	/// key is not in the cache.
+	pub fn cached_storage_at(&self, key: &H256) -> Option<H256> {
+		if let Some(value) = self.storage_changes.get(key) {
+			return Some(value.clone())
+		}
+		if let Some(value) = self.storage_cache.borrow_mut().get_mut(key) {
+			return Some(value.clone())
+		}
+		None
 	}
 
 	/// return the balance associated with this account.
@@ -232,11 +266,12 @@ impl Account {
 
 	/// Is this a new or modified account?
 	pub fn is_dirty(&self) -> bool {
-		self.filth == Filth::Dirty
+		self.filth == Filth::Dirty || !self.storage_is_clean()
 	}
 
 	/// Mark account as clean.
 	pub fn set_clean(&mut self) {
+		assert!(self.storage_is_clean());
 		self.filth = Filth::Clean
 	}
 
@@ -281,16 +316,15 @@ impl Account {
 			}
 	}
 
-	#[cfg(test)]
 	/// Determine whether there are any un-`commit()`-ed storage-setting operations.
-	pub fn storage_is_clean(&self) -> bool { self.storage_overlay.borrow().iter().find(|&(_, &(f, _))| f == Filth::Dirty).is_none() }
+	pub fn storage_is_clean(&self) -> bool { self.storage_changes.is_empty() }
 
 	#[cfg(test)]
 	/// return the storage root associated with this account or None if it has been altered via the overlay.
 	pub fn storage_root(&self) -> Option<&H256> { if self.storage_is_clean() {Some(&self.storage_root)} else {None} }
 
 	/// return the storage overlay.
-	pub fn storage_overlay(&self) -> Ref<HashMap<H256, (Filth, H256)>> { self.storage_overlay.borrow() }
+	pub fn storage_changes(&self) -> &HashMap<H256, H256> { &self.storage_changes }
 
 	/// Increment the nonce of the account by one.
 	pub fn inc_nonce(&mut self) {
@@ -316,26 +350,24 @@ impl Account {
 		}
 	}
 
-	/// Commit the `storage_overlay` to the backing DB and update `storage_root`.
+	/// Commit the `storage_changes` to the backing DB and update `storage_root`.
 	pub fn commit_storage(&mut self, trie_factory: &TrieFactory, db: &mut AccountDBMut) {
 		let mut t = trie_factory.from_existing(db, &mut self.storage_root)
 			.expect("Account storage_root initially set to zero (valid) and only altered by SecTrieDBMut. \
 				SecTrieDBMut would not set it to an invalid state root. Therefore the root is valid and DB creation \
 				using it will not fail.");
-		for (k, &mut (ref mut f, ref mut v)) in self.storage_overlay.borrow_mut().iter_mut() {
-			if f == &Filth::Dirty {
-				// cast key and value to trait type,
-				// so we can call overloaded `to_bytes` method
-				let res = match v.is_zero() {
-					true => t.remove(k),
-					false => t.insert(k, &encode(&U256::from(v.as_slice()))),
-				};
+		for (k, v) in self.storage_changes.drain() {
+			// cast key and value to trait type,
+			// so we can call overloaded `to_bytes` method
+			let res = match v.is_zero() {
+				true => t.remove(k.as_slice()),
+				false => t.insert(k.as_slice(), &encode(&U256::from(v.as_slice()))),
+			};
 
-				if let Err(e) = res {
-					warn!("Encountered potential DB corruption: {}", e);
-				}
-				*f = Filth::Clean;
+			if let Err(e) = res {
+				warn!("Encountered potential DB corruption: {}", e);
 			}
+			self.storage_cache.borrow_mut().insert(k, v);
 		}
 	}
 
@@ -363,6 +395,54 @@ impl Account {
 		stream.append(&self.storage_root);
 		stream.append(self.code_hash.as_ref().unwrap_or(&SHA3_EMPTY));
 		stream.out()
+	}
+
+	/// Clone basic account data
+	pub fn clone_basic(&self) -> Account {
+		Account {
+			balance: self.balance.clone(),
+			nonce: self.nonce.clone(),
+			storage_root: self.storage_root.clone(),
+			storage_cache: Self::empty_storage_cache(),
+			storage_changes: HashMap::new(),
+			code_hash: self.code_hash.clone(),
+			code_size: self.code_size.clone(),
+			code_cache: Bytes::new(),
+			filth: self.filth,
+			address_hash: self.address_hash.clone(),
+		}
+	}
+
+	/// Clone account data and dirty storage keys
+	pub fn clone_dirty(&self) -> Account {
+		let mut account = self.clone_basic();
+		account.storage_changes = self.storage_changes.clone();
+		account.code_cache = self.code_cache.clone();
+		account
+	}
+
+	/// Clone account data, dirty storage keys and cached storage keys.
+	pub fn clone_all(&self) -> Account {
+		let mut account = self.clone_dirty();
+		account.storage_cache = self.storage_cache.clone();
+		account
+	}
+
+	/// Replace self with the data from other account merging storage cache
+	pub fn merge_with(&mut self, other: Account) {
+		assert!(self.storage_is_clean());
+		assert!(other.storage_is_clean());
+		self.balance = other.balance;
+		self.nonce = other.nonce;
+		self.storage_root = other.storage_root;
+		self.code_hash = other.code_hash;
+		self.code_cache = other.code_cache;
+		self.code_size = other.code_size;
+		self.address_hash = other.address_hash;
+		let mut cache = self.storage_cache.borrow_mut();
+		for (k, v) in other.storage_cache.into_inner().into_iter() {
+			cache.insert(k.clone() , v.clone()); //TODO: cloning should not be required here
+		}
 	}
 }
 

--- a/ethcore/src/block.rs
+++ b/ethcore/src/block.rs
@@ -19,6 +19,7 @@
 use common::*;
 use engines::Engine;
 use state::*;
+use state_db::StateDB;
 use verification::PreverifiedBlock;
 use trace::FlatTrace;
 use evm::Factory as EvmFactory;
@@ -178,7 +179,7 @@ pub trait IsBlock {
 /// Trait for a object that has a state database.
 pub trait Drain {
 	/// Drop this object and return the underlieing database.
-	fn drain(self) -> Box<JournalDB>;
+	fn drain(self) -> StateDB;
 }
 
 impl IsBlock for ExecutedBlock {
@@ -233,7 +234,7 @@ impl<'x> OpenBlock<'x> {
 		vm_factory: &'x EvmFactory,
 		trie_factory: TrieFactory,
 		tracing: bool,
-		db: Box<JournalDB>,
+		db: StateDB,
 		parent: &Header,
 		last_hashes: Arc<LastHashes>,
 		author: Address,
@@ -465,7 +466,10 @@ impl LockedBlock {
 
 impl Drain for LockedBlock {
 	/// Drop this object and return the underlieing database.
-	fn drain(self) -> Box<JournalDB> { self.block.state.drop().1 }
+	fn drain(mut self) -> StateDB {
+		self.block.state.commit_cache();
+		self.block.state.drop().1
+	}
 }
 
 impl SealedBlock {
@@ -481,7 +485,10 @@ impl SealedBlock {
 
 impl Drain for SealedBlock {
 	/// Drop this object and return the underlieing database.
-	fn drain(self) -> Box<JournalDB> { self.block.state.drop().1 }
+	fn drain(mut self) -> StateDB {
+		self.block.state.commit_cache();
+		self.block.state.drop().1
+	}
 }
 
 impl IsBlock for SealedBlock {
@@ -496,7 +503,7 @@ pub fn enact(
 	uncles: &[Header],
 	engine: &Engine,
 	tracing: bool,
-	db: Box<JournalDB>,
+	db: StateDB,
 	parent: &Header,
 	last_hashes: Arc<LastHashes>,
 	vm_factory: &EvmFactory,
@@ -529,7 +536,7 @@ pub fn enact_bytes(
 	block_bytes: &[u8],
 	engine: &Engine,
 	tracing: bool,
-	db: Box<JournalDB>,
+	db: StateDB,
 	parent: &Header,
 	last_hashes: Arc<LastHashes>,
 	vm_factory: &EvmFactory,
@@ -546,7 +553,7 @@ pub fn enact_verified(
 	block: &PreverifiedBlock,
 	engine: &Engine,
 	tracing: bool,
-	db: Box<JournalDB>,
+	db: StateDB,
 	parent: &Header,
 	last_hashes: Arc<LastHashes>,
 	vm_factory: &EvmFactory,
@@ -562,7 +569,7 @@ pub fn enact_and_seal(
 	block_bytes: &[u8],
 	engine: &Engine,
 	tracing: bool,
-	db: Box<JournalDB>,
+	db: StateDB,
 	parent: &Header,
 	last_hashes: Arc<LastHashes>,
 	vm_factory: &EvmFactory,
@@ -583,9 +590,9 @@ mod tests {
 		use spec::*;
 		let spec = Spec::new_test();
 		let genesis_header = spec.genesis_header();
-		let mut db_result = get_temp_journal_db();
+		let mut db_result = get_temp_state_db();
 		let mut db = db_result.take();
-		spec.ensure_db_good(db.as_hashdb_mut()).unwrap();
+		spec.ensure_db_good(&mut db).unwrap();
 		let last_hashes = Arc::new(vec![genesis_header.hash()]);
 		let vm_factory = Default::default();
 		let b = OpenBlock::new(&*spec.engine, &vm_factory, Default::default(), false, db, &genesis_header, last_hashes, Address::zero(), (3141562.into(), 31415620.into()), vec![]).unwrap();
@@ -600,9 +607,9 @@ mod tests {
 		let engine = &*spec.engine;
 		let genesis_header = spec.genesis_header();
 
-		let mut db_result = get_temp_journal_db();
+		let mut db_result = get_temp_state_db();
 		let mut db = db_result.take();
-		spec.ensure_db_good(db.as_hashdb_mut()).unwrap();
+		spec.ensure_db_good(&mut db).unwrap();
 		let vm_factory = Default::default();
 		let last_hashes = Arc::new(vec![genesis_header.hash()]);
 		let b = OpenBlock::new(engine, &vm_factory, Default::default(), false, db, &genesis_header, last_hashes.clone(), Address::zero(), (3141562.into(), 31415620.into()), vec![]).unwrap()
@@ -610,16 +617,16 @@ mod tests {
 		let orig_bytes = b.rlp_bytes();
 		let orig_db = b.drain();
 
-		let mut db_result = get_temp_journal_db();
+		let mut db_result = get_temp_state_db();
 		let mut db = db_result.take();
-		spec.ensure_db_good(db.as_hashdb_mut()).unwrap();
+		spec.ensure_db_good(&mut db).unwrap();
 		let e = enact_and_seal(&orig_bytes, engine, false, db, &genesis_header, last_hashes, &Default::default(), Default::default()).unwrap();
 
 		assert_eq!(e.rlp_bytes(), orig_bytes);
 
 		let db = e.drain();
-		assert_eq!(orig_db.keys(), db.keys());
-		assert!(orig_db.keys().iter().filter(|k| orig_db.get(k.0) != db.get(k.0)).next() == None);
+		assert_eq!(orig_db.journal_db().keys(), db.journal_db().keys());
+		assert!(orig_db.journal_db().keys().iter().filter(|k| orig_db.journal_db().get(k.0) != db.journal_db().get(k.0)).next() == None);
 	}
 
 	#[test]
@@ -629,9 +636,9 @@ mod tests {
 		let engine = &*spec.engine;
 		let genesis_header = spec.genesis_header();
 
-		let mut db_result = get_temp_journal_db();
+		let mut db_result = get_temp_state_db();
 		let mut db = db_result.take();
-		spec.ensure_db_good(db.as_hashdb_mut()).unwrap();
+		spec.ensure_db_good(&mut db).unwrap();
 		let vm_factory = Default::default();
 		let last_hashes = Arc::new(vec![genesis_header.hash()]);
 		let mut open_block = OpenBlock::new(engine, &vm_factory, Default::default(), false, db, &genesis_header, last_hashes.clone(), Address::zero(), (3141562.into(), 31415620.into()), vec![]).unwrap();
@@ -646,9 +653,9 @@ mod tests {
 		let orig_bytes = b.rlp_bytes();
 		let orig_db = b.drain();
 
-		let mut db_result = get_temp_journal_db();
+		let mut db_result = get_temp_state_db();
 		let mut db = db_result.take();
-		spec.ensure_db_good(db.as_hashdb_mut()).unwrap();
+		spec.ensure_db_good(&mut db).unwrap();
 		let e = enact_and_seal(&orig_bytes, engine, false, db, &genesis_header, last_hashes, &Default::default(), Default::default()).unwrap();
 
 		let bytes = e.rlp_bytes();
@@ -657,7 +664,7 @@ mod tests {
 		assert_eq!(uncles[1].extra_data, b"uncle2");
 
 		let db = e.drain();
-		assert_eq!(orig_db.keys(), db.keys());
-		assert!(orig_db.keys().iter().filter(|k| orig_db.get(k.0) != db.get(k.0)).next() == None);
+		assert_eq!(orig_db.journal_db().keys(), db.journal_db().keys());
+		assert!(orig_db.journal_db().keys().iter().filter(|k| orig_db.journal_db().get(k.0) != db.journal_db().get(k.0)).next() == None);
 	}
 }

--- a/ethcore/src/block.rs
+++ b/ethcore/src/block.rs
@@ -466,8 +466,7 @@ impl LockedBlock {
 
 impl Drain for LockedBlock {
 	/// Drop this object and return the underlieing database.
-	fn drain(mut self) -> StateDB {
-		self.block.state.commit_cache();
+	fn drain(self) -> StateDB {
 		self.block.state.drop().1
 	}
 }
@@ -485,8 +484,7 @@ impl SealedBlock {
 
 impl Drain for SealedBlock {
 	/// Drop this object and return the underlieing database.
-	fn drain(mut self) -> StateDB {
-		self.block.state.commit_cache();
+	fn drain(self) -> StateDB {
 		self.block.state.drop().1
 	}
 }

--- a/ethcore/src/client/client.rs
+++ b/ethcore/src/client/client.rs
@@ -23,7 +23,6 @@ use time::precise_time_ns;
 
 // util
 use util::{journaldb, rlp, Bytes, View, PerfTimer, Itertools, Mutex, RwLock};
-use util::journaldb::JournalDB;
 use util::rlp::{UntrustedRlp};
 use util::numbers::*;
 use util::sha3::*;
@@ -65,6 +64,7 @@ use evm::Factory as EvmFactory;
 use miner::{Miner, MinerService};
 use util::TrieFactory;
 use snapshot::{self, io as snapshot_io};
+use state_db::StateDB;
 
 // re-export
 pub use types::blockchain_info::BlockChainInfo;
@@ -124,7 +124,7 @@ pub struct Client {
 	tracedb: Arc<TraceDB<BlockChain>>,
 	engine: Arc<Engine>,
 	db: Arc<Database>,
-	state_db: Mutex<Box<JournalDB>>,
+	state_db: Mutex<StateDB>,
 	block_queue: BlockQueue,
 	report: RwLock<ClientReport>,
 	import_lock: Mutex<()>,
@@ -184,14 +184,15 @@ impl Client {
 		let chain = Arc::new(BlockChain::new(config.blockchain, &gb, db.clone()));
 		let tracedb = Arc::new(try!(TraceDB::new(config.tracing, db.clone(), chain.clone())));
 
-		let mut state_db = journaldb::new(db.clone(), config.pruning, DB_COL_STATE);
-		if state_db.is_empty() && try!(spec.ensure_db_good(state_db.as_hashdb_mut())) {
+		let journal_db = journaldb::new(db.clone(), config.pruning, DB_COL_STATE);
+		let mut state_db = StateDB::new(journal_db);
+		if state_db.journal_db().is_empty() && try!(spec.ensure_db_good(&mut state_db)) {
 			let batch = DBTransaction::new(&db);
 			try!(state_db.commit(&batch, 0, &spec.genesis_header().hash(), None));
 			try!(db.write(batch).map_err(ClientError::Database));
 		}
 
-		if !chain.block_header(&chain.best_block_hash()).map_or(true, |h| state_db.contains(h.state_root())) {
+		if !chain.block_header(&chain.best_block_hash()).map_or(true, |h| state_db.journal_db().contains(h.state_root())) {
 			warn!("State root not found for block #{} ({})", chain.best_block_number(), chain.best_block_hash().hex());
 		}
 
@@ -301,7 +302,8 @@ impl Client {
 		// Enact Verified Block
 		let parent = chain_has_parent.unwrap();
 		let last_hashes = self.build_last_hashes(header.parent_hash.clone());
-		let db = self.state_db.lock().boxed_clone();
+		let is_canon = header.parent_hash == self.chain.best_block_hash();
+		let db = if is_canon { self.state_db.lock().canon_clone() } else { self.state_db.lock().boxed_clone() };
 
 		let enact_result = enact_verified(block, engine, self.tracedb.tracing_enabled(), db, &parent, last_hashes, &self.vm_factory, self.trie_factory.clone());
 		if let Err(e) = enact_result {
@@ -443,7 +445,8 @@ impl Client {
 		// CHECK! I *think* this is fine, even if the state_root is equal to another
 		// already-imported block of the same number.
 		// TODO: Prove it with a test.
-		block.drain().commit(&batch, number, hash, ancient).expect("DB commit failed.");
+		let mut state = block.drain();
+		state.commit(&batch, number, hash, ancient).expect("DB commit failed.");
 
 		let route = self.chain.insert_block(&batch, block_data, receipts);
 		self.tracedb.import(&batch, TraceImportRequest {
@@ -456,6 +459,13 @@ impl Client {
 		// Final commit to the DB
 		self.db.write_buffered(batch).expect("DB write failed.");
 		self.chain.commit();
+
+		if route.enacted.len() == 1 && route.retracted.len() == 0 && route.omitted.len() == 0 {
+			// cache canon block
+			state.commit_cache();
+		} else {
+			state.clear_cache();
+		}
 
 		self.update_last_hashes(&parent, hash);
 		route
@@ -600,7 +610,7 @@ impl Client {
 	/// Take a snapshot at the given block.
 	/// If the ID given is "latest", this will default to 1000 blocks behind.
 	pub fn take_snapshot<W: snapshot_io::SnapshotWriter + Send>(&self, writer: W, at: BlockID, p: &snapshot::Progress) -> Result<(), ::error::Error> {
-		let db = self.state_db.lock().boxed_clone();
+		let db = self.state_db.lock().journal_db().boxed_clone();
 		let best_block_number = self.chain_info().best_block_number;
 		let block_number = try!(self.block_number(at).ok_or(snapshot::Error::InvalidStartingBlock(at)));
 
@@ -881,7 +891,7 @@ impl BlockChainClient for Client {
 	}
 
 	fn state_data(&self, hash: &H256) -> Option<Bytes> {
-		self.state_db.lock().state(hash)
+		self.state_db.lock().journal_db().state(hash)
 	}
 
 	fn block_receipts(&self, hash: &H256) -> Option<Bytes> {

--- a/ethcore/src/engines/basic_authority.rs
+++ b/ethcore/src/engines/basic_authority.rs
@@ -248,9 +248,9 @@ mod tests {
 		let spec = new_test_authority();
 		let engine = &*spec.engine;
 		let genesis_header = spec.genesis_header();
-		let mut db_result = get_temp_journal_db();
+		let mut db_result = get_temp_state_db();
 		let mut db = db_result.take();
-		spec.ensure_db_good(db.as_hashdb_mut()).unwrap();
+		spec.ensure_db_good(&mut db).unwrap();
 		let last_hashes = Arc::new(vec![genesis_header.hash()]);
 		let vm_factory = Default::default();
 		let b = OpenBlock::new(engine, &vm_factory, Default::default(), false, db, &genesis_header, last_hashes, addr, (3141562.into(), 31415620.into()), vec![]).unwrap();

--- a/ethcore/src/engines/instant_seal.rs
+++ b/ethcore/src/engines/instant_seal.rs
@@ -82,9 +82,9 @@ mod tests {
 		let spec = new_test_instant();
 		let engine = &*spec.engine;
 		let genesis_header = spec.genesis_header();
-		let mut db_result = get_temp_journal_db();
+		let mut db_result = get_temp_state_db();
 		let mut db = db_result.take();
-		spec.ensure_db_good(db.as_hashdb_mut()).unwrap();
+		spec.ensure_db_good(&mut db).unwrap();
 		let last_hashes = Arc::new(vec![genesis_header.hash()]);
 		let vm_factory = Default::default();
 		let b = OpenBlock::new(engine, &vm_factory, Default::default(), false, db, &genesis_header, last_hashes, addr, (3141562.into(), 31415620.into()), vec![]).unwrap();

--- a/ethcore/src/ethereum/ethash.rs
+++ b/ethcore/src/ethereum/ethash.rs
@@ -353,9 +353,9 @@ mod tests {
 		let spec = new_morden();
 		let engine = &*spec.engine;
 		let genesis_header = spec.genesis_header();
-		let mut db_result = get_temp_journal_db();
+		let mut db_result = get_temp_state_db();
 		let mut db = db_result.take();
-		spec.ensure_db_good(db.as_hashdb_mut()).unwrap();
+		spec.ensure_db_good(&mut db).unwrap();
 		let last_hashes = Arc::new(vec![genesis_header.hash()]);
 		let vm_factory = Default::default();
 		let b = OpenBlock::new(engine, &vm_factory, Default::default(), false, db, &genesis_header, last_hashes, Address::zero(), (3141562.into(), 31415620.into()), vec![]).unwrap();
@@ -368,9 +368,9 @@ mod tests {
 		let spec = new_morden();
 		let engine = &*spec.engine;
 		let genesis_header = spec.genesis_header();
-		let mut db_result = get_temp_journal_db();
+		let mut db_result = get_temp_state_db();
 		let mut db = db_result.take();
-		spec.ensure_db_good(db.as_hashdb_mut()).unwrap();
+		spec.ensure_db_good(&mut db).unwrap();
 		let last_hashes = Arc::new(vec![genesis_header.hash()]);
 		let vm_factory = Default::default();
 		let mut b = OpenBlock::new(engine, &vm_factory, Default::default(), false, db, &genesis_header, last_hashes, Address::zero(), (3141562.into(), 31415620.into()), vec![]).unwrap();

--- a/ethcore/src/ethereum/mod.rs
+++ b/ethcore/src/ethereum/mod.rs
@@ -65,9 +65,9 @@ mod tests {
 		let spec = new_morden();
 		let engine = &spec.engine;
 		let genesis_header = spec.genesis_header();
-		let mut db_result = get_temp_journal_db();
+		let mut db_result = get_temp_state_db();
 		let mut db = db_result.take();
-		spec.ensure_db_good(db.as_hashdb_mut()).unwrap();
+		spec.ensure_db_good(&mut db).unwrap();
 		let s = State::from_existing(db, genesis_header.state_root.clone(), engine.account_start_nonce(), Default::default()).unwrap();
 		assert_eq!(s.balance(&address_from_hex("0000000000000000000000000000000000000001")), U256::from(1u64));
 		assert_eq!(s.balance(&address_from_hex("0000000000000000000000000000000000000002")), U256::from(1u64));

--- a/ethcore/src/evm/ext.rs
+++ b/ethcore/src/evm/ext.rs
@@ -83,6 +83,9 @@ pub trait Ext {
 	/// Returns code at given address
 	fn extcode(&self, address: &Address) -> Bytes;
 
+	/// Returns code length in bytes at given address
+	fn extcode_len(&self, address: &Address) -> u64;
+
 	/// Creates log entry with given topics and data
 	fn log(&mut self, topics: Vec<H256>, data: &[u8]);
 

--- a/ethcore/src/evm/interpreter/mod.rs
+++ b/ethcore/src/evm/interpreter/mod.rs
@@ -471,7 +471,7 @@ impl<Cost: CostType> Interpreter<Cost> {
 			},
 			instructions::EXTCODESIZE => {
 				let address = u256_to_address(&stack.pop_back());
-				let len = ext.extcode(&address).len();
+				let len = ext.extcode_len(&address);
 				stack.push(U256::from(len));
 			},
 			instructions::CALLDATACOPY => {

--- a/ethcore/src/evm/tests.rs
+++ b/ethcore/src/evm/tests.rs
@@ -140,6 +140,10 @@ impl Ext for FakeExt {
 		self.codes.get(address).unwrap_or(&Bytes::new()).clone()
 	}
 
+	fn extcode_len(&self, address: &Address) -> u64 {
+		self.codes.get(address).map_or(0, |c| c.len() as u64)
+	}
+
 	fn log(&mut self, topics: Vec<H256>, data: &[u8]) {
 		self.logs.push(FakeLogEntry {
 			topics: topics,

--- a/ethcore/src/externalities.rs
+++ b/ethcore/src/externalities.rs
@@ -206,6 +206,10 @@ impl<'a, T, V> Ext for Externalities<'a, T, V> where T: 'a + Tracer, V: 'a + VMT
 		self.state.code(address).unwrap_or_else(|| vec![])
 	}
 
+	fn extcode_len(&self, address: &Address) -> u64 {
+		self.state.code_size(address).unwrap_or(0)
+	}
+
 	#[cfg_attr(feature="dev", allow(match_ref_pats))]
 	fn ret(mut self, gas: &U256, data: &[u8]) -> evm::Result<U256>
 		where Self: Sized {

--- a/ethcore/src/json_tests/executive.rs
+++ b/ethcore/src/json_tests/executive.rs
@@ -132,6 +132,10 @@ impl<'a, T, V> Ext for TestExt<'a, T, V> where T: Tracer, V: VMTracer {
 		self.ext.extcode(address)
 	}
 
+	fn extcode_len(&self, address: &Address) -> u64  {
+		self.ext.extcode_len(address)
+	}
+
 	fn log(&mut self, topics: Vec<H256>, data: &[u8]) {
 		self.ext.log(topics, data)
 	}

--- a/ethcore/src/lib.rs
+++ b/ethcore/src/lib.rs
@@ -100,6 +100,7 @@ extern crate ethcore_ipc_nano as nanoipc;
 extern crate ethcore_devtools as devtools;
 extern crate rand;
 extern crate bit_set;
+extern crate lru_cache;
 
 #[cfg(feature = "jit" )] extern crate evmjit;
 
@@ -130,6 +131,7 @@ mod basic_types;
 mod env_info;
 mod pod_account;
 mod state;
+mod state_db;
 mod account;
 mod account_db;
 mod builtin;

--- a/ethcore/src/pod_account.rs
+++ b/ethcore/src/pod_account.rs
@@ -47,7 +47,7 @@ impl PodAccount {
 		PodAccount {
 			balance: *acc.balance(),
 			nonce: *acc.nonce(),
-			storage: acc.storage_overlay().iter().fold(BTreeMap::new(), |mut m, (k, &(_, ref v))| {m.insert(k.clone(), v.clone()); m}),
+			storage: acc.storage_changes().iter().fold(BTreeMap::new(), |mut m, (k, v)| {m.insert(k.clone(), v.clone()); m}),
 			code: acc.code().map(|x| x.to_vec()),
 		}
 	}

--- a/ethcore/src/snapshot/account.rs
+++ b/ethcore/src/snapshot/account.rs
@@ -143,7 +143,7 @@ impl Account {
 #[cfg(test)]
 mod tests {
 	use account_db::{AccountDB, AccountDBMut};
-	use tests::helpers::get_temp_journal_db;
+	use tests::helpers::get_temp_state_db;
 	use snapshot::tests::helpers::fill_storage;
 
 	use util::{SHA3_NULL_RLP, SHA3_EMPTY};
@@ -154,8 +154,7 @@ mod tests {
 
 	#[test]
 	fn encoding_basic() {
-		let mut db = get_temp_journal_db();
-		let mut db = &mut **db;
+		let mut db = get_temp_state_db();
 		let addr = Address::random();
 
 		let account = Account {
@@ -175,8 +174,7 @@ mod tests {
 
 	#[test]
 	fn encoding_storage() {
-		let mut db = get_temp_journal_db();
-		let mut db = &mut **db;
+		let mut db = get_temp_state_db();
 		let addr = Address::random();
 
 		let account = {

--- a/ethcore/src/spec/spec.rs
+++ b/ethcore/src/spec/spec.rs
@@ -20,6 +20,7 @@ use common::*;
 use engines::{Engine, NullEngine, InstantSeal, BasicAuthority};
 use pod_state::*;
 use account_db::*;
+use state_db::StateDB;
 use super::genesis::Genesis;
 use super::seal::Generic as GenericSeal;
 use ethereum;
@@ -229,19 +230,19 @@ impl Spec {
 	}
 
 	/// Ensure that the given state DB has the trie nodes in for the genesis state.
-	pub fn ensure_db_good(&self, db: &mut HashDB) -> Result<bool, Box<TrieError>> {
-		if !db.contains(&self.state_root()) {
+	pub fn ensure_db_good(&self, db: &mut StateDB) -> Result<bool, Box<TrieError>> {
+		if !db.as_hashdb().contains(&self.state_root()) {
 			let mut root = H256::new();
 			{
-				let mut t = SecTrieDBMut::new(db, &mut root);
+				let mut t = SecTrieDBMut::new(db.as_hashdb_mut(), &mut root);
 				for (address, account) in self.genesis_state.get().iter() {
 					try!(t.insert(address.as_slice(), &account.rlp()));
 				}
 			}
 			for (address, account) in self.genesis_state.get().iter() {
-				account.insert_additional(&mut AccountDBMut::new(db, address));
+				account.insert_additional(&mut AccountDBMut::new(db.as_hashdb_mut(), address));
 			}
-			assert!(db.contains(&self.state_root()));
+			assert!(db.as_hashdb().contains(&self.state_root()));
 			Ok(true)
 		} else { Ok(false) }
 	}

--- a/ethcore/src/state.rs
+++ b/ethcore/src/state.rs
@@ -38,16 +38,37 @@ pub struct ApplyOutcome {
 /// Result type for the execution ("application") of a transaction.
 pub type ApplyResult = Result<ApplyOutcome, Error>;
 
+#[derive(Clone, Debug)]
+enum AccountEntry {
+	/// Contains account data.
+	Cached(Account),
+	/// Account has been deleted.
+	Killed,
+	/// Account does not exist.
+	Missing,
+}
+
+impl AccountEntry {
+	fn is_dirty(&self) -> bool {
+		match *self {
+			AccountEntry::Cached(ref a) => a.is_dirty(),
+			AccountEntry::Killed => true,
+			AccountEntry::Missing => false,
+		}
+	}
+}
+
 /// Representation of the entire state of all accounts in the system.
 pub struct State {
 	db: StateDB,
 	root: H256,
-	cache: RefCell<HashMap<Address, Option<Account>>>,
-	snapshots: RefCell<Vec<HashMap<Address, Option<Option<Account>>>>>,
+	cache: RefCell<HashMap<Address, AccountEntry>>,
+	snapshots: RefCell<Vec<HashMap<Address, Option<AccountEntry>>>>,
 	account_start_nonce: U256,
 	trie_factory: TrieFactory,
 }
 
+#[derive(Copy, Clone)]
 enum RequireCache {
 	None,
 	CodeSize,
@@ -125,11 +146,11 @@ impl State {
 						//self.cache.borrow_mut().remove(&k);
 						match self.cache.borrow_mut().entry(k) {
 							::std::collections::hash_map::Entry::Occupied(e) => {
-								if e.get().as_ref().map_or(true, |a| a.is_dirty()) {
+								if e.get().is_dirty() {
 									e.remove();
 								}
 							},
-							_ => ()
+							_ => {}
 						}
 					}
 				}
@@ -137,7 +158,7 @@ impl State {
 		}
 	}
 
-	fn insert_cache(&self, address: &Address, account: Option<Account>) {
+	fn insert_cache(&self, address: &Address, account: AccountEntry) {
 		if let Some(ref mut snapshot) = self.snapshots.borrow_mut().last_mut() {
 			if !snapshot.contains_key(address) {
 				snapshot.insert(address.clone(), self.cache.borrow_mut().insert(address.clone(), account));
@@ -156,7 +177,8 @@ impl State {
 	}
 
 	/// Destroy the current object and return root and database.
-	pub fn drop(self) -> (H256, StateDB) {
+	pub fn drop(mut self) -> (H256, StateDB) {
+		self.commit_cache();
 		(self.root, self.db)
 	}
 
@@ -168,12 +190,12 @@ impl State {
 	/// Create a new contract at address `contract`. If there is already an account at the address
 	/// it will have its code reset, ready for `init_code()`.
 	pub fn new_contract(&mut self, contract: &Address, balance: U256) {
-		self.insert_cache(contract, Some(Account::new_contract(balance, self.account_start_nonce)));
+		self.insert_cache(contract, AccountEntry::Cached(Account::new_contract(balance, self.account_start_nonce)));
 	}
 
 	/// Remove an existing account.
 	pub fn kill_account(&mut self, account: &Address) {
-		self.insert_cache(account, None);
+		self.insert_cache(account, AccountEntry::Killed);
 	}
 
 	/// Determine whether an account exists.
@@ -268,18 +290,17 @@ impl State {
 	/// Commit accounts to SecTrieDBMut. This is similar to cpp-ethereum's dev::eth::commit.
 	/// `accounts` is mutable because we may need to commit the code or storage and record that.
 	#[cfg_attr(feature="dev", allow(match_ref_pats))]
-	pub fn commit_into(
+	fn commit_into(
 		trie_factory: &TrieFactory,
 		db: &mut StateDB,
 		root: &mut H256,
-		accounts: &mut HashMap<Address,
-		Option<Account>>
+		accounts: &mut HashMap<Address, AccountEntry>
 	) -> Result<(), Error> {
 		// first, commit the sub trees.
 		// TODO: is this necessary or can we dispense with the `ref mut a` for just `a`?
 		for (address, ref mut a) in accounts.iter_mut() {
 			match a {
-				&mut&mut Some(ref mut account) if account.is_dirty() => {
+				&mut&mut AccountEntry::Cached(ref mut account) if account.is_dirty() => {
 					let mut account_db = AccountDBMut::from_hash(db.as_hashdb_mut(), account.address_hash(address));
 					account.commit_storage(trie_factory, &mut account_db);
 					account.commit_code(&mut account_db);
@@ -292,12 +313,15 @@ impl State {
 			let mut trie = trie_factory.from_existing(db.as_hashdb_mut(), root).unwrap();
 			for (address, ref mut a) in accounts.iter_mut() {
 				match **a {
-					Some(ref mut account) if account.is_dirty() => {
+					AccountEntry::Cached(ref mut account) if account.is_dirty() => {
 						account.set_clean();
-						try!(trie.insert(address, &account.rlp()))
+						try!(trie.insert(address, &account.rlp()));
 					},
-					None => try!(trie.remove(address)),
-					_ => (),
+					AccountEntry::Killed => {
+						try!(trie.remove(address));
+						**a = AccountEntry::Missing;
+					},
+					_ => {},
 				}
 			}
 		}
@@ -305,10 +329,20 @@ impl State {
 		Ok(())
 	}
 
-	pub fn commit_cache(&mut self) {
+	fn commit_cache(&mut self) {
 		let mut addresses = self.cache.borrow_mut();
 		for (address, a) in addresses.drain() {
-			self.db.cache_account(address, a);
+			match a {
+				AccountEntry::Cached(account) => {
+					if !account.is_dirty() {
+						self.db.cache_account(address, Some(account));
+					}
+				},
+				AccountEntry::Missing => {
+					self.db.cache_account(address, None);
+				}
+				_ => {},
+			}
 		}
 	}
 
@@ -339,7 +373,7 @@ impl State {
 		// TODO: handle database rather than just the cache.
 		// will need fat db.
 		PodState::from(self.cache.borrow().iter().fold(BTreeMap::new(), |mut m, (add, opt)| {
-			if let Some(ref acc) = *opt {
+			if let AccountEntry::Cached(ref acc) = *opt {
 				m.insert(add.clone(), PodAccount::from_account(acc));
 			}
 			m
@@ -367,41 +401,60 @@ impl State {
 		pod_state::diff_pod(&state_pre.to_pod(), &pod_state_post)
 	}
 
-	/// Ensure account `a` is in our cache of the trie DB and return a handle for getting it.
-	/// `require_code` requires that the code be cached, too.
-	fn ensure_cached<'a, F, U>(&'a self, a: &'a Address, require: RequireCache, f: F) -> U
-		where F: FnOnce(&Option<Account>) -> U {
-		let have_key = self.cache.borrow().contains_key(a);
-		if !have_key {
-			let maybe_acc = match self.db.get_cached_account(a) {
-				Some(maybe_acc) => maybe_acc,
-				None => {
-					let db = self.trie_factory.readonly(self.db.as_hashdb(), &self.root).expect(SEC_TRIE_DB_UNWRAP_STR);
-					match db.get(a) {
-						Ok(acc) => acc.map(Account::from_rlp),
-						Err(e) => panic!("Potential DB corruption encountered: {}", e),
-					}
-				},
-			};
-			self.insert_cache(a, maybe_acc);
-		}
+	fn update_account_cache(require: RequireCache, account: &mut Account, address: &Address, db: &HashDB) {
 		match require {
 			RequireCache::None => (),
 			RequireCache::Code => {
-				if let Some(ref mut account) = self.cache.borrow_mut().get_mut(a).unwrap().as_mut() {
-					let addr_hash = account.address_hash(a);
-					account.cache_code(&AccountDB::from_hash(self.db.as_hashdb(), addr_hash));
-				}
+				let address_hash = account.address_hash(address);
+				account.cache_code(&AccountDB::from_hash(db, address_hash));
 			}
 			RequireCache::CodeSize => {
-				if let Some(ref mut account) = self.cache.borrow_mut().get_mut(a).unwrap().as_mut() {
-					let addr_hash = account.address_hash(a);
-					account.cache_code_size(&AccountDB::from_hash(self.db.as_hashdb(), addr_hash));
-				}
+				let address_hash = account.address_hash(address);
+				account.cache_code_size(&AccountDB::from_hash(db, address_hash));
 			}
 		}
+	}
 
-		f(self.cache.borrow().get(a).unwrap())
+	/// Ensure account `a` is in our cache of the trie DB and return a handle for getting it.
+	/// `require_code` requires that the code be cached, too.
+	fn ensure_cached<F, U>(&self, a: &Address, require: RequireCache, f: F) -> U
+		where F: Fn(Option<&Account>) -> U {
+		// check local cache first
+		if let Some(ref mut maybe_acc) = self.cache.borrow_mut().get_mut(a) {
+			if let AccountEntry::Cached(ref mut account) = **maybe_acc {
+				Self::update_account_cache(require, account, a, self.db.as_hashdb());
+				return f(Some(account));
+			}
+			return f(None);
+		}
+
+		// check global cache
+		let result = self.db.get_cached(a, |mut acc| {
+			if let Some(ref mut account) = acc {
+				Self::update_account_cache(require, account, a, self.db.as_hashdb());
+			}
+			f(acc.map(|a| &*a))
+		});
+		match result {
+			Some(r) => r,
+			None => {
+				// not found in the global cache, get from DB and insert into local
+				let db = self.trie_factory.readonly(self.db.as_hashdb(), &self.root).expect(SEC_TRIE_DB_UNWRAP_STR);
+				let mut maybe_acc = match db.get(a) {
+					Ok(acc) => acc.map(Account::from_rlp),
+					Err(e) => panic!("Potential DB corruption encountered: {}", e),
+				};
+				if let Some(ref mut account) = maybe_acc.as_mut() {
+					Self::update_account_cache(require, account, a, self.db.as_hashdb());
+				}
+				let r = f(maybe_acc.as_ref());
+				match maybe_acc {
+					Some(account) => self.insert_cache(a, AccountEntry::Cached(account)),
+					None => self.insert_cache(a, AccountEntry::Missing),
+				}
+				r
+			}
+		}
 	}
 
 	/// Pull account `a` in our cache from the trie DB. `require_code` requires that the code be cached, too.
@@ -416,29 +469,39 @@ impl State {
 	{
 		let contains_key = self.cache.borrow().contains_key(a);
 		if !contains_key {
-			let db = self.trie_factory.readonly(self.db.as_hashdb(), &self.root).expect(SEC_TRIE_DB_UNWRAP_STR);
-			let maybe_acc = match db.get(a) {
-				Ok(acc) => acc.map(Account::from_rlp),
-				Err(e) => panic!("Potential DB corruption encountered: {}", e),
-			};
-
-			self.insert_cache(a, maybe_acc);
+			match self.db.get_cached_account(a) {
+				Some(Some(acc)) => self.insert_cache(a, AccountEntry::Cached(acc)),
+				Some(None) => self.insert_cache(a, AccountEntry::Missing),
+				None => {
+					let db = self.trie_factory.readonly(self.db.as_hashdb(), &self.root).expect(SEC_TRIE_DB_UNWRAP_STR);
+					let maybe_acc = match db.get(a) {
+						Ok(Some(acc)) => AccountEntry::Cached(Account::from_rlp(acc)),
+						Ok(None) => AccountEntry::Missing,
+						Err(e) => panic!("Potential DB corruption encountered: {}", e),
+					};
+					self.insert_cache(a, maybe_acc);
+				}
+			}
 		} else {
 			self.note_cache(a);
 		}
 
 		match self.cache.borrow_mut().get_mut(a).unwrap() {
-			&mut Some(ref mut acc) => not_default(acc),
-			slot @ &mut None => *slot = Some(default()),
+			&mut AccountEntry::Cached(ref mut acc) => not_default(acc),
+			slot @ _ => *slot = AccountEntry::Cached(default()),
 		}
 
 		RefMut::map(self.cache.borrow_mut(), |c| {
-			let account = c.get_mut(a).unwrap().as_mut().unwrap();
-			if require_code {
-				let addr_hash = account.address_hash(a);
-				account.cache_code(&AccountDB::from_hash(self.db.as_hashdb(), addr_hash));
+			match c.get_mut(a).unwrap() {
+				&mut AccountEntry::Cached(ref mut account) => {
+					if require_code {
+						let addr_hash = account.address_hash(a);
+						account.cache_code(&AccountDB::from_hash(self.db.as_hashdb(), addr_hash));
+					}
+					account
+				},
+				_ => panic!("Required account must always exist; qed"),
 			}
-			account
 		})
 	}
 }
@@ -456,11 +519,11 @@ impl Clone for State {
 			for (key, val) in self.cache.borrow().iter() {
 				let key = key.clone();
 				match *val {
-					Some(ref acc) if acc.is_dirty() => {
-						cache.insert(key, Some(acc.clone()));
+					AccountEntry::Cached(ref acc) if acc.is_dirty() => {
+						cache.insert(key, AccountEntry::Cached(acc.clone()));
 					},
-					None => {
-						cache.insert(key, None);
+					AccountEntry::Killed => {
+						cache.insert(key, AccountEntry::Killed);
 					},
 					_ => {},
 				}

--- a/ethcore/src/state.rs
+++ b/ethcore/src/state.rs
@@ -38,7 +38,7 @@ pub struct ApplyOutcome {
 /// Result type for the execution ("application") of a transaction.
 pub type ApplyResult = Result<ApplyOutcome, Error>;
 
-#[derive(Clone, Debug)]
+#[derive(Debug)]
 enum AccountEntry {
 	/// Contains account data.
 	Cached(Account),
@@ -56,9 +56,36 @@ impl AccountEntry {
 			AccountEntry::Missing => false,
 		}
 	}
+
+	/// Clone dirty data into new `AccountEntry`.
+	/// Returns None if clean.
+	fn clone_dirty(&self) -> Option<AccountEntry> {
+		match *self {
+			AccountEntry::Cached(ref acc) if acc.is_dirty() => Some(AccountEntry::Cached(acc.clone_dirty())),
+			AccountEntry::Killed => Some(AccountEntry::Killed),
+			_ => None,
+		}
+	}
+
+	/// Clone account entry data that needs to be saved in the snapshot.
+	/// This includes basic account information and dirty storage keys
+	fn clone_for_snapshot(&self) -> AccountEntry {
+		match *self {
+			AccountEntry::Cached(ref acc) => AccountEntry::Cached(acc.clone_all()),
+			AccountEntry::Killed => AccountEntry::Killed,
+			AccountEntry::Missing => AccountEntry::Missing,
+		}
+	}
 }
 
 /// Representation of the entire state of all accounts in the system.
+///
+/// `State` can work together with `StateDB` to share account cache.
+/// All read-only state queries check local cache/modifications first,
+/// then global state cache. If data is not found in any of the caches
+/// it is loaded from the DB to the local cache.
+/// Upon destruction all the local cache data merged into the global cache.
+/// The merge might be rejected if current state is non-canonical.
 pub struct State {
 	db: StateDB,
 	root: H256,
@@ -143,7 +170,6 @@ impl State {
 						self.cache.borrow_mut().insert(k, v);
 					},
 					None => {
-						//self.cache.borrow_mut().remove(&k);
 						match self.cache.borrow_mut().entry(k) {
 							::std::collections::hash_map::Entry::Occupied(e) => {
 								if e.get().is_dirty() {
@@ -171,7 +197,7 @@ impl State {
 	fn note_cache(&self, address: &Address) {
 		if let Some(ref mut snapshot) = self.snapshots.borrow_mut().last_mut() {
 			if !snapshot.contains_key(address) {
-				snapshot.insert(address.clone(), self.cache.borrow().get(address).cloned());
+				snapshot.insert(address.clone(), self.cache.borrow().get(address).map(AccountEntry::clone_for_snapshot));
 			}
 		}
 	}
@@ -217,16 +243,61 @@ impl State {
 
 	/// Mutate storage of account `address` so that it is `value` for `key`.
 	pub fn storage_at(&self, address: &Address, key: &H256) -> H256 {
-		self.ensure_cached(address, RequireCache::None,
-			|a| a.as_ref().map_or(H256::new(), |a| a.storage_at(&AccountDB::from_hash(self.db.as_hashdb(), a.address_hash(address)), key)))
+		// Storage key search and update works like this:
+		// 1. If there's an entry for the account in the local cache check for the key and return it if found.
+		// 2. If there's an entry for the account in the global cache check for the key or load it into that account.
+		// 3. If account is missing in the global cache load it into the local cache and cache the key there.
+
+		// check local cache first without updating
+		{
+			let local_cache = self.cache.borrow_mut();
+			let mut local_account = None;
+			if let Some(maybe_acc) = local_cache.get(address) {
+				match *maybe_acc {
+					AccountEntry::Cached(ref account) => {
+						if let Some(value) = account.cached_storage_at(key) {
+							return value;
+						} else {
+							local_account = Some(maybe_acc);
+						}
+					},
+					_ => return H256::new(),
+				}
+			}
+			// check the global cache and and cache storage key there if found,
+			// otherwise cache the account localy and cache storage key there.
+			if let Some(result) = self.db.get_cached(address, |acc| acc.map_or(H256::new(), |a| a.storage_at(&AccountDB::from_hash(self.db.as_hashdb(), a.address_hash(address)), key))) {
+				return result;
+			}
+			if let Some(ref mut acc) = local_account {
+				if let AccountEntry::Cached(ref account) = **acc {
+					return account.storage_at(&AccountDB::from_hash(self.db.as_hashdb(), account.address_hash(address)), key)
+				} else {
+					return H256::new()
+				}
+			}
+		}
+		// account is not found in the global cache, get from the DB and insert into local
+		let db = self.trie_factory.readonly(self.db.as_hashdb(), &self.root).expect(SEC_TRIE_DB_UNWRAP_STR);
+		let maybe_acc = match db.get(address) {
+			Ok(acc) => acc.map(Account::from_rlp),
+			Err(e) => panic!("Potential DB corruption encountered: {}", e),
+		};
+		let r = maybe_acc.as_ref().map_or(H256::new(), |a| a.storage_at(&AccountDB::from_hash(self.db.as_hashdb(), a.address_hash(address)), key));
+		match maybe_acc {
+			Some(account) => self.insert_cache(address, AccountEntry::Cached(account)),
+			None => self.insert_cache(address, AccountEntry::Missing),
+		}
+		r
 	}
 
-	/// Mutate storage of account `a` so that it is `value` for `key`.
+	/// Get accounts' code.
 	pub fn code(&self, a: &Address) -> Option<Bytes> {
 		self.ensure_cached(a, RequireCache::Code,
 			|a| a.as_ref().map_or(None, |a| a.code().map(|x|x.to_vec())))
 	}
 
+	/// Get accounts' code size.
 	pub fn code_size(&self, a: &Address) -> Option<u64> {
 		self.ensure_cached(a, RequireCache::CodeSize,
 			|a| a.as_ref().and_then(|a| a.code_size()))
@@ -363,7 +434,7 @@ impl State {
 	pub fn populate_from(&mut self, accounts: PodState) {
 		assert!(self.snapshots.borrow().is_empty());
 		for (add, acc) in accounts.drain().into_iter() {
-			self.cache.borrow_mut().insert(add, Some(Account::from_pod(acc)));
+			self.cache.borrow_mut().insert(add, AccountEntry::Cached(Account::from_pod(acc)));
 		}
 	}
 
@@ -415,8 +486,9 @@ impl State {
 		}
 	}
 
-	/// Ensure account `a` is in our cache of the trie DB and return a handle for getting it.
-	/// `require_code` requires that the code be cached, too.
+	/// Check caches for required data
+	/// First searches for account in the local, then the shared cache.
+	/// Populates local cache if nothing found.
 	fn ensure_cached<F, U>(&self, a: &Address, require: RequireCache, f: F) -> U
 		where F: Fn(Option<&Account>) -> U {
 		// check local cache first
@@ -427,7 +499,6 @@ impl State {
 			}
 			return f(None);
 		}
-
 		// check global cache
 		let result = self.db.get_cached(a, |mut acc| {
 			if let Some(ref mut account) = acc {
@@ -438,7 +509,7 @@ impl State {
 		match result {
 			Some(r) => r,
 			None => {
-				// not found in the global cache, get from DB and insert into local
+				// not found in the global cache, get from the DB and insert into local
 				let db = self.trie_factory.readonly(self.db.as_hashdb(), &self.root).expect(SEC_TRIE_DB_UNWRAP_STR);
 				let mut maybe_acc = match db.get(a) {
 					Ok(acc) => acc.map(Account::from_rlp),
@@ -488,7 +559,7 @@ impl State {
 
 		match self.cache.borrow_mut().get_mut(a).unwrap() {
 			&mut AccountEntry::Cached(ref mut acc) => not_default(acc),
-			slot @ _ => *slot = AccountEntry::Cached(default()),
+			slot => *slot = AccountEntry::Cached(default()),
 		}
 
 		RefMut::map(self.cache.borrow_mut(), |c| {
@@ -515,17 +586,10 @@ impl fmt::Debug for State {
 impl Clone for State {
 	fn clone(&self) -> State {
 		let cache = {
-			let mut cache = HashMap::new();
+			let mut cache: HashMap<Address, AccountEntry> = HashMap::new();
 			for (key, val) in self.cache.borrow().iter() {
-				let key = key.clone();
-				match *val {
-					AccountEntry::Cached(ref acc) if acc.is_dirty() => {
-						cache.insert(key, AccountEntry::Cached(acc.clone()));
-					},
-					AccountEntry::Killed => {
-						cache.insert(key, AccountEntry::Killed);
-					},
-					_ => {},
+				if let Some(entry) = val.clone_dirty() {
+					cache.insert(key.clone(), entry);
 				}
 			}
 			cache
@@ -535,7 +599,7 @@ impl Clone for State {
 			db: self.db.boxed_clone(),
 			root: self.root.clone(),
 			cache: RefCell::new(cache),
-			snapshots: RefCell::new(self.snapshots.borrow().clone()),
+			snapshots: RefCell::new(Vec::new()),
 			account_start_nonce: self.account_start_nonce.clone(),
 			trie_factory: self.trie_factory.clone(),
 		}

--- a/ethcore/src/state_db.rs
+++ b/ethcore/src/state_db.rs
@@ -1,0 +1,128 @@
+// Copyright 2015, 2016 Ethcore (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+use lru_cache::LruCache;
+use util::journaldb::JournalDB;
+use util::hash::{H256};
+use util::hashdb::HashDB;
+use util::{Arc, Address, DBTransaction, UtilError, Mutex};
+use account::Account;
+
+struct AccountCache {
+	accounts: LruCache<Address, Option<Account>>,
+}
+
+/// State database abstraction.
+pub struct StateDB {
+	db: Box<JournalDB>,
+	account_cache: Arc<Mutex<AccountCache>>,
+	cache_overlay: Vec<(Address, Option<Account>)>,
+	is_canon: bool,
+}
+
+impl StateDB {
+	/// Create a new instance wrapping `JournalDB`
+	pub fn new(db: Box<JournalDB>) -> StateDB {
+		StateDB {
+			db: db,
+			account_cache: Arc::new(Mutex::new(AccountCache { accounts: LruCache::new(65536) })),
+			cache_overlay: Vec::new(),
+			is_canon: false,
+		}
+	}
+
+	/// Commit all recent insert operations and canonical historical commits' removals from the
+	/// old era to the backing database, reverting any non-canonical historical commit's inserts.
+	pub fn commit(&mut self, batch: &DBTransaction, now: u64, id: &H256, end: Option<(u64, H256)>) -> Result<u32, UtilError> {
+		self.db.commit(batch, now, id, end)
+	}
+
+	/// Returns an interface to HashDB.
+	pub fn as_hashdb(&self) -> &HashDB {
+		self.db.as_hashdb()
+	}
+
+	/// Returns an interface to mutable HashDB.
+	pub fn as_hashdb_mut(&mut self) -> &mut HashDB {
+		self.db.as_hashdb_mut()
+	}
+
+	/// Clone the database.
+	pub fn boxed_clone(&self) -> StateDB {
+		StateDB {
+			db: self.db.boxed_clone(),
+			account_cache: self.account_cache.clone(),
+			cache_overlay: Vec::new(),
+			is_canon: false,
+		}
+	}
+
+	/// Clone the database for a canonical state.
+	pub fn canon_clone(&self) -> StateDB {
+		StateDB {
+			db: self.db.boxed_clone(),
+			account_cache: self.account_cache.clone(),
+			cache_overlay: Vec::new(),
+			is_canon: true,
+		}
+	}
+
+	/// Check if pruning is enabled on the database.
+	pub fn is_pruned(&self) -> bool {
+		self.db.is_pruned()
+	}
+
+	/// Heap size used.
+	pub fn mem_used(&self) -> usize {
+		self.db.mem_used()
+	}
+
+	/// Returns underlying `JournalDB`.
+	pub fn journal_db(&self) -> &JournalDB {
+		&*self.db
+	}
+
+	pub fn cache_account(&mut self, addr: Address, data: Option<Account>) {
+		trace!("CACHING {}", addr.hex());
+		self.cache_overlay.push((addr, data));
+	}
+
+	pub fn commit_cache(&mut self) {
+		trace!("COMMIT_CACHE {} items", self.cache_overlay.len());
+		let mut cache = self.account_cache.lock();
+		cache.accounts.extend(self.cache_overlay.drain(..));
+	}
+
+	pub fn clear_cache(&self) {
+		trace!("CLEAR CACHE");
+		let mut cache = self.account_cache.lock();
+		cache.accounts.clear();
+	}
+
+	pub fn get_cached_account(&self, addr: &Address) -> Option<Option<Account>> {
+		if !self.is_canon {
+			return None;
+		}
+		let mut cache = self.account_cache.lock();
+		let r = cache.accounts.get_mut(&addr).map(|a| a.clone());
+		match r {
+			Some(_) => { trace!("CACHE HIT {}", addr.hex()); },
+			None => { trace!("CACHE MISS {}", addr.hex()); },
+		}
+		r
+	}
+}
+

--- a/ethcore/src/state_db.rs
+++ b/ethcore/src/state_db.rs
@@ -24,6 +24,7 @@ use account::Account;
 const STATE_CACHE_ITEMS: usize = 65536;
 
 struct AccountCache {
+	/// DB Account cache. `None` indicates that account is known to be missing.
 	accounts: LruCache<Address, Option<Account>>,
 }
 

--- a/ethcore/src/state_db.rs
+++ b/ethcore/src/state_db.rs
@@ -21,11 +21,18 @@ use util::hashdb::HashDB;
 use util::{Arc, Address, DBTransaction, UtilError, Mutex};
 use account::Account;
 
+const STATE_CACHE_ITEMS: usize = 65536;
+
 struct AccountCache {
 	accounts: LruCache<Address, Option<Account>>,
 }
 
 /// State database abstraction.
+/// Manages shared global state cache.
+/// A clone of `StateDB` may be created as canonical or not.
+/// For canonical clones cache changes are accumulated and applied
+/// on commit.
+/// For non-canonical clones cache is cleared on commit.
 pub struct StateDB {
 	db: Box<JournalDB>,
 	account_cache: Arc<Mutex<AccountCache>>,
@@ -38,7 +45,7 @@ impl StateDB {
 	pub fn new(db: Box<JournalDB>) -> StateDB {
 		StateDB {
 			db: db,
-			account_cache: Arc::new(Mutex::new(AccountCache { accounts: LruCache::new(65536) })),
+			account_cache: Arc::new(Mutex::new(AccountCache { accounts: LruCache::new(STATE_CACHE_ITEMS) })),
 			cache_overlay: Vec::new(),
 			is_canon: false,
 		}
@@ -47,7 +54,13 @@ impl StateDB {
 	/// Commit all recent insert operations and canonical historical commits' removals from the
 	/// old era to the backing database, reverting any non-canonical historical commit's inserts.
 	pub fn commit(&mut self, batch: &DBTransaction, now: u64, id: &H256, end: Option<(u64, H256)>) -> Result<u32, UtilError> {
-		self.db.commit(batch, now, id, end)
+		let records = try!(self.db.commit(batch, now, id, end));
+		if self.is_canon {
+			self.commit_cache();
+		} else {
+			self.clear_cache();
+		}
+		Ok(records)
 	}
 
 	/// Returns an interface to HashDB.
@@ -71,7 +84,7 @@ impl StateDB {
 	}
 
 	/// Clone the database for a canonical state.
-	pub fn canon_clone(&self) -> StateDB {
+	pub fn boxed_clone_canon(&self) -> StateDB {
 		StateDB {
 			db: self.db.boxed_clone(),
 			account_cache: self.account_cache.clone(),
@@ -87,7 +100,7 @@ impl StateDB {
 
 	/// Heap size used.
 	pub fn mem_used(&self) -> usize {
-		self.db.mem_used()
+		self.db.mem_used() //TODO: + self.account_cache.lock().heap_size_of_children()
 	}
 
 	/// Returns underlying `JournalDB`.
@@ -95,28 +108,46 @@ impl StateDB {
 		&*self.db
 	}
 
+	/// Enqueue cache change.
 	pub fn cache_account(&mut self, addr: Address, data: Option<Account>) {
 		self.cache_overlay.push((addr, data));
 	}
 
-	pub fn commit_cache(&mut self) {
+	/// Apply pending cache changes.
+	fn commit_cache(&mut self) {
 		let mut cache = self.account_cache.lock();
-		cache.accounts.extend(self.cache_overlay.drain(..));
+		for (address, account) in self.cache_overlay.drain(..) {
+			if let Some(&mut Some(ref mut existing)) = cache.accounts.get_mut(&address) {
+				if let Some(new) = account {
+					existing.merge_with(new);
+					continue;
+				}
+			}
+			cache.accounts.insert(address, account);
+		}
 	}
 
-	pub fn clear_cache(&self) {
+	/// Clear the cache.
+	pub fn clear_cache(&mut self) {
+		self.cache_overlay.clear();
 		let mut cache = self.account_cache.lock();
 		cache.accounts.clear();
 	}
 
+	/// Get basic copy of the cached account. Does not include storage.
+	/// Returns 'None' if the state is non-canonical and cache is disabled
+	/// or if the account is not cached.
 	pub fn get_cached_account(&self, addr: &Address) -> Option<Option<Account>> {
 		if !self.is_canon {
 			return None;
 		}
 		let mut cache = self.account_cache.lock();
-		cache.accounts.get_mut(&addr).map(|a| a.clone())
+		cache.accounts.get_mut(&addr).map(|a| a.as_ref().map(|a| a.clone_basic()))
 	}
 
+	/// Get value from a cached account.
+	/// Returns 'None' if the state is non-canonical and cache is disabled
+	/// or if the account is not cached.
 	pub fn get_cached<F, U>(&self, a: &Address, f: F) -> Option<U>
 		where F: FnOnce(Option<&mut Account>) -> U {
 		if !self.is_canon {

--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -89,10 +89,10 @@ pub fn setup_log(config: &Config) -> Result<Arc<RotatingLogger>, String> {
 		let timestamp = time::strftime("%Y-%m-%d %H:%M:%S %Z", &time::now()).unwrap();
 
 		let with_color = if max_log_level() <= LogLevelFilter::Info {
-			format!("{}{}", Colour::Black.bold().paint(timestamp), record.args())
+			format!("{} {}", Colour::Black.bold().paint(timestamp), record.args())
 		} else {
 			let name = thread::current().name().map_or_else(Default::default, |x| format!("{}", Colour::Blue.bold().paint(x)));
-			format!("{}{} {} {}  {}", Colour::Black.bold().paint(timestamp), name, record.level(), record.target(), record.args())
+			format!("{} {} {} {}  {}", Colour::Black.bold().paint(timestamp), name, record.level(), record.target(), record.args())
 		};
 
 		let removed_color = kill_color(with_color.as_ref());

--- a/util/network/src/connection.rs
+++ b/util/network/src/connection.rs
@@ -110,8 +110,8 @@ impl<Socket: GenericSocket> GenericConnection<Socket> {
 		}
 		if !self.interest.is_writable() {
 			self.interest.insert(EventSet::writable());
-			io.update_registration(self.token).ok();
 		}
+		io.update_registration(self.token).ok();
 	}
 
 	/// Check if this connection has data to be sent.


### PR DESCRIPTION
Still left to do: 
* Handle reorgs more efficiently. Right now the whole cache is cleared on reorg
* Don't copy data from global cache to state and back (a major slowdown)
* Bind cache size to memory used, not to the number of accounts