### PR TITLE
update ethcore-bigint crate to 0.1.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -308,7 +308,7 @@ dependencies = [
 
 [[package]]
 name = "ethcore-bigint"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "heapsize 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -539,7 +539,7 @@ dependencies = [
  "elastic-array 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "env_logger 0.3.3 (registry+https://github.com/rust-lang/crates.io-index)",
  "eth-secp256k1 0.5.4 (git+https://github.com/ethcore/rust-secp256k1)",
- "ethcore-bigint 0.1.0",
+ "ethcore-bigint 0.1.1",
  "ethcore-bloom-journal 0.1.0",
  "ethcore-devtools 1.4.0",
  "heapsize 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -568,7 +568,7 @@ name = "ethcrypto"
 version = "0.1.0"
 dependencies = [
  "eth-secp256k1 0.5.4 (git+https://github.com/ethcore/rust-secp256k1)",
- "ethcore-bigint 0.1.0",
+ "ethcore-bigint 0.1.1",
  "ethkey 0.2.0",
  "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "tiny-keccak 1.0.5 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -591,7 +591,7 @@ version = "0.2.0"
 dependencies = [
  "docopt 0.6.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "eth-secp256k1 0.5.4 (git+https://github.com/ethcore/rust-secp256k1)",
- "ethcore-bigint 0.1.0",
+ "ethcore-bigint 0.1.1",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1398,7 +1398,7 @@ name = "rlp"
 version = "0.1.0"
 dependencies = [
  "elastic-array 0.5.0 (registry+https://github.com/rust-lang/crates.io-index)",
- "ethcore-bigint 0.1.0",
+ "ethcore-bigint 0.1.1",
  "lazy_static 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/util/bigint/Cargo.toml
+++ b/util/bigint/Cargo.toml
@@ -4,7 +4,7 @@ homepage = "http://ethcore.io"
 repository = "https://github.com/ethcore/parity"
 license = "GPL-3.0"
 name = "ethcore-bigint"
-version = "0.1.0"
+version = "0.1.1"
 authors = ["Ethcore <admin@ethcore.io>"]
 build = "build.rs"
 


### PR DESCRIPTION
...and publish to crates.io. Contains the fix for https://github.com/rust-lang/rust/issues/36830