### PR TITLE
Specify column cache sizes explicitly; default fallback of 2MB

### DIFF
--- a/ethcore/src/service.rs
+++ b/ethcore/src/service.rs
@@ -83,7 +83,10 @@ impl ClientService {
 
 		// give all rocksdb cache to state column; everything else has its
 		// own caches.
-		db_config.set_cache(::db::COL_STATE, config.db_cache_size);
+		if let Some(size) = config.db_cache_size {
+			db_config.set_cache(::db::COL_STATE, size);
+		}
+
 		db_config.compaction = config.db_compaction.compaction_profile();
 		db_config.wal = config.db_wal;
 
@@ -93,7 +96,7 @@ impl ClientService {
 		let snapshot_params = SnapServiceParams {
 			engine: spec.engine.clone(),
 			genesis_block: spec.genesis_block(),
-			db_config: db_config,
+			db_config: db_config.clone(),
 			pruning: pruning,
 			channel: io_service.channel(),
 			snapshot_root: snapshot_path.into(),

--- a/ethcore/src/service.rs
+++ b/ethcore/src/service.rs
@@ -80,7 +80,10 @@ impl ClientService {
 		}
 
 		let mut db_config = DatabaseConfig::with_columns(::db::NUM_COLUMNS);
-		db_config.cache_size = config.db_cache_size;
+
+		// give all rocksdb cache to state column; everything else has its
+		// own caches.
+		db_config.set_cache(::db::COL_STATE, config.db_cache_size);
 		db_config.compaction = config.db_compaction.compaction_profile();
 		db_config.wal = config.db_wal;
 

--- a/parity/migration.rs
+++ b/parity/migration.rs
@@ -160,7 +160,7 @@ fn consolidate_database(
 	let config = default_migration_settings(compaction_profile);
 	let mut db_config = DatabaseConfig {
 		max_open_files: 64,
-		cache_size: None,
+		cache_sizes: Default::default(),
 		compaction: config.compaction_profile,
 		columns: None,
 		wal: true,

--- a/util/src/kvdb.rs
+++ b/util/src/kvdb.rs
@@ -147,7 +147,7 @@ impl CompactionProfile {
 pub struct DatabaseConfig {
 	/// Max number of open files.
 	pub max_open_files: i32,
-	/// Vector of cache sizes (in MiB) for specific columns.
+	/// Cache sizes (in MiB) for specific columns.
 	pub cache_sizes: HashMap<Option<u32>, usize>,
 	/// Compaction profile
 	pub compaction: CompactionProfile,

--- a/util/src/kvdb.rs
+++ b/util/src/kvdb.rs
@@ -167,7 +167,7 @@ impl DatabaseConfig {
 	}
 
 	/// Set the column cache size in MiB.
-	pub fn with_cache(&mut self, col: Option<u32>, size: usize) {
+	pub fn set_cache(&mut self, col: Option<u32>, size: usize) {
 		self.cache_sizes.insert(col, size);
 	}
 }

--- a/util/src/kvdb.rs
+++ b/util/src/kvdb.rs
@@ -247,10 +247,7 @@ impl Database {
 			opts.set_target_file_size_base(config.compaction.initial_file_size);
 			opts.set_target_file_size_multiplier(config.compaction.file_size_multiplier);
 
-			let col_opt = match col {
-				0 => None,
-				x => Some(x - 1),
-			};
+			let col_opt = config.columns.map(|_| col);
 
 			{
 				let cache_size = config.cache_sizes.get(&col_opt).cloned().unwrap_or(DEFAULT_CACHE);
@@ -259,6 +256,7 @@ impl Database {
 				block_opts.set_cache(Cache::new(cache_size * 1024 * 1024));
 				opts.set_block_based_table_factory(&block_opts);
 			}
+
 			cf_options.push(opts);
 		}
 

--- a/util/src/migration/mod.rs
+++ b/util/src/migration/mod.rs
@@ -210,7 +210,7 @@ impl Manager {
 		if migrations.is_empty() { return Err(Error::MigrationImpossible) };
 		let mut db_config = DatabaseConfig {
 			max_open_files: 64,
-			cache_size: None,
+			cache_sizes: Default::default(),
 			compaction: config.compaction_profile,
 			columns: columns,
 			wal: true,


### PR DESCRIPTION
`service` now gives all of the `cache_size_db` flag to the state column as we have explicit caches for everything else.