### PR TITLE
Removing PropTypes on build

### DIFF
--- a/js/.babelrc
+++ b/js/.babelrc
@@ -1,5 +1,15 @@
 {
   "presets": ["es2017", "es2016", "es2015", "stage-0", "react"],
-  "plugins": ["transform-runtime", "transform-decorators-legacy", "transform-class-properties", "lodash"],
-  "retainLines": true
+  "plugins": [
+    "transform-runtime",
+    "transform-decorators-legacy",
+    "transform-class-properties",
+    "lodash"
+  ],
+  "retainLines": true,
+  "env": {
+    "production": {
+      "plugins": ["transform-react-remove-prop-types"]
+    }
+  }
 }

--- a/js/build-server.js
+++ b/js/build-server.js
@@ -1,3 +1,9 @@
+/**
+ * Run `PARITY_URL="127.0.0.1:8180" NODE_ENV="production" npm run build`
+ * to build the project ; use this server to test that the minifed
+ * version is working (this is a simple proxy server)
+ */
+
 var express = require('express');
 var proxy = require('http-proxy-middleware');
 
@@ -11,7 +17,7 @@ app.use('/api/*', proxy({
 }));
 
 app.use('/rpc/*', proxy({
-  target: 'http://localhost:8080',
+  target: 'http://127.0.0.1:8080',
   changeOrigin: true
 }));
 

--- a/js/build-server.js
+++ b/js/build-server.js
@@ -1,0 +1,18 @@
+var express = require('express');
+var proxy = require('http-proxy-middleware');
+
+var app = express();
+
+app.use(express.static('build'));
+
+app.use('/api/*', proxy({
+  target: 'http://127.0.0.1:8080',
+  changeOrigin: true
+}));
+
+app.use('/rpc/*', proxy({
+  target: 'http://localhost:8080',
+  changeOrigin: true
+}));
+
+app.listen(3000);

--- a/js/build-server.js
+++ b/js/build-server.js
@@ -1,3 +1,19 @@
+// Copyright 2015, 2016 Ethcore (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
 /**
  * Run `PARITY_URL="127.0.0.1:8180" NODE_ENV="production" npm run build`
  * to build the project ; use this server to test that the minifed

--- a/js/package.json
+++ b/js/package.json
@@ -44,6 +44,7 @@
     "babel-plugin-lodash": "^3.2.2",
     "babel-plugin-transform-class-properties": "^6.11.5",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",
+    "babel-plugin-transform-react-remove-prop-types": "^0.2.9",
     "babel-plugin-transform-runtime": "^6.9.0",
     "babel-polyfill": "^6.13.0",
     "babel-preset-es2015": "^6.9.0",

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -46,7 +46,12 @@ import './index.html';
 injectTapEventPlugin();
 
 const initToken = window.localStorage.getItem('sysuiToken');
-const parityUrl = process.env.NODE_ENV === 'production' ? window.location.host : '127.0.0.1:8180';
+const parityUrl = process.env.PARITY_URL ||
+  (
+    process.env.NODE_ENV === 'production'
+    ? window.location.host
+    : '127.0.0.1:8180'
+  );
 
 const api = new Api(new Api.Transport.Ws(`ws://${parityUrl}`, initToken)); // new Api.Transport.Http('/rpc/'));
 

--- a/js/webpack.config.js
+++ b/js/webpack.config.js
@@ -139,6 +139,7 @@ module.exports = {
         'process.env': {
           NODE_ENV: JSON.stringify(ENV),
           RPC_ADDRESS: JSON.stringify(process.env.RPC_ADDRESS),
+          PARITY_URL: JSON.stringify(process.env.PARITY_URL),
           LOGGING: JSON.stringify(!isProd)
         }
       })

--- a/js/webpack.vendor.js
+++ b/js/webpack.vendor.js
@@ -56,6 +56,12 @@ module.exports = {
       new webpack.DllPlugin({
         name: '[name]_lib',
         path: 'build/[name]-manifest.json'
+      }),
+
+      new webpack.DefinePlugin({
+        'process.env': {
+          NODE_ENV: JSON.stringify(ENV)
+        }
       })
     ];
 


### PR DESCRIPTION
Removes React PropTypes from Component on build.
Simple proxy server to test the minified version of the JS files.

Issue #2157 