### PR TITLE
Fixing Signer token RPC API

### DIFF
--- a/parity/run.rs
+++ b/parity/run.rs
@@ -241,7 +241,9 @@ pub fn execute(cmd: RunCmd) -> Result<(), String> {
 	let signer_path = cmd.signer_conf.signer_path.clone();
 	let deps_for_rpc_apis = Arc::new(rpc_apis::Dependencies {
 		signer_port: cmd.signer_port,
-		signer_service: Arc::new(rpc_apis::SignerService::new(move || signer::new_token(signer_path.clone()))),
+		signer_service: Arc::new(rpc_apis::SignerService::new(move || {
+			signer::generate_new_token(signer_path.clone()).map_err(|e| format!("{:?}", e))
+		})),
 		client: client.clone(),
 		sync: sync_provider.clone(),
 		net: manage_network.clone(),

--- a/parity/signer.rs
+++ b/parity/signer.rs
@@ -74,7 +74,7 @@ pub fn new_token(path: String) -> Result<String, String> {
 		.map_err(|err| format!("Error generating token: {:?}", err))
 }
 
-fn generate_new_token(path: String) -> io::Result<String> {
+pub fn generate_new_token(path: String) -> io::Result<String> {
 	let path = codes_path(path);
 	let mut codes = try!(signer::AuthCodes::from_file(&path));
 	let code = try!(codes.generate_new());


### PR DESCRIPTION
Previously token was returned with formatting text.