### PR TITLE
Fixing logs-receipt matching

### DIFF
--- a/ethcore/src/blockchain/blockchain.rs
+++ b/ethcore/src/blockchain/blockchain.rs
@@ -331,11 +331,12 @@ impl BlockProvider for BlockChain {
 			.filter_map(|number| self.block_hash(number).map(|hash| (number, hash)))
 			.filter_map(|(number, hash)| self.block_receipts(&hash).map(|r| (number, hash, r.receipts)))
 			.filter_map(|(number, hash, receipts)| self.block_body(&hash).map(|ref b| (number, hash, receipts, BodyView::new(b).transaction_hashes())))
-			.flat_map(|(number, hash, mut receipts, hashes)| {
+			.flat_map(|(number, hash, mut receipts, mut hashes)| {
 				assert_eq!(receipts.len(), hashes.len());
 				log_index = receipts.iter().fold(0, |sum, receipt| sum + receipt.logs.len());
 
 				let receipts_len = receipts.len();
+				hashes.reverse();
 				receipts.reverse();
 				receipts.into_iter()
 					.map(|receipt| receipt.logs)
@@ -1761,7 +1762,7 @@ mod tests {
 			gas_price: 0.into(),
 			gas: 100_000.into(),
 			action: Action::Create,
-			value: 100.into(),
+			value: 101.into(),
 			data: "601080600c6000396000f3006000355415600957005b60203560003555".from_hex().unwrap(),
 		}.sign(&"".sha3());
 		let t2 = Transaction {
@@ -1769,7 +1770,7 @@ mod tests {
 			gas_price: 0.into(),
 			gas: 100_000.into(),
 			action: Action::Create,
-			value: 100.into(),
+			value: 102.into(),
 			data: "601080600c6000396000f3006000355415600957005b60203560003555".from_hex().unwrap(),
 		}.sign(&"".sha3());
 		let t3 = Transaction {
@@ -1777,7 +1778,7 @@ mod tests {
 			gas_price: 0.into(),
 			gas: 100_000.into(),
 			action: Action::Create,
-			value: 100.into(),
+			value: 103.into(),
 			data: "601080600c6000396000f3006000355415600957005b60203560003555".from_hex().unwrap(),
 		}.sign(&"".sha3());
 		let tx_hash1 = t1.hash();


### PR DESCRIPTION
Test didn't find this error, cause all transactions were the same (thus the hashes were the same).
Fixed test and added `hashes.reverse`