### PR TITLE
mitigate refcell conflict in state diffing

### DIFF
--- a/ethcore/src/state/mod.rs
+++ b/ethcore/src/state/mod.rs
@@ -1797,4 +1797,20 @@ fn create_empty() {
 	assert_eq!(state.root().hex(), "56e81f171bcc55a6ff8345e692c0f86e5b48e01b996cadc001622fb5e363b421");
 }
 
+#[test]
+fn should_not_panic_on_state_diff_with_storage() {
+	let state = get_temp_state();
+	let mut state = state.reference().clone();
+
+	let a: Address = 0xa.into();
+	state.init_code(&a, b"abcdefg".to_vec());
+	state.add_balance(&a, &256.into());
+	state.set_storage(&a, 0xb.into(), 0xc.into());
+
+	let mut new_state = state.clone();
+	new_state.set_storage(&a, 0xb.into(), 0xd.into());
+
+	new_state.diff_from(state);
+}
+
 }


### PR DESCRIPTION
Should fix #2600 

I also switched a few uses of `borrow_mut` to `get_mut`, which should lead to better overall correctness.
These RefCells are pretty dangerous, and the strange mishmash of interior and actual mutability in this structure can lead to correctness issues, not to mention some slight runtime overhead.

It can probably be refactored a bit to make it safer. Use of `RefCell` should be considered similar to `Option::unwrap`.