### PR TITLE
Make migration api more friendly

### DIFF
--- a/ethcore/src/migrations/v9.rs
+++ b/ethcore/src/migrations/v9.rs
@@ -20,6 +20,7 @@
 use rlp::{Rlp, RlpStream, View, Stream};
 use util::kvdb::Database;
 use util::migration::{Batch, Config, Error, Migration, Progress};
+use std::sync::Arc;
 
 /// Which part of block to preserve
 pub enum Extract {
@@ -55,7 +56,7 @@ impl Migration for ToV9 {
 
 	fn version(&self) -> u32 { 9 }
 
-	fn migrate(&mut self, source: &Database, config: &Config, dest: &mut Database, col: Option<u32>) -> Result<(), Error> {
+	fn migrate(&mut self, source: Arc<Database>, config: &Config, dest: &mut Database, col: Option<u32>) -> Result<(), Error> {
 		let mut batch = Batch::new(config, self.column);
 
 		for (key, value) in source.iter(col) {

--- a/util/src/migration/tests.rs
+++ b/util/src/migration/tests.rs
@@ -91,7 +91,7 @@ impl Migration for AddsColumn {
 
 	fn version(&self) -> u32 { 1 }
 
-	fn migrate(&mut self, source: &Database, config: &Config, dest: &mut Database, col: Option<u32>) -> Result<(), Error> {
+	fn migrate(&mut self, source: Arc<Database>, config: &Config, dest: &mut Database, col: Option<u32>) -> Result<(), Error> {
 		let mut batch = Batch::new(config, col);
 
 		for (key, value) in source.iter(col) {


### PR DESCRIPTION
once it is passed with arc reference, original database can now be used in more complex queries 