### PR TITLE
Added peers details to ethcore_netPeers RPC

### DIFF
--- a/rpc/src/v1/impls/ethcore.rs
+++ b/rpc/src/v1/impls/ethcore.rs
@@ -165,13 +165,16 @@ impl<C, M, S: ?Sized, F> Ethcore for EthcoreClient<C, M, S, F> where
 	fn net_peers(&self) -> Result<Peers, Error> {
 		try!(self.active());
 
-		let sync_status = take_weak!(self.sync).status();
+		let sync = take_weak!(self.sync);
+		let sync_status = sync.status();
 		let net_config = take_weak!(self.net).network_config();
+		let peers = sync.peers().into_iter().map(|s| s.into()).collect();
 
 		Ok(Peers {
 			active: sync_status.num_active_peers,
 			connected: sync_status.num_peers,
 			max: sync_status.current_max_peers(net_config.min_peers, net_config.max_peers),
+			peers: peers
 		})
 	}
 

--- a/rpc/src/v1/impls/ethcore.rs
+++ b/rpc/src/v1/impls/ethcore.rs
@@ -168,7 +168,7 @@ impl<C, M, S: ?Sized, F> Ethcore for EthcoreClient<C, M, S, F> where
 		let sync = take_weak!(self.sync);
 		let sync_status = sync.status();
 		let net_config = take_weak!(self.net).network_config();
-		let peers = sync.peers().into_iter().map(|s| s.into()).collect();
+		let peers = sync.peers().into_iter().map(Into::into).collect();
 
 		Ok(Peers {
 			active: sync_status.num_active_peers,

--- a/rpc/src/v1/tests/helpers/sync_provider.rs
+++ b/rpc/src/v1/tests/helpers/sync_provider.rs
@@ -17,7 +17,7 @@
 //! Test implementation of SyncProvider.
 
 use util::{RwLock, U256};
-use ethsync::{SyncProvider, SyncStatus, SyncState};
+use ethsync::{SyncProvider, SyncStatus, SyncState, PeerInfo};
 
 /// TestSyncProvider config.
 pub struct Config {
@@ -59,6 +59,31 @@ impl TestSyncProvider {
 impl SyncProvider for TestSyncProvider {
 	fn status(&self) -> SyncStatus {
 		self.status.read().clone()
+	}
+
+	fn peers(&self) -> Vec<PeerInfo> {
+		vec![
+			PeerInfo {
+				id: Some("node1".to_owned()),
+    			client_version: "Parity/1".to_owned(),
+				capabilities: vec!["eth/62".to_owned(), "eth/63".to_owned()], 
+    			remote_address: "127.0.0.1:7777".to_owned(),
+				local_address: "127.0.0.1:8888".to_owned(),
+				eth_version: 62,
+				eth_difficulty: Some(40.into()),
+				eth_head: 50.into()
+			},
+			PeerInfo {
+				id: None,
+    			client_version: "Parity/2".to_owned(),
+				capabilities: vec!["eth/63".to_owned(), "eth/64".to_owned()], 
+    			remote_address: "Handshake".to_owned(),
+				local_address: "127.0.0.1:3333".to_owned(),
+				eth_version: 64,
+				eth_difficulty: None,
+				eth_head: 60.into()
+			}
+		]
 	}
 }
 

--- a/rpc/src/v1/tests/mocked/ethcore.rs
+++ b/rpc/src/v1/tests/mocked/ethcore.rs
@@ -208,7 +208,12 @@ fn rpc_ethcore_net_peers() {
 	io.add_delegate(ethcore_client(&client, &miner, &sync, &net).to_delegate());
 
 	let request = r#"{"jsonrpc": "2.0", "method": "ethcore_netPeers", "params":[], "id": 1}"#;
-	let response = r#"{"jsonrpc":"2.0","result":{"active":0,"connected":120,"max":50},"id":1}"#;
+	let response = "{\"jsonrpc\":\"2.0\",\"result\":{\"active\":0,\"connected\":120,\"max\":50,\"peers\":[{\"caps\":[\"eth/62\",\"eth/63\"],\
+\"id\":\"node1\",\"name\":\"Parity/1\",\"network\":{\"localAddress\":\"127.0.0.1:8888\",\"remoteAddress\":\"127.0.0.1:7777\"}\
+,\"protocols\":{\"eth\":{\"difficulty\":\"0x28\",\"head\":\"0000000000000000000000000000000000000000000000000000000000000032\"\
+,\"version\":62}}},{\"caps\":[\"eth/63\",\"eth/64\"],\"id\":null,\"name\":\"Parity/2\",\"network\":{\"localAddress\":\
+\"127.0.0.1:3333\",\"remoteAddress\":\"Handshake\"},\"protocols\":{\"eth\":{\"difficulty\":null,\"head\":\
+\"000000000000000000000000000000000000000000000000000000000000003c\",\"version\":64}}}]},\"id\":1}";
 
 	assert_eq!(io.handle_request_sync(request), Some(response.to_owned()));
 }

--- a/rpc/src/v1/types/mod.rs.in
+++ b/rpc/src/v1/types/mod.rs.in
@@ -42,7 +42,7 @@ pub use self::filter::{Filter, FilterChanges};
 pub use self::hash::{H64, H160, H256, H512, H520, H2048};
 pub use self::index::Index;
 pub use self::log::Log;
-pub use self::sync::{SyncStatus, SyncInfo, Peers};
+pub use self::sync::{SyncStatus, SyncInfo, Peers, PeerInfo, PeerNetworkInfo, PeerProtocolsInfo, PeerEthereumProtocolInfo};
 pub use self::transaction::Transaction;
 pub use self::transaction_request::TransactionRequest;
 pub use self::receipt::Receipt;

--- a/rpc/src/v1/types/sync.rs
+++ b/rpc/src/v1/types/sync.rs
@@ -46,7 +46,7 @@ pub struct Peers {
 }
 
 /// Peer connection information
-#[derive(Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct PeerInfo {
 	/// Public node id
 	pub id: Option<String>,
@@ -61,7 +61,7 @@ pub struct PeerInfo {
 }
 
 /// Peer network information
-#[derive(Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct PeerNetworkInfo {
 	/// Remote endpoint address
 	#[serde(rename="remoteAddress")]
@@ -72,14 +72,14 @@ pub struct PeerNetworkInfo {
 }
 
 /// Peer protocols information
-#[derive(Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct PeerProtocolsInfo {
 	/// Ethereum protocol information
 	pub eth: PeerEthereumProtocolInfo
 }
 
 /// Peer Ethereum protocol information
-#[derive(Serialize)]
+#[derive(Default, Debug, Serialize)]
 pub struct PeerEthereumProtocolInfo {
 	/// Negotiated ethereum protocol version
 	pub version: u32,

--- a/rpc/src/v1/types/sync.rs
+++ b/rpc/src/v1/types/sync.rs
@@ -42,7 +42,7 @@ pub struct Peers {
 	/// Max number of peers
 	pub max: u32,
 	/// Detailed information on peers
-	pub peers: Vec<PeerInfo>
+	pub peers: Vec<PeerInfo>,
 }
 
 /// Peer connection information
@@ -57,7 +57,7 @@ pub struct PeerInfo {
 	/// Network information
 	pub network: PeerNetworkInfo,
 	/// Protocols information
-	pub protocols: PeerProtocolsInfo
+	pub protocols: PeerProtocolsInfo,
 }
 
 /// Peer network information
@@ -68,14 +68,14 @@ pub struct PeerNetworkInfo {
 	pub remote_address: String,
 	/// Local endpoint address
 	#[serde(rename="localAddress")]
-	pub local_address: String
+	pub local_address: String,
 }
 
 /// Peer protocols information
 #[derive(Default, Debug, Serialize)]
 pub struct PeerProtocolsInfo {
 	/// Ethereum protocol information
-	pub eth: Option<PeerEthereumProtocolInfo>
+	pub eth: Option<PeerEthereumProtocolInfo>,
 }
 
 /// Peer Ethereum protocol information
@@ -86,7 +86,7 @@ pub struct PeerEthereumProtocolInfo {
 	/// Peer total difficulty if known
 	pub difficulty: Option<U256>,
 	/// SHA3 of peer best block hash
-	pub head: String
+	pub head: String,
 }
 
 /// Sync status
@@ -116,15 +116,15 @@ impl From<SyncPeerInfo> for PeerInfo {
 			caps: p.capabilities,
 			network: PeerNetworkInfo {
 				remote_address: p.remote_address,
-				local_address: p.local_address
+				local_address: p.local_address,
 			},
 			protocols: PeerProtocolsInfo {
 				eth: Some(PeerEthereumProtocolInfo {
 					version: p.eth_version,
 					difficulty: p.eth_difficulty.map(|d| d.into()),
-					head: p.eth_head.hex()
+					head: p.eth_head.hex(),
 				})
-			}
+			},
 		}
 	}
 }

--- a/rpc/src/v1/types/sync.rs
+++ b/rpc/src/v1/types/sync.rs
@@ -14,6 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
+use ethsync::PeerInfo as SyncPeerInfo;
 use serde::{Serialize, Serializer};
 use v1::types::U256;
 
@@ -32,7 +33,7 @@ pub struct SyncInfo {
 }
 
 /// Peers info
-#[derive(Default, Debug, Serialize, PartialEq)]
+#[derive(Default, Debug, Serialize)]
 pub struct Peers {
 	/// Number of active peers
 	pub active: usize,
@@ -40,6 +41,52 @@ pub struct Peers {
 	pub connected: usize,
 	/// Max number of peers
 	pub max: u32,
+	/// Detailed information on peers
+	pub peers: Vec<PeerInfo>
+}
+
+/// Peer connection information
+#[derive(Serialize)]
+pub struct PeerInfo {
+	/// Public node id
+	pub id: Option<String>,
+	/// Node client ID
+    pub name: String,
+	/// Capabilities
+	pub caps: Vec<String>, 
+	/// Network information
+	pub network: PeerNetworkInfo,
+	/// Protocols information
+	pub protocols: PeerProtocolsInfo
+}
+
+/// Peer network information
+#[derive(Serialize)]
+pub struct PeerNetworkInfo {
+	/// Remote endpoint address
+	#[serde(rename="remoteAddress")]
+    pub remote_address: String,
+	/// Local endpoint address
+	#[serde(rename="localAddress")]
+    pub local_address: String
+}
+
+/// Peer protocols information
+#[derive(Serialize)]
+pub struct PeerProtocolsInfo {
+	/// Ethereum protocol information
+	pub eth: PeerEthereumProtocolInfo
+}
+
+/// Peer Ethereum protocol information
+#[derive(Serialize)]
+pub struct PeerEthereumProtocolInfo {
+	/// Negotiated ethereum protocol version
+	pub version: u32,
+	/// Peer total difficulty if known
+	pub difficulty: Option<U256>,
+	/// SHA3 of peer best block hash
+	pub head: String
 }
 
 /// Sync status
@@ -61,6 +108,27 @@ impl Serialize for SyncStatus {
 	}
 }
 
+impl From<SyncPeerInfo> for PeerInfo {
+	fn from(p: SyncPeerInfo) -> PeerInfo {
+		PeerInfo {
+			id: p.id,
+			name: p.client_version,
+			caps: p.capabilities,
+			network: PeerNetworkInfo {
+				remote_address: p.remote_address,
+				local_address: p.local_address
+			},
+			protocols: PeerProtocolsInfo {
+				eth: PeerEthereumProtocolInfo {
+					version: p.eth_version,
+					difficulty: p.eth_difficulty.map(|d| d.into()),
+					head: p.eth_head.hex()
+				}
+			}
+		}
+	}
+}
+
 #[cfg(test)]
 mod tests {
 	use serde_json;
@@ -77,7 +145,7 @@ mod tests {
 	fn test_serialize_peers() {
 		let t = Peers::default();
 		let serialized = serde_json::to_string(&t).unwrap();
-		assert_eq!(serialized, r#"{"active":0,"connected":0,"max":0}"#);
+		assert_eq!(serialized, r#"{"active":0,"connected":0,"max":0,"peers":[]}"#);
 	}
 
 	#[test]

--- a/rpc/src/v1/types/sync.rs
+++ b/rpc/src/v1/types/sync.rs
@@ -51,7 +51,7 @@ pub struct PeerInfo {
 	/// Public node id
 	pub id: Option<String>,
 	/// Node client ID
-    pub name: String,
+	pub name: String,
 	/// Capabilities
 	pub caps: Vec<String>, 
 	/// Network information
@@ -65,10 +65,10 @@ pub struct PeerInfo {
 pub struct PeerNetworkInfo {
 	/// Remote endpoint address
 	#[serde(rename="remoteAddress")]
-    pub remote_address: String,
+	pub remote_address: String,
 	/// Local endpoint address
 	#[serde(rename="localAddress")]
-    pub local_address: String
+	pub local_address: String
 }
 
 /// Peer protocols information

--- a/rpc/src/v1/types/sync.rs
+++ b/rpc/src/v1/types/sync.rs
@@ -75,7 +75,7 @@ pub struct PeerNetworkInfo {
 #[derive(Default, Debug, Serialize)]
 pub struct PeerProtocolsInfo {
 	/// Ethereum protocol information
-	pub eth: PeerEthereumProtocolInfo
+	pub eth: Option<PeerEthereumProtocolInfo>
 }
 
 /// Peer Ethereum protocol information
@@ -119,11 +119,11 @@ impl From<SyncPeerInfo> for PeerInfo {
 				local_address: p.local_address
 			},
 			protocols: PeerProtocolsInfo {
-				eth: PeerEthereumProtocolInfo {
+				eth: Some(PeerEthereumProtocolInfo {
 					version: p.eth_version,
 					difficulty: p.eth_difficulty.map(|d| d.into()),
 					head: p.eth_head.hex()
-				}
+				})
 			}
 		}
 	}

--- a/sync/src/api.rs
+++ b/sync/src/api.rs
@@ -67,18 +67,18 @@ pub trait SyncProvider: Send + Sync {
 }
 
 /// Peer connection information
-#[derive(Binary)]
+#[derive(Debug, Binary)]
 pub struct PeerInfo {
 	/// Public node id
 	pub id: Option<String>,
 	/// Node client ID
-    pub client_version: String,
+	pub client_version: String,
 	/// Capabilities
 	pub capabilities: Vec<String>, 
 	/// Remote endpoint address
-    pub remote_address: String,
+	pub remote_address: String,
 	/// Local endpoint address
-    pub local_address: String,
+	pub local_address: String,
 	/// Ethereum protocol version
 	pub eth_version: u32,
 	/// SHA3 of peer best block hash

--- a/sync/src/api.rs
+++ b/sync/src/api.rs
@@ -61,6 +61,30 @@ binary_fixed_size!(SyncStatus);
 pub trait SyncProvider: Send + Sync {
 	/// Get sync status
 	fn status(&self) -> SyncStatus;
+
+	/// Get peers information
+	fn peers(&self) -> Vec<PeerInfo>;
+}
+
+/// Peer connection information
+#[derive(Binary)]
+pub struct PeerInfo {
+	/// Public node id
+	pub id: Option<String>,
+	/// Node client ID
+    pub client_version: String,
+	/// Capabilities
+	pub capabilities: Vec<String>, 
+	/// Remote endpoint address
+    pub remote_address: String,
+	/// Local endpoint address
+    pub local_address: String,
+	/// Ethereum protocol version
+	pub eth_version: u32,
+	/// SHA3 of peer best block hash
+	pub eth_head: H256,
+	/// Peer total difficulty if known
+	pub eth_difficulty: Option<U256>,
 }
 
 /// Ethereum network protocol handler
@@ -93,6 +117,14 @@ impl SyncProvider for EthSync {
 	/// Get sync status
 	fn status(&self) -> SyncStatus {
 		self.handler.sync.write().status()
+	}
+
+	/// Get sync peers
+	fn peers(&self) -> Vec<PeerInfo> {
+		self.network.with_context_eval(self.subprotocol_name, |context| {
+			let sync_io = NetSyncIo::new(context, &*self.handler.chain, &*self.handler.snapshot_service);
+			self.handler.sync.write().peers(&sync_io)
+		}).unwrap_or(Vec::new())
 	}
 }
 

--- a/sync/src/chain.rs
+++ b/sync/src/chain.rs
@@ -372,9 +372,9 @@ impl ChainSync {
 	/// @returns Information on peers connections
 	pub fn peers(&self, io: &SyncIo) -> Vec<PeerInfoDigest> {
 		self.peers.iter()
-			.filter_map(|(&peer_id, ref peer_data)| {
-				if let Some(session_info) = io.peer_session_info(peer_id) {
-					return Some(PeerInfoDigest {
+			.filter_map(|(&peer_id, ref peer_data)|
+				io.peer_session_info(peer_id).map(|session_info|
+					PeerInfoDigest {
 						id: session_info.id.map(|id| id.hex()),
 						client_version: session_info.client_version,
 						capabilities: session_info.peer_capabilities.into_iter().map(|c| c.to_string()).collect(),
@@ -383,10 +383,8 @@ impl ChainSync {
 						eth_version: peer_data.protocol_version,
 						eth_difficulty: peer_data.difficulty,
 						eth_head: peer_data.latest_hash
-					})
-				};
-				None
-			})
+				})
+			)
 			.collect()
 	}
 

--- a/sync/src/chain.rs
+++ b/sync/src/chain.rs
@@ -347,7 +347,7 @@ impl ChainSync {
 		}
 	}
 
-	/// @returns Synchonization status
+	/// Returns synchonization status
 	pub fn status(&self) -> SyncStatus {
 		SyncStatus {
 			state: self.state.clone(),
@@ -369,7 +369,7 @@ impl ChainSync {
 		}
 	}
 
-	/// @returns Information on peers connections
+	/// Returns information on peers connections
 	pub fn peers(&self, io: &SyncIo) -> Vec<PeerInfoDigest> {
 		self.peers.iter()
 			.filter_map(|(&peer_id, ref peer_data)|
@@ -382,7 +382,7 @@ impl ChainSync {
 						local_address: session_info.local_address,
 						eth_version: peer_data.protocol_version,
 						eth_difficulty: peer_data.difficulty,
-						eth_head: peer_data.latest_hash
+						eth_head: peer_data.latest_hash,
 				})
 			)
 			.collect()

--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -60,7 +60,7 @@ mod api {
 }
 
 pub use api::{EthSync, SyncProvider, SyncClient, NetworkManagerClient, ManageNetwork, SyncConfig,
-	ServiceConfiguration, NetworkConfiguration};
+	ServiceConfiguration, NetworkConfiguration, PeerInfo};
 pub use chain::{SyncStatus, SyncState};
 pub use network::{is_valid_node_url, NonReservedPeerMode, NetworkError};
 

--- a/sync/src/sync_io.rs
+++ b/sync/src/sync_io.rs
@@ -38,7 +38,7 @@ pub trait SyncIo {
 	fn peer_info(&self, peer_id: PeerId) -> String {
 		peer_id.to_string()
 	}
-	/// Returns peer client identifier string
+	/// Returns information on p2p session
 	fn peer_session_info(&self, peer_id: PeerId) -> Option<SessionInfo>;
 	/// Maximum mutuallt supported ETH protocol version
 	fn eth_protocol_version(&self, peer_id: PeerId) -> u8;

--- a/sync/src/sync_io.rs
+++ b/sync/src/sync_io.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-use network::{NetworkContext, PeerId, PacketId, NetworkError};
+use network::{NetworkContext, PeerId, PacketId, NetworkError, SessionInfo};
 use ethcore::client::BlockChainClient;
 use ethcore::snapshot::SnapshotService;
 
@@ -34,10 +34,12 @@ pub trait SyncIo {
 	fn chain(&self) -> &BlockChainClient;
 	/// Get the snapshot service.
 	fn snapshot_service(&self) -> &SnapshotService;
-	/// Returns peer client identifier string
+	/// Returns peer identifier string
 	fn peer_info(&self, peer_id: PeerId) -> String {
 		peer_id.to_string()
 	}
+	/// Returns peer client identifier string
+	fn peer_session_info(&self, peer_id: PeerId) -> Option<SessionInfo>;
 	/// Maximum mutuallt supported ETH protocol version
 	fn eth_protocol_version(&self, peer_id: PeerId) -> u8;
 	/// Returns if the chain block queue empty
@@ -91,8 +93,8 @@ impl<'s, 'h> SyncIo for NetSyncIo<'s, 'h> {
 		self.snapshot_service
 	}
 
-	fn peer_info(&self, peer_id: PeerId) -> String {
-		self.network.peer_info(peer_id)
+	fn peer_session_info(&self, peer_id: PeerId) -> Option<SessionInfo> {
+		self.network.session_info(peer_id)
 	}
 
 	fn is_expired(&self) -> bool {

--- a/sync/src/tests/helpers.rs
+++ b/sync/src/tests/helpers.rs
@@ -83,6 +83,10 @@ impl<'p> SyncIo for TestIo<'p> {
 		self.snapshot_service
 	}
 
+	fn peer_session_info(&self, _peer_id: PeerId) -> Option<SessionInfo> {
+		None
+	}
+
 	fn eth_protocol_version(&self, _peer: PeerId) -> u8 {
 		64
 	}

--- a/util/network/src/connection.rs
+++ b/util/network/src/connection.rs
@@ -191,6 +191,11 @@ impl Connection {
 		self.socket.peer_addr().map(|a| a.to_string()).unwrap_or_else(|_| "Unknown".to_owned())
 	}
 
+	/// Get local peer address string
+	pub fn local_addr_str(&self) -> String {
+		self.socket.local_addr().map(|a| a.to_string()).unwrap_or_else(|_| "Unknown".to_owned())
+	}
+
 	/// Clone this connection. Clears the receiving buffer of the returned connection.
 	pub fn try_clone(&self) -> io::Result<Self> {
 		Ok(Connection {

--- a/util/network/src/lib.rs
+++ b/util/network/src/lib.rs
@@ -99,6 +99,7 @@ pub use host::NetworkIoMessage;
 pub use error::NetworkError;
 pub use host::NetworkConfiguration;
 pub use stats::NetworkStats;
+pub use session::SessionInfo;
 
 use io::TimerToken;
 pub use node_table::is_valid_node_url;

--- a/util/network/src/service.rs
+++ b/util/network/src/service.rs
@@ -178,6 +178,16 @@ impl NetworkService {
 			host.with_context(protocol, &io, action);
 		};
 	}
+
+	/// Evaluates function in the network context
+	pub fn with_context_eval<F, T>(&self, protocol: ProtocolId, action: F) -> Option<T> where F: Fn(&NetworkContext) -> T {
+		let io = IoContext::new(self.io_service.channel(), 0);
+		let host = self.host.read();
+		match host.as_ref() {
+			Some(ref host) => Some(host.with_context_eval(protocol, &io, action)),
+			None => None
+		}
+	}
 }
 
 impl MayPanic for NetworkService {

--- a/util/network/src/service.rs
+++ b/util/network/src/service.rs
@@ -183,10 +183,7 @@ impl NetworkService {
 	pub fn with_context_eval<F, T>(&self, protocol: ProtocolId, action: F) -> Option<T> where F: Fn(&NetworkContext) -> T {
 		let io = IoContext::new(self.io_service.channel(), 0);
 		let host = self.host.read();
-		match host.as_ref() {
-			Some(ref host) => Some(host.with_context_eval(protocol, &io, action)),
-			None => None
-		}
+		host.as_ref().map(|ref host| host.with_context_eval(protocol, &io, action))
 	}
 }
 

--- a/util/network/src/session.rs
+++ b/util/network/src/session.rs
@@ -91,7 +91,7 @@ pub struct SessionInfo {
 	/// Remote endpoint address of the session
 	pub remote_address: String,
 	/// Local endpoint address of the session
-	pub local_address: String
+	pub local_address: String,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/util/network/src/session.rs
+++ b/util/network/src/session.rs
@@ -72,7 +72,7 @@ pub enum SessionData {
 }
 
 /// Shared session information
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct SessionInfo {
 	/// Peer public key
 	pub id: Option<NodeId>,

--- a/util/network/src/tests.rs
+++ b/util/network/src/tests.rs
@@ -69,7 +69,7 @@ impl NetworkProtocolHandler for TestProtocol {
 	}
 
 	fn connected(&self, io: &NetworkContext, peer: &PeerId) {
-		assert!(io.peer_info(*peer).contains("Parity"));
+		assert!(io.peer_client_version(*peer).contains("Parity"));
 		if self.drop_session {
 			io.disconnect_peer(*peer)
 		} else {


### PR DESCRIPTION
closes ethcore/parity#2433

I've tried to make returned data to look exactly like Geth' admin.peers output. However, protocols.eth.difficulty is returned as decimal number in Geth, while in ethcore_* APIs all bigints are returned as hex numbers (at my first glance). Not sure if I should break this rule here => difficulty is also returned as hex number here.
I'm still not sure whether it is ok to alter existing RPC - Parity already had ethcore_netPeers RPC before - I've just added another member to the returned value. Hope this won't break any clients.