### PR TITLE
reverse call data decoding given transaction data & method

### DIFF
--- a/js/src/abi/decoder/decoder.js
+++ b/js/src/abi/decoder/decoder.js
@@ -24,6 +24,8 @@ import { sliceData } from '../util/slice';
 import { asAddress, asBool, asI32, asU32 } from '../util/sliceAs';
 import { isArray, isInstanceOf } from '../util/types';
 
+const NULL = '0000000000000000000000000000000000000000000000000000000000000000';
+
 export default class Decoder {
   static decode (params, data) {
     if (!isArray(params)) {
@@ -42,7 +44,7 @@ export default class Decoder {
 
   static peek (slices, position) {
     if (!slices || !slices[position]) {
-      throw new Error(`Invalid position ${position} in slices peek`);
+      return NULL;
     }
 
     return slices[position];
@@ -56,7 +58,7 @@ export default class Decoder {
       bytesStr = `${bytesStr}${Decoder.peek(slices, position + idx)}`;
     }
 
-    const bytes = bytesStr.substr(0, length * 2).match(/.{1,2}/g).map((code) => parseInt(code, 16));
+    const bytes = (bytesStr.substr(0, length * 2).match(/.{1,2}/g) || []).map((code) => parseInt(code, 16));
 
     return new BytesTaken(bytes, position + slicesLength);
   }

--- a/js/src/abi/decoder/decoder.spec.js
+++ b/js/src/abi/decoder/decoder.spec.js
@@ -68,8 +68,8 @@ describe('abi/decoder/Decoder', () => {
       expect(() => Decoder.peek(slices, 4)).to.throw(/Invalid/);
     });
 
-    it('throws an error on invalid slices', () => {
-      expect(() => Decoder.peek(null, 4)).to.throw(/Invalid/);
+    it('returns empty on invalid slices', () => {
+      expect(Decoder.peek(null, 4)).to.equal('0000000000000000000000000000000000000000000000000000000000000000');
     });
   });
 

--- a/js/src/abi/decoder/decoder.spec.js
+++ b/js/src/abi/decoder/decoder.spec.js
@@ -60,14 +60,6 @@ describe('abi/decoder/Decoder', () => {
       expect(Decoder.peek(slices, 1)).to.equal(slices[1]);
     });
 
-    it('throws an error if the position is < 0', () => {
-      expect(() => Decoder.peek(slices, -1)).to.throw(/Invalid/);
-    });
-
-    it('throws an error if the position is >= length', () => {
-      expect(() => Decoder.peek(slices, 4)).to.throw(/Invalid/);
-    });
-
     it('returns empty on invalid slices', () => {
       expect(Decoder.peek(null, 4)).to.equal('0000000000000000000000000000000000000000000000000000000000000000');
     });

--- a/js/src/abi/spec/function.js
+++ b/js/src/abi/spec/function.js
@@ -65,6 +65,10 @@ export default class Func {
     return `${this._signature}${Encoder.encode(tokens)}`;
   }
 
+  decodeInput (data) {
+    return Decoder.decode(this.inputParamTypes(), data);
+  }
+
   decodeOutput (data) {
     return Decoder.decode(this.outputParamTypes(), data);
   }

--- a/js/src/api/util/decode.js
+++ b/js/src/api/util/decode.js
@@ -18,22 +18,22 @@ import { isHex } from './types';
 
 import Func from '../../abi/spec/function';
 
-export function decodeInputData (data) {
+export function decodeCallData (data) {
   if (!isHex(data)) {
-    throw new Error('Input to decodeInputData should be a hex value');
+    throw new Error('Input to decodeCallData should be a hex value');
   }
 
   if (data.substr(0, 2) === '0x') {
-    return decodeInputData(data.slice(2));
+    return decodeCallData(data.slice(2));
   } else if (data.length < 8) {
-    throw new Error('Input to decodeInputData should be method signature + data');
+    throw new Error('Input to decodeCallData should be method signature + data');
   }
 
   const signature = data.substr(0, 8);
   const paramdata = data.substr(8);
 
   if (paramdata.length % 64 !== 0) {
-    throw new Error('Parameter length in decodeInputData not a multiple of 64 characters');
+    throw new Error('Parameter length in decodeCallData not a multiple of 64 characters');
   }
 
   return {

--- a/js/src/api/util/decode.js
+++ b/js/src/api/util/decode.js
@@ -17,6 +17,7 @@
 import { isHex } from './types';
 
 import Func from '../../abi/spec/function';
+import { fromParamType, toParamType } from '../../abi/spec/paramType/format';
 
 const CREATE_METHOD = '60606040';
 
@@ -60,7 +61,7 @@ export function decodeMethodInput (methodAbi, paramdata) {
   return new Func(methodAbi).decodeInput(paramdata).map((decoded) => decoded.value);
 }
 
-// takes a method in form name(..., types) and returns the interred abi definition
+// takes a method in form name(...,types) and returns the inferred abi definition
 export function methodToAbi (method) {
   const length = method.length;
   const typesStart = method.indexOf('(');
@@ -78,7 +79,9 @@ export function methodToAbi (method) {
 
   const name = method.substr(0, typesStart);
   const types = method.substr(typesStart + 1, length - (typesStart + 1) - 1).split(',');
-  const inputs = types.map((type) => {
+  const inputs = types.map((_type) => {
+    const type = fromParamType(toParamType(_type));
+
     return { type };
   });
 

--- a/js/src/api/util/decode.js
+++ b/js/src/api/util/decode.js
@@ -38,7 +38,7 @@ export function decodeCallData (data) {
   const signature = data.substr(0, 8);
   const paramdata = data.substr(8);
 
-  if ((signature !== CREATE_METHOD) && length % 64 !== 0) {
+  if ((signature !== CREATE_METHOD) && paramdata.length % 64 !== 0) {
     throw new Error(`Parameter length in decodeCallData not a multiple of 64 characters, ${paramdata.length}`);
   }
 

--- a/js/src/api/util/decode.js
+++ b/js/src/api/util/decode.js
@@ -1,0 +1,84 @@
+// Copyright 2015, 2016 Ethcore (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+import { isHex } from './types';
+
+import Func from '../../abi/spec/function';
+
+export function decodeInputData (data) {
+  if (!isHex(data)) {
+    throw new Error('Input to decodeInputData should be a hex value');
+  }
+
+  if (data.substr(0, 2) === '0x') {
+    return decodeInputData(data.slice(2));
+  } else if (data.length < 8) {
+    throw new Error('Input to decodeInputData should be method signature + data');
+  }
+
+  const signature = data.substr(0, 8);
+  const paramdata = data.substr(8);
+
+  if (paramdata.length % 64 !== 0) {
+    throw new Error('Parameter length in decodeInputData not a multiple of 64 characters');
+  }
+
+  return {
+    signature: `0x${signature}`,
+    paramdata: `0x${paramdata}`
+  };
+}
+
+export function decodeMethodInput (methodAbi, paramdata) {
+  if (!methodAbi) {
+    throw new Error('decodeMethodInput should receive valid method-specific ABI');
+  } else if (!paramdata) {
+    throw new Error('decodeMethodInput should receive valid parameter input data');
+  } else if (!isHex(paramdata)) {
+    throw new Error('Input to decodeMethodInput should be a hex value');
+  } else if (paramdata.substr(0, 2) === '0x') {
+    return decodeMethodInput(methodAbi, paramdata.slice(2));
+  } else if (paramdata.length % 64 !== 0) {
+    throw new Error('Parameter length in decodeMethodInput not a multiple of 64 characters');
+  }
+
+  return new Func(methodAbi).decodeInput(paramdata).map((decoded) => decoded.value);
+}
+
+// takes a method in form name(..., types) and returns the interred abi definition
+export function methodToAbi (method) {
+  const length = method.length;
+  const typesStart = method.indexOf('(');
+  const typesEnd = method.indexOf(')');
+
+  if (typesStart === -1) {
+    throw new Error(`Missing start ( in call to decodeMethod with ${method}`);
+  } else if (typesEnd === -1) {
+    throw new Error(`Missing end ) in call to decodeMethod with ${method}`);
+  } else if (typesEnd < typesStart) {
+    throw new Error(`End ) is before start ( in call to decodeMethod with ${method}`);
+  } else if (typesEnd !== length - 1) {
+    throw new Error(`Extra characters after end ) in call to decodeMethod with ${method}`);
+  }
+
+  const name = method.substr(0, typesStart);
+  const types = method.substr(typesStart + 1, length - (typesStart + 1) - 1).split(',');
+  const inputs = types.map((type) => {
+    return { type };
+  });
+
+  return { type: 'function', name, inputs };
+}

--- a/js/src/api/util/decode.js
+++ b/js/src/api/util/decode.js
@@ -21,10 +21,6 @@ import Func from '../../abi/spec/function';
 const CREATE_METHOD = '60606040';
 
 export function decodeCallData (data) {
-  if (!data || !data.length) {
-    return {};
-  }
-
   if (!isHex(data)) {
     throw new Error('Input to decodeCallData should be a hex value');
   }

--- a/js/src/api/util/decode.js
+++ b/js/src/api/util/decode.js
@@ -18,7 +18,13 @@ import { isHex } from './types';
 
 import Func from '../../abi/spec/function';
 
+const CREATE_METHOD = '60606040';
+
 export function decodeCallData (data) {
+  if (!data || !data.length) {
+    return {};
+  }
+
   if (!isHex(data)) {
     throw new Error('Input to decodeCallData should be a hex value');
   }
@@ -32,8 +38,8 @@ export function decodeCallData (data) {
   const signature = data.substr(0, 8);
   const paramdata = data.substr(8);
 
-  if (paramdata.length % 64 !== 0) {
-    throw new Error('Parameter length in decodeCallData not a multiple of 64 characters');
+  if ((signature !== CREATE_METHOD) && length % 64 !== 0) {
+    throw new Error(`Parameter length in decodeCallData not a multiple of 64 characters, ${paramdata.length}`);
   }
 
   return {

--- a/js/src/api/util/decode.spec.js
+++ b/js/src/api/util/decode.spec.js
@@ -35,14 +35,6 @@ describe('api/util/decode', () => {
       expect(() => decodeCallData(`${ENCO.slice(-32)}`)).to.throw(/not a multiple of/);
     });
 
-    it('returns an empty object for ""', () => {
-      expect(decodeCallData('')).to.deep.equal({});
-    });
-
-    it('returns an empty object for "0x"', () => {
-      expect(decodeCallData('0x')).to.deep.equal({});
-    });
-
     it('splits valid inputs properly', () => {
       expect(decodeCallData(ENCO)).to.deep.equal({
         signature: METH,
@@ -95,12 +87,16 @@ describe('api/util/decode', () => {
       expect(() => methodToAbi('invalid)uint,bool(')).to.throw(/End \) is before start \(/);
     });
 
+    it('throws when invalid types are present', () => {
+      expect(() => methodToAbi('method(invalidType,bool,uint)')).to.throw(/Cannot convert invalidType/);
+    });
+
     it('returns a valid methodabi for a valid method', () => {
       expect(methodToAbi('valid(uint,bool)')).to.deep.equals({
         type: 'function',
         name: 'valid',
         inputs: [
-          { type: 'uint' },
+          { type: 'uint256' },
           { type: 'bool' }
         ]
       });

--- a/js/src/api/util/decode.spec.js
+++ b/js/src/api/util/decode.spec.js
@@ -15,28 +15,28 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 import BigNumber from 'bignumber.js';
-import { decodeInputData, decodeMethodInput, methodToAbi } from './decode';
+import { decodeCallData, decodeMethodInput, methodToAbi } from './decode';
 
 describe('api/util/decode', () => {
   const METH = '0x70a08231';
   const ENCO = '0x70a082310000000000000000000000005A5eFF38DA95b0D58b6C616f2699168B480953C9';
   const DATA = '0x0000000000000000000000005A5eFF38DA95b0D58b6C616f2699168B480953C9';
 
-  describe('decodeInputData', () => {
+  describe('decodeCallData', () => {
     it('throws on non-hex inputs', () => {
-      expect(() => decodeInputData('invalid')).to.throw(/should be a hex value/);
+      expect(() => decodeCallData('invalid')).to.throw(/should be a hex value/);
     });
 
     it('throws when invalid signature length', () => {
-      expect(() => decodeInputData(METH.slice(-6))).to.throw(/should be method signature/);
+      expect(() => decodeCallData(METH.slice(-6))).to.throw(/should be method signature/);
     });
 
     it('throws when invalid data length', () => {
-      expect(() => decodeInputData(`${ENCO.slice(-32)}`)).to.throw(/not a multiple of/);
+      expect(() => decodeCallData(`${ENCO.slice(-32)}`)).to.throw(/not a multiple of/);
     });
 
     it('splits valid inputs properly', () => {
-      expect(decodeInputData(ENCO)).to.deep.equal({
+      expect(decodeCallData(ENCO)).to.deep.equal({
         signature: METH,
         paramdata: DATA
       });

--- a/js/src/api/util/decode.spec.js
+++ b/js/src/api/util/decode.spec.js
@@ -1,0 +1,101 @@
+// Copyright 2015, 2016 Ethcore (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+import BigNumber from 'bignumber.js';
+import { decodeInputData, decodeMethodInput, methodToAbi } from './decode';
+
+describe('api/util/decode', () => {
+  const METH = '0x70a08231';
+  const ENCO = '0x70a082310000000000000000000000005A5eFF38DA95b0D58b6C616f2699168B480953C9';
+  const DATA = '0x0000000000000000000000005A5eFF38DA95b0D58b6C616f2699168B480953C9';
+
+  describe('decodeInputData', () => {
+    it('throws on non-hex inputs', () => {
+      expect(() => decodeInputData('invalid')).to.throw(/should be a hex value/);
+    });
+
+    it('throws when invalid signature length', () => {
+      expect(() => decodeInputData(METH.slice(-6))).to.throw(/should be method signature/);
+    });
+
+    it('throws when invalid data length', () => {
+      expect(() => decodeInputData(`${ENCO.slice(-32)}`)).to.throw(/not a multiple of/);
+    });
+
+    it('splits valid inputs properly', () => {
+      expect(decodeInputData(ENCO)).to.deep.equal({
+        signature: METH,
+        paramdata: DATA
+      });
+    });
+  });
+
+  describe('decodeMethodInput', () => {
+    it('expects a valid ABI', () => {
+      expect(() => decodeMethodInput(null, null)).to.throw(/should receive valid method/);
+    });
+
+    it('expects valid parameter data', () => {
+      expect(() => decodeMethodInput({}, null)).to.throw(/should receive valid parameter/);
+    });
+
+    it('expect valid hex parameter data', () => {
+      expect(() => decodeMethodInput({}, 'invalid')).to.throw(/should be a hex value/);
+    });
+
+    it('throws on invalid lengths', () => {
+      expect(() => decodeMethodInput({}, DATA.slice(-32))).to.throw(/not a multiple of/);
+    });
+
+    it('correctly decodes valid inputs', () => {
+      expect(decodeMethodInput({
+        type: 'function',
+        inputs: [
+          { type: 'uint' }
+        ]
+      }, DATA)).to.deep.equal([ new BigNumber('0x5a5eff38da95b0d58b6c616f2699168b480953c9') ]);
+    });
+  });
+
+  describe('methodToAbi', () => {
+    it('throws when no start ( specified', () => {
+      expect(() => methodToAbi('invalid,uint,bool)')).to.throw(/Missing start \(/);
+    });
+
+    it('throws when no end ) specified', () => {
+      expect(() => methodToAbi('invalid(uint,bool')).to.throw(/Missing end \)/);
+    });
+
+    it('throws when end ) is not in the last position', () => {
+      expect(() => methodToAbi('invalid(uint,bool)2')).to.throw(/Extra characters after end \)/);
+    });
+
+    it('throws when start ( is after end )', () => {
+      expect(() => methodToAbi('invalid)uint,bool(')).to.throw(/End \) is before start \(/);
+    });
+
+    it('returns a valid methodabi for a valid method', () => {
+      expect(methodToAbi('valid(uint,bool)')).to.deep.equals({
+        type: 'function',
+        name: 'valid',
+        inputs: [
+          { type: 'uint' },
+          { type: 'bool' }
+        ]
+      });
+    });
+  });
+});

--- a/js/src/api/util/decode.spec.js
+++ b/js/src/api/util/decode.spec.js
@@ -35,6 +35,14 @@ describe('api/util/decode', () => {
       expect(() => decodeCallData(`${ENCO.slice(-32)}`)).to.throw(/not a multiple of/);
     });
 
+    it('returns an empty object for ""', () => {
+      expect(decodeCallData('')).to.deep.equal({});
+    });
+
+    it('returns an empty object for "0x"', () => {
+      expect(decodeCallData('0x')).to.deep.equal({});
+    });
+
     it('splits valid inputs properly', () => {
       expect(decodeCallData(ENCO)).to.deep.equal({
         signature: METH,

--- a/js/src/api/util/index.js
+++ b/js/src/api/util/index.js
@@ -15,6 +15,7 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 import { isAddress as isAddressValid, toChecksumAddress } from '../../abi/util/address';
+import { decodeInputData, decodeMethodInput, methodToAbi } from './decode';
 import { bytesToHex } from './format';
 import { fromWei, toWei } from './wei';
 import { sha3 } from './sha3';
@@ -30,6 +31,9 @@ export default {
   isString,
   bytesToHex,
   createIdentityImg,
+  decodeInputData,
+  decodeMethodInput,
+  methodToAbi,
   fromWei,
   toChecksumAddress,
   toWei,

--- a/js/src/api/util/index.js
+++ b/js/src/api/util/index.js
@@ -15,7 +15,7 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 import { isAddress as isAddressValid, toChecksumAddress } from '../../abi/util/address';
-import { decodeInputData, decodeMethodInput, methodToAbi } from './decode';
+import { decodeCallData, decodeMethodInput, methodToAbi } from './decode';
 import { bytesToHex } from './format';
 import { fromWei, toWei } from './wei';
 import { sha3 } from './sha3';
@@ -31,7 +31,7 @@ export default {
   isString,
   bytesToHex,
   createIdentityImg,
-  decodeInputData,
+  decodeCallData,
   decodeMethodInput,
   methodToAbi,
   fromWei,


### PR DESCRIPTION
api.util.* -

- decodeCallData - converts transaction data into the signature and data parts

- methodToAbi  - converts string in the format of transfer(address,uint) to a method abi

- decodeMethodInput - with an ABI & data from the first call, decode the data (string, uint, etc.)

Allows decoding of values for https://github.com/ethcore/parity/issues/2208 & https://github.com/ethcore/parity/issues/2280