### PR TITLE
Adjust build output directories

### DIFF
--- a/js/.gitignore
+++ b/js/.gitignore
@@ -1,5 +1,5 @@
-coverage
 node_modules
 npm-debug.log
-build
+.build
+.coverage
 .happypack

--- a/js/.istanbul.yml
+++ b/js/.istanbul.yml
@@ -2,3 +2,5 @@ instrumentation:
   root: src
   extensions:
     - .js
+reporting:
+  dir: ./.coverage

--- a/js/scripts/release.sh
+++ b/js/scripts/release.sh
@@ -1,8 +1,11 @@
 #!/bin/bash
 
+# find the build destimation
+DEST=${BUILD_DEST:=.build}
+
 # change into the js directory (one down from scripts)
 pushd `dirname $0`
-cd ../build
+cd ../$DEST
 
 # variables
 UTCDATE=`date -u "+%Y%m%d-%H%M%S"`

--- a/js/webpack.config.js
+++ b/js/webpack.config.js
@@ -24,6 +24,7 @@ const WebpackErrorNotificationPlugin = require('webpack-error-notification');
 
 const ENV = process.env.NODE_ENV || 'development';
 const isProd = ENV === 'production';
+const DEST = process.env.BUILD_DEST || '.build';
 
 module.exports = {
   debug: !isProd,
@@ -44,7 +45,7 @@ module.exports = {
     'index': ['./index.js']
   },
   output: {
-    path: path.join(__dirname, 'build'),
+    path: path.join(__dirname, DEST),
     filename: '[name].js'
   },
   module: {
@@ -138,7 +139,7 @@ module.exports = {
       }),
       new webpack.DllReferencePlugin({
         context: '.',
-        manifest: require('./build/vendor-manifest.json')
+        manifest: require(`./${DEST}/vendor-manifest.json`)
       }),
 
       new WebpackErrorNotificationPlugin(),
@@ -191,7 +192,7 @@ module.exports = {
     return plugins;
   }()),
   devServer: {
-    contentBase: './build',
+    contentBase: `./${DEST}`,
     historyApiFallback: false,
     quiet: false,
     hot: !isProd,

--- a/js/webpack.vendor.js
+++ b/js/webpack.vendor.js
@@ -18,6 +18,7 @@ const webpack = require('webpack');
 
 const ENV = process.env.NODE_ENV || 'development';
 const isProd = ENV === 'production';
+const DEST = process.env.BUILD_DEST || '.build';
 
 let modules = [
   'babel-polyfill',
@@ -47,14 +48,14 @@ module.exports = {
   },
   output: {
     filename: '[name].js',
-    path: 'build/',
+    path: `${DEST}/`,
     library: '[name]_lib'
   },
   plugins: (function () {
     const plugins = [
       new webpack.DllPlugin({
         name: '[name]_lib',
-        path: 'build/[name]-manifest.json'
+        path: `${DEST}/[name]-manifest.json`
       }),
 
       new webpack.DefinePlugin({


### PR DESCRIPTION
- Compiled files into `.build`, can be overridden by `BUILD_DEST` environment
- Coverage reports into `.coverage`