### PR TITLE
Fixing Delegate Call in JIT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,7 +283,7 @@ dependencies = [
  "ethjson 0.1.0",
  "ethkey 0.2.0",
  "ethstore 0.1.0",
- "evmjit 1.3.0",
+ "evmjit 1.4.0",
  "heapsize 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.4 (git+https://github.com/ethcore/hyper)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -629,7 +629,7 @@ dependencies = [
 
 [[package]]
 name = "evmjit"
-version = "1.3.0"
+version = "1.4.0"
 dependencies = [
  "tiny-keccak 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -283,7 +283,7 @@ dependencies = [
  "ethjson 0.1.0",
  "ethkey 0.2.0",
  "ethstore 0.1.0",
- "evmjit 1.4.0",
+ "evmjit 1.3.0",
  "heapsize 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.9.4 (git+https://github.com/ethcore/hyper)",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -629,7 +629,7 @@ dependencies = [
 
 [[package]]
 name = "evmjit"
-version = "1.4.0"
+version = "1.3.0"
 dependencies = [
  "tiny-keccak 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/ethcore/src/evm/jit.rs
+++ b/ethcore/src/evm/jit.rs
@@ -215,11 +215,7 @@ impl<'a> evmjit::Ext for ExtAdapter<'a> {
 		let is_callcode = receive_address != code_address;
 		let is_delegatecall = is_callcode && sender_address != receive_address;
 
-		let value = if is_delegatecall {
-			None
-		} else {
-			Some(transfer_value)
-		};
+		let value = if is_delegatecall { None } else { Some(transfer_value) };
 
 		if !is_callcode && !self.ext.exists(&code_address) {
 			gas_cost = gas_cost + U256::from(self.ext.schedule().call_new_account_gas);

--- a/ethcore/src/evm/jit.rs
+++ b/ethcore/src/evm/jit.rs
@@ -196,6 +196,7 @@ impl<'a> evmjit::Ext for ExtAdapter<'a> {
 				receive_address: *const evmjit::H256,
 				code_address: *const evmjit::H256,
 				transfer_value: *const evmjit::I256,
+				// We are ignoring apparent value - it's handled in externalities.
 				_apparent_value: *const evmjit::I256,
 				in_beg: *const u8,
 				in_size: u64,
@@ -208,12 +209,17 @@ impl<'a> evmjit::Ext for ExtAdapter<'a> {
 		let sender_address = unsafe { Address::from_jit(&*sender_address) };
 		let receive_address = unsafe { Address::from_jit(&*receive_address) };
 		let code_address = unsafe { Address::from_jit(&*code_address) };
-		// TODO Is it always safe in case of DELEGATE_CALL?
 		let transfer_value = unsafe { U256::from_jit(&*transfer_value) };
-		let value = Some(transfer_value);
 
 		// receive address and code address are the same in normal calls
 		let is_callcode = receive_address != code_address;
+		let is_delegatecall = is_callcode && sender_address != receive_address;
+
+		let value = if is_delegatecall {
+			None
+		} else {
+			Some(transfer_value)
+		};
 
 		if !is_callcode && !self.ext.exists(&code_address) {
 			gas_cost = gas_cost + U256::from(self.ext.schedule().call_new_account_gas);
@@ -242,10 +248,10 @@ impl<'a> evmjit::Ext for ExtAdapter<'a> {
 			}
 		}
 
-		// TODO [ToDr] Any way to detect DelegateCall?
-		let call_type = match is_callcode {
-			true => CallType::CallCode,
-			false => CallType::Call,
+		let call_type = match (is_callcode, is_delegatecall) {
+			(_, true) => CallType::DelegateCall,
+			(true, false) => CallType::CallCode,
+			(false, false) => CallType::Call,
 		};
 
 		match self.ext.call(

--- a/ethcore/src/executive.rs
+++ b/ethcore/src/executive.rs
@@ -589,8 +589,11 @@ mod tests {
 		assert_eq!(substate.contracts_created.len(), 0);
 	}
 
-	evm_test!{test_call_to_create: test_call_to_create_jit, test_call_to_create_int}
-	fn test_call_to_create(factory: Factory) {
+	#[test]
+	// Tracing is not suported in JIT
+	fn test_call_to_create() {
+		let factory = Factory::new(VMType::Interpreter);
+
 		// code:
 		//
 		// 7c 601080600c6000396000f3006000355415600957005b60203560003555 - push 29 bytes?
@@ -712,8 +715,10 @@ mod tests {
 		assert_eq!(vm_tracer.drain().unwrap(), expected_vm_trace);
 	}
 
-	evm_test!{test_create_contract: test_create_contract_jit, test_create_contract_int}
-	fn test_create_contract(factory: Factory) {
+	#[test]
+	fn test_create_contract() {
+		// Tracing is not supported in JIT
+		let factory = Factory::new(VMType::Interpreter);
 		// code:
 		//
 		// 60 10 - push 16


### PR DESCRIPTION
Already backported to beta in #2376.

Disabling two tests with tracing (cause it's not supported in JIT)