### PR TITLE
Run inplace upgrades after version update

### DIFF
--- a/parity/migration.rs
+++ b/parity/migration.rs
@@ -270,10 +270,11 @@ pub fn migrate(path: &Path, pruning: Algorithm, compaction_profile: CompactionPr
 		println!("Migration finished");
 	}
 
-	try!(run_inplace_upgrades(consolidated_database_path(path).as_path()));
-
 	// update version file.
 	update_version(path)
+	
+	// run any inplace migrations for the fully upgraded database
+	try!(run_inplace_upgrades(consolidated_database_path(path).as_path()));
 }
 
 /// Old migrations utilities

--- a/parity/migration.rs
+++ b/parity/migration.rs
@@ -271,10 +271,12 @@ pub fn migrate(path: &Path, pruning: Algorithm, compaction_profile: CompactionPr
 	}
 
 	// update version file.
-	update_version(path)
-	
+	try!(update_version(path));
+
 	// run any inplace migrations for the fully upgraded database
 	try!(run_inplace_upgrades(consolidated_database_path(path).as_path()));
+
+	Ok(())
 }
 
 /// Old migrations utilities


### PR DESCRIPTION
In highly unlikely scenario when the bloom update fails it will at least try again on the next run