### PR TITLE
Allow tags for Accounts, Addresses and Contracts

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -119,7 +119,7 @@
     "lodash": "^4.11.1",
     "marked": "^0.3.6",
     "material-ui": "^0.15.4",
-    "material-ui-chip-input": "^0.7.0",
+    "material-ui-chip-input": "github:ngotchac/material-ui-chip-input",
     "moment": "^2.14.1",
     "react": "^15.2.1",
     "react-addons-css-transition-group": "^15.2.1",

--- a/js/package.json
+++ b/js/package.json
@@ -119,6 +119,7 @@
     "lodash": "^4.11.1",
     "marked": "^0.3.6",
     "material-ui": "^0.15.4",
+    "material-ui-chip-input": "^0.7.0",
     "moment": "^2.14.1",
     "react": "^15.2.1",
     "react-addons-css-transition-group": "^15.2.1",

--- a/js/package.json
+++ b/js/package.json
@@ -82,8 +82,6 @@
     "istanbul": "^1.0.0-alpha.2",
     "jsdom": "9.2.1",
     "json-loader": "^0.5.4",
-    "less": "^2.7.1",
-    "less-loader": "^2.2.3",
     "mocha": "^3.0.0-1",
     "mock-local-storage": "1.0.2",
     "mock-socket": "^3.0.1",

--- a/js/package.json
+++ b/js/package.json
@@ -119,7 +119,7 @@
     "lodash": "^4.11.1",
     "marked": "^0.3.6",
     "material-ui": "^0.15.4",
-    "material-ui-chip-input": "github:ngotchac/material-ui-chip-input",
+    "material-ui-chip-input": "^0.8.0",
     "moment": "^2.14.1",
     "react": "^15.2.1",
     "react-addons-css-transition-group": "^15.2.1",

--- a/js/src/modals/EditMeta/editMeta.js
+++ b/js/src/modals/EditMeta/editMeta.js
@@ -107,6 +107,8 @@ export default class EditMeta extends Component {
       defaultValue={ tags }
       onChange={ onChange }
       floatingLabelText='(optional) tags'
+      hintText='enter tags here'
+      floatingLabelFixed
       fullWidth
     />);
   }

--- a/js/src/modals/EditMeta/editMeta.js
+++ b/js/src/modals/EditMeta/editMeta.js
@@ -104,14 +104,16 @@ export default class EditMeta extends Component {
     const { tags } = meta || [];
     const onChange = (chips) => this.onMetaChange('tags', chips);
 
-    return (<ChipInput
-      defaultValue={ tags }
-      onChange={ onChange }
-      floatingLabelText='(optional) tags'
-      hintText='press <Enter> to add a tag'
-      floatingLabelFixed
-      fullWidth
-    />);
+    return (
+      <ChipInput
+        defaultValue={ tags }
+        onChange={ onChange }
+        floatingLabelText='(optional) tags'
+        hintText='press <Enter> to add a tag'
+        floatingLabelFixed
+        fullWidth
+      />
+    );
   }
 
   onNameChange = (name) => {

--- a/js/src/modals/EditMeta/editMeta.js
+++ b/js/src/modals/EditMeta/editMeta.js
@@ -17,7 +17,8 @@
 import React, { Component, PropTypes } from 'react';
 import ContentClear from 'material-ui/svg-icons/content/clear';
 import ContentSave from 'material-ui/svg-icons/content/save';
-import ChipInput from 'material-ui-chip-input';
+// import ChipInput from 'material-ui-chip-input';
+import ChipInput from 'material-ui-chip-input/src/ChipInput';
 
 import { Button, Form, Input, Modal } from '../../ui';
 import { validateName } from '../../util/validation';
@@ -107,7 +108,7 @@ export default class EditMeta extends Component {
       defaultValue={ tags }
       onChange={ onChange }
       floatingLabelText='(optional) tags'
-      hintText='enter tags here'
+      hintText='press <Enter> to add a tag'
       floatingLabelFixed
       fullWidth
     />);

--- a/js/src/modals/EditMeta/editMeta.js
+++ b/js/src/modals/EditMeta/editMeta.js
@@ -17,6 +17,7 @@
 import React, { Component, PropTypes } from 'react';
 import ContentClear from 'material-ui/svg-icons/content/clear';
 import ContentSave from 'material-ui/svg-icons/content/save';
+import ChipInput from 'material-ui-chip-input';
 
 import { Button, Form, Input, Modal } from '../../ui';
 import { validateName } from '../../util/validation';
@@ -55,6 +56,7 @@ export default class EditMeta extends Component {
             error={ nameError }
             onSubmit={ this.onNameChange } />
           { this.renderMetaFields() }
+          { this.renderTags() }
         </Form>
       </Modal>
     );
@@ -94,6 +96,19 @@ export default class EditMeta extends Component {
           onSubmit={ onSubmit } />
       );
     });
+  }
+
+  renderTags () {
+    const { meta } = this.state;
+    const { tags } = meta || [];
+    const onChange = (chips) => this.onMetaChange('tags', chips);
+
+    return (<ChipInput
+      defaultValue={ tags }
+      onChange={ onChange }
+      floatingLabelText='(optional) tags'
+      fullWidth
+    />);
   }
 
   onNameChange = (name) => {

--- a/js/src/ui/Actionbar/Search/index.js
+++ b/js/src/ui/Actionbar/Search/index.js
@@ -1,0 +1,17 @@
+// Copyright 2015, 2016 Ethcore (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+export default from './search';

--- a/js/src/ui/Actionbar/Search/search.css
+++ b/js/src/ui/Actionbar/Search/search.css
@@ -14,6 +14,10 @@
 /* You should have received a copy of the GNU General Public License
 /* along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 */
+.searchcontainer {
+  display: flex;
+  overflow: hidden;
+}
 
 .searchButton {
   min-width: 50px !important;
@@ -21,6 +25,6 @@
 
 .searchInput {
   transition: width 450ms !important;
-  transition: visibility 0 450ms !important;
   white-space: nowrap;
+  overflow: hidden;
 }

--- a/js/src/ui/Actionbar/Search/search.css
+++ b/js/src/ui/Actionbar/Search/search.css
@@ -23,8 +23,21 @@
   min-width: 50px !important;
 }
 
-.searchInput {
-  transition: width 450ms !important;
+.input {
+  width: 500px !important;
+}
+
+.inputContainer {
+  transition: width 450ms ease-in-out 0ms, height 0ms ease-in-out 0ms;
   white-space: nowrap;
   overflow: hidden;
+  width: 500px;
+  height: 100%;
+  position: relative;
+}
+
+.inputContainerShown {
+  transition: width 450ms ease-in-out 0ms, height 0ms ease-in-out 400ms;
+  width: 0;
+  height: 0;
 }

--- a/js/src/ui/Actionbar/Search/search.css
+++ b/js/src/ui/Actionbar/Search/search.css
@@ -1,0 +1,26 @@
+/* Copyright 2015, 2016 Ethcore (UK) Ltd.
+/* This file is part of Parity.
+/*
+/* Parity is free software: you can redistribute it and/or modify
+/* it under the terms of the GNU General Public License as published by
+/* the Free Software Foundation, either version 3 of the License, or
+/* (at your option) any later version.
+/*
+/* Parity is distributed in the hope that it will be useful,
+/* but WITHOUT ANY WARRANTY; without even the implied warranty of
+/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+/* GNU General Public License for more details.
+/*
+/* You should have received a copy of the GNU General Public License
+/* along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+.searchButton {
+  min-width: 50px !important;
+}
+
+.searchInput {
+  transition: width 450ms !important;
+  transition: visibility 0 450ms !important;
+  white-space: nowrap;
+}

--- a/js/src/ui/Actionbar/Search/search.js
+++ b/js/src/ui/Actionbar/Search/search.js
@@ -1,0 +1,100 @@
+// Copyright 2015, 2016 Ethcore (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+import React, { Component, PropTypes } from 'react';
+import TextField from 'material-ui/TextField';
+import ActionSearch from 'material-ui/svg-icons/action/search';
+
+import { Button } from '../../';
+
+import styles from './search.css';
+
+export default class ActionbarSearch extends Component {
+  static propTypes = {
+    onChange: PropTypes.func.isRequired
+  };
+
+  state = {
+    showSearch: false,
+    searchValue: '',
+    stateChanging: false
+  }
+
+  render () {
+    const { onChange } = this.props;
+    const { showSearch } = this.state;
+
+    const onSearchClick = () => {
+      this.handleOpenSearch(!this.state.showSearch);
+    };
+
+    const onSearchBlur = () => {
+      if (this.state.searchValue.length === 0) {
+        this.handleOpenSearch(false);
+      }
+    };
+
+    const onSearchChange = (event) => {
+      const searchValue = event.target.value;
+
+      this.setState({ searchValue });
+      onChange(searchValue);
+    };
+
+    const searchInputStyle = {};
+
+    if (!showSearch) {
+      searchInputStyle.width = 0;
+    }
+
+    return (<div key='searchAccount'>
+      <TextField
+        className={ styles.searchInput }
+        style={ searchInputStyle }
+        hintText='Enter search input...'
+        hintStyle={ {
+          maxWidth: '100%',
+          overflow: 'hidden'
+        } }
+        ref='searchInput'
+        onBlur={ onSearchBlur }
+        onChange={ onSearchChange } />
+
+      <Button
+        className={ styles.searchButton }
+        icon={ <ActionSearch /> }
+        label=''
+        onClick={ onSearchClick } />
+    </div>);
+  }
+
+  handleOpenSearch = (showSearch) => {
+    if (this.state.stateChanging) return false;
+
+    this.setState({
+      showSearch: showSearch,
+      stateChanging: true
+    });
+
+    if (showSearch) {
+      this.refs.searchInput.focus();
+    }
+
+    window.setTimeout(() => {
+      this.setState({ stateChanging: false });
+    }, 450);
+  }
+}

--- a/js/src/ui/Actionbar/Search/search.js
+++ b/js/src/ui/Actionbar/Search/search.js
@@ -17,7 +17,6 @@
 import React, { Component, PropTypes } from 'react';
 // import ChipInput from 'material-ui-chip-input';
 import ChipInput from 'material-ui-chip-input/src/ChipInput';
-// import ChipInput from '../../../../../../../material-ui-chip-input/src/ChipInput';
 import ActionSearch from 'material-ui/svg-icons/action/search';
 import { uniq } from 'lodash';
 

--- a/js/src/ui/Actionbar/Search/search.js
+++ b/js/src/ui/Actionbar/Search/search.js
@@ -17,6 +17,7 @@
 import React, { Component, PropTypes } from 'react';
 // import ChipInput from 'material-ui-chip-input';
 import ChipInput from 'material-ui-chip-input/src/ChipInput';
+// import ChipInput from '../../../../../../../material-ui-chip-input/src/ChipInput';
 import ActionSearch from 'material-ui/svg-icons/action/search';
 import { uniq } from 'lodash';
 
@@ -26,45 +27,53 @@ import styles from './search.css';
 
 export default class ActionbarSearch extends Component {
   static propTypes = {
-    onChange: PropTypes.func.isRequired
+    onChange: PropTypes.func.isRequired,
+    tokens: PropTypes.array
   };
 
   state = {
     showSearch: false,
-    searchValues: [],
     stateChanging: false,
     inputValue: ''
   }
 
-  render () {
-    const { showSearch, searchValues } = this.state;
+  componentWillReceiveProps (nextProps) {
+    const { tokens } = nextProps;
 
-    const searchInputStyle = { width: 500 };
+    if (tokens.length > 0 && this.props.tokens.length === 0) {
+      this.handleOpenSearch(true, true);
+    }
+  }
+
+  render () {
+    const { showSearch } = this.state;
+    const { tokens } = this.props;
+
+    const inputContainerClasses = [ styles.inputContainer ];
 
     if (!showSearch) {
-      searchInputStyle.width = 0;
+      inputContainerClasses.push(styles.inputContainerShown);
     }
 
     return (
       <div
         className={ styles.searchcontainer }
         key='searchAccount'>
-        <ChipInput
-          persistInput
-          style={ searchInputStyle }
-          className={ styles.searchInput }
-          hintText='Enter search input...'
-          hintStyle={ {
-            maxWidth: '100%',
-            overflow: 'hidden',
-            bottom: 22
-          } }
-          ref='searchInput'
-          value={ searchValues }
-          onBlur={ this.handleSearchBlur }
-          onRequestAdd={ this.handleTokenAdd }
-          onRequestDelete={ this.handleTokenDelete }
-          onUpdateInput={ this.handleInputChange } />
+        <div className={ inputContainerClasses.join(' ') }>
+          <ChipInput
+            clearOnBlur={ false }
+            className={ styles.input }
+            hintText='Enter search input...'
+            hintStyle={ {
+              transition: 'none'
+            } }
+            ref='searchInput'
+            value={ tokens }
+            onBlur={ this.handleSearchBlur }
+            onRequestAdd={ this.handleTokenAdd }
+            onRequestDelete={ this.handleTokenDelete }
+            onUpdateInput={ this.handleInputChange } />
+        </div>
 
         <Button
           className={ styles.searchButton }
@@ -76,37 +85,33 @@ export default class ActionbarSearch extends Component {
   }
 
   handleTokenAdd = (value) => {
-    const { searchValues } = this.state;
+    const { tokens } = this.props;
 
-    const newSearchValues = uniq([].concat(searchValues, value));
+    const newSearchValues = uniq([].concat(tokens, value));
 
     this.setState({
-      searchValues: newSearchValues
+      inputValue: ''
     });
 
     this.handleSearchChange(newSearchValues);
   }
 
   handleTokenDelete = (value) => {
-    const { searchValues } = this.state;
+    const { tokens } = this.props;
 
     const newSearchValues = []
-      .concat(searchValues)
+      .concat(tokens)
       .filter(v => v !== value);
 
     this.setState({
-      searchValues: newSearchValues
+      inputValue: ''
     });
 
     this.handleSearchChange(newSearchValues);
+    this.refs.searchInput.focus();
   }
 
   handleInputChange = (value) => {
-    const { searchValues } = this.state;
-
-    const newSearchValues = uniq([].concat(searchValues, value));
-
-    this.handleSearchChange(newSearchValues);
     this.setState({ inputValue: value });
   }
 
@@ -124,15 +129,18 @@ export default class ActionbarSearch extends Component {
   }
 
   handleSearchBlur = () => {
-    const { searchValues, inputValue } = this.state;
+    window.setTimeout(() => {
+      const { inputValue } = this.state;
+      const { tokens } = this.props;
 
-    if (searchValues.length === 0 && inputValue.length === 0) {
-      this.handleOpenSearch(false);
-    }
+      if (tokens.length === 0 && inputValue.length === 0) {
+        this.handleOpenSearch(false);
+      }
+    }, 250);
   }
 
-  handleOpenSearch = (showSearch) => {
-    if (this.state.stateChanging) return false;
+  handleOpenSearch = (showSearch, force) => {
+    if (this.state.stateChanging && !force) return false;
 
     this.setState({
       showSearch: showSearch,

--- a/js/src/ui/Actionbar/Search/search.js
+++ b/js/src/ui/Actionbar/Search/search.js
@@ -34,7 +34,8 @@ export default class ActionbarSearch extends Component {
   state = {
     showSearch: false,
     stateChanging: false,
-    inputValue: ''
+    inputValue: '',
+    timeoutIds: []
   }
 
   componentWillReceiveProps (nextProps) {
@@ -42,6 +43,14 @@ export default class ActionbarSearch extends Component {
 
     if (tokens.length > 0 && this.props.tokens.length === 0) {
       this.handleOpenSearch(true, true);
+    }
+  }
+
+  componentWillUnmount () {
+    const { timeoutIds } = this.state;
+
+    if (timeoutIds.length > 0) {
+      timeoutIds.map(id => window.clearTimeout(id));
     }
   }
 
@@ -129,7 +138,7 @@ export default class ActionbarSearch extends Component {
   }
 
   handleSearchBlur = () => {
-    window.setTimeout(() => {
+    const timeoutId = window.setTimeout(() => {
       const { inputValue } = this.state;
       const { tokens } = this.props;
 
@@ -137,6 +146,10 @@ export default class ActionbarSearch extends Component {
         this.handleOpenSearch(false);
       }
     }, 250);
+
+    this.setState({
+      timeoutIds: [].concat(this.state.timeoutIds, timeoutId)
+    });
   }
 
   handleOpenSearch = (showSearch, force) => {
@@ -153,8 +166,12 @@ export default class ActionbarSearch extends Component {
       this.refs.searchInput.getInputNode().blur();
     }
 
-    window.setTimeout(() => {
+    const timeoutId = window.setTimeout(() => {
       this.setState({ stateChanging: false });
     }, 450);
+
+    this.setState({
+      timeoutIds: [].concat(this.state.timeoutIds, timeoutId)
+    });
   }
 }

--- a/js/src/ui/Actionbar/Sort/index.js
+++ b/js/src/ui/Actionbar/Sort/index.js
@@ -1,0 +1,17 @@
+// Copyright 2015, 2016 Ethcore (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+export default from './sort';

--- a/js/src/ui/Actionbar/Sort/sort.css
+++ b/js/src/ui/Actionbar/Sort/sort.css
@@ -1,0 +1,20 @@
+/* Copyright 2015, 2016 Ethcore (UK) Ltd.
+/* This file is part of Parity.
+/*
+/* Parity is free software: you can redistribute it and/or modify
+/* it under the terms of the GNU General Public License as published by
+/* the Free Software Foundation, either version 3 of the License, or
+/* (at your option) any later version.
+/*
+/* Parity is distributed in the hope that it will be useful,
+/* but WITHOUT ANY WARRANTY; without even the implied warranty of
+/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+/* GNU General Public License for more details.
+/*
+/* You should have received a copy of the GNU General Public License
+/* along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+.sortButton {
+  min-width: 50px !important;
+}

--- a/js/src/ui/Actionbar/Sort/sort.js
+++ b/js/src/ui/Actionbar/Sort/sort.js
@@ -51,6 +51,7 @@ export default class ActionbarSort extends Component {
         targetOrigin={ { horizontal: 'right', vertical: 'top' } }
         anchorOrigin={ { horizontal: 'right', vertical: 'top' } }
         >
+        <MenuItem value='' primaryText='Default' />
         <MenuItem value='tags' primaryText='Sort by tags' />
         <MenuItem value='name' primaryText='Sort by name' />
       </IconMenu>

--- a/js/src/ui/Actionbar/Sort/sort.js
+++ b/js/src/ui/Actionbar/Sort/sort.js
@@ -1,0 +1,72 @@
+// Copyright 2015, 2016 Ethcore (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+import React, { Component, PropTypes } from 'react';
+import IconMenu from 'material-ui/IconMenu';
+import MenuItem from 'material-ui/MenuItem';
+
+import SortIcon from 'material-ui/svg-icons/content/sort';
+
+import { Button } from '../../';
+
+import styles from './sort.css';
+
+export default class ActionbarSort extends Component {
+  static propTypes = {
+    onChange: PropTypes.func.isRequired,
+    order: PropTypes.string
+  };
+
+  state = {
+    menuOpen: false
+  }
+
+  render () {
+    return (
+      <IconMenu
+        iconButtonElement={
+          <Button
+            className={ styles.sortButton }
+            label=''
+            icon={ <SortIcon /> }
+            onClick={ this.handleMenuOpen }
+            />
+        }
+        open={ this.state.menuOpen }
+        onRequestChange={ this.handleMenuChange }
+        onItemTouchTap={ this.handleSortChange }
+        targetOrigin={ { horizontal: 'right', vertical: 'top' } }
+        anchorOrigin={ { horizontal: 'right', vertical: 'top' } }
+        >
+        <MenuItem value='tags' primaryText='Sort by tags' />
+        <MenuItem value='name' primaryText='Sort by name' />
+      </IconMenu>
+    );
+  }
+
+  handleSortChange = (event, child) => {
+    const order = child.props.value;
+    this.props.onChange(order);
+  }
+
+  handleMenuOpen = () => {
+    this.setState({ menuOpen: true });
+  }
+
+  handleMenuChange = (open) => {
+    this.setState({ menuOpen: open });
+  }
+}

--- a/js/src/ui/Container/container.css
+++ b/js/src/ui/Container/container.css
@@ -15,13 +15,15 @@
 /* along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 */
 .container {
-  padding: 0em
+  padding: 0em;
 }
 
 .padded {
   padding: 1.5em;
   background: rgba(0, 0, 0, 0.8) !important;
   border-radius: 0 !important;
+  position: relative;
+  overflow: auto;
 }
 
 .light .padded {

--- a/js/src/ui/Tags/index.js
+++ b/js/src/ui/Tags/index.js
@@ -1,0 +1,17 @@
+// Copyright 2015, 2016 Ethcore (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+export default from './tags';

--- a/js/src/ui/Tags/tags.css
+++ b/js/src/ui/Tags/tags.css
@@ -15,7 +15,7 @@
 /* along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-:local(.tags) {
+.tags {
   display: flex;
   flex-wrap: wrap;
   position: absolute;
@@ -23,14 +23,14 @@
   top: 0;
 }
 
-:local(.tag) {
-  font-size: 0.8rem;
+.tag {
+  font-size: 0.75rem;
   background: rgba(255, 255, 255, 0.07);
   border-radius: 16px;
   margin: 0.75em 0.5em 0 0;
   padding: 0.25em 1em;
+}
 
-  &.tagClickable:hover {
-    cursor: pointer;
-  }
+.tagClickable:hover {
+  cursor: pointer;
 }

--- a/js/src/ui/Tags/tags.css
+++ b/js/src/ui/Tags/tags.css
@@ -1,9 +1,13 @@
 .tags {
   display: flex;
   flex-wrap: wrap;
+  position: absolute;
+  right: 0.25rem;
+  top: 0;
 }
 
 .tag {
+  font-size: 0.9rem;
   background: rgba(255, 255, 255, 0.07);
   border-radius: 16px;
   margin: 0.75em 0.5em 0 0;

--- a/js/src/ui/Tags/tags.css
+++ b/js/src/ui/Tags/tags.css
@@ -1,0 +1,11 @@
+.tags {
+  display: flex;
+  flex-wrap: wrap;
+}
+
+.tag {
+  background: rgba(255, 255, 255, 0.07);
+  border-radius: 16px;
+  margin: 0.75em 0.5em 0 0;
+  padding: 0.25em 1em;
+}

--- a/js/src/ui/Tags/tags.js
+++ b/js/src/ui/Tags/tags.js
@@ -15,7 +15,6 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 import React, { Component, PropTypes } from 'react';
-import Chip from 'material-ui/Chip';
 
 import styles from './tags.css';
 

--- a/js/src/ui/Tags/tags.js
+++ b/js/src/ui/Tags/tags.js
@@ -16,11 +16,12 @@
 
 import React, { Component, PropTypes } from 'react';
 
-import styles from './tags.css';
+import styles from './tags.less';
 
 export default class Tags extends Component {
   static propTypes = {
-    tags: PropTypes.array
+    tags: PropTypes.array,
+    handleAddSearchToken: PropTypes.func
   }
 
   render () {
@@ -30,10 +31,26 @@ export default class Tags extends Component {
   }
 
   renderTags () {
+    const { handleAddSearchToken } = this.props;
     const tags = this.props.tags || [];
 
-    return tags.map((tag, idx) => (
-      <div key={ idx } className={ styles.tag }>{ tag }</div>
-    ));
+    const tagClasses = handleAddSearchToken
+      ? [ styles.tag, styles.tagClickable ]
+      : [ styles.tag ]
+
+    return tags.map((tag, idx) => {
+      const onClick = handleAddSearchToken
+        ? () => handleAddSearchToken(tag)
+        : null;
+
+      return (
+        <div
+          key={ idx }
+          className={ tagClasses.join(' ') }
+          onClick={ onClick }>
+          { tag }
+        </div>
+      );
+    });
   }
 }

--- a/js/src/ui/Tags/tags.js
+++ b/js/src/ui/Tags/tags.js
@@ -16,7 +16,7 @@
 
 import React, { Component, PropTypes } from 'react';
 
-import styles from './tags.less';
+import styles from './tags.css';
 
 export default class Tags extends Component {
   static propTypes = {
@@ -36,7 +36,7 @@ export default class Tags extends Component {
 
     const tagClasses = handleAddSearchToken
       ? [ styles.tag, styles.tagClickable ]
-      : [ styles.tag ]
+      : [ styles.tag ];
 
     return tags.map((tag, idx) => {
       const onClick = handleAddSearchToken

--- a/js/src/ui/Tags/tags.js
+++ b/js/src/ui/Tags/tags.js
@@ -1,0 +1,40 @@
+// Copyright 2015, 2016 Ethcore (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+import React, { Component, PropTypes } from 'react';
+import Chip from 'material-ui/Chip';
+
+import styles from './tags.css';
+
+export default class Tags extends Component {
+  static propTypes = {
+    tags: PropTypes.array
+  }
+
+  render () {
+    return (<div className={ styles.tags }>
+      { this.renderTags() }
+    </div>);
+  }
+
+  renderTags () {
+    const tags = this.props.tags || [];
+
+    return tags.map((tag, idx) => (
+      <div key={ idx } className={ styles.tag }>{ tag }</div>
+    ));
+  }
+}

--- a/js/src/ui/Tags/tags.less
+++ b/js/src/ui/Tags/tags.less
@@ -1,3 +1,20 @@
+/* Copyright 2015, 2016 Ethcore (UK) Ltd.
+/* This file is part of Parity.
+/*
+/* Parity is free software: you can redistribute it and/or modify
+/* it under the terms of the GNU General Public License as published by
+/* the Free Software Foundation, either version 3 of the License, or
+/* (at your option) any later version.
+/*
+/* Parity is distributed in the hope that it will be useful,
+/* but WITHOUT ANY WARRANTY; without even the implied warranty of
+/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+/* GNU General Public License for more details.
+/*
+/* You should have received a copy of the GNU General Public License
+/* along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
 :local(.tags) {
   display: flex;
   flex-wrap: wrap;

--- a/js/src/ui/Tags/tags.less
+++ b/js/src/ui/Tags/tags.less
@@ -1,4 +1,4 @@
-.tags {
+:local(.tags) {
   display: flex;
   flex-wrap: wrap;
   position: absolute;
@@ -6,10 +6,14 @@
   top: 0;
 }
 
-.tag {
+:local(.tag) {
   font-size: 0.9rem;
   background: rgba(255, 255, 255, 0.07);
   border-radius: 16px;
   margin: 0.75em 0.5em 0 0;
   padding: 0.25em 1em;
+
+  &.tagClickable:hover {
+    cursor: pointer;
+  }
 }

--- a/js/src/ui/Tags/tags.less
+++ b/js/src/ui/Tags/tags.less
@@ -7,7 +7,7 @@
 }
 
 :local(.tag) {
-  font-size: 0.9rem;
+  font-size: 0.8rem;
   background: rgba(255, 255, 255, 0.07);
   border-radius: 16px;
   margin: 0.75em 0.5em 0 0;

--- a/js/src/ui/index.js
+++ b/js/src/ui/index.js
@@ -15,6 +15,7 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 import Actionbar from './Actionbar';
+import ActionbarSearch from './Actionbar/Search';
 import Badge from './Badge';
 import Balance from './Balance';
 import Button from './Button';
@@ -37,6 +38,7 @@ import TxHash from './TxHash';
 
 export {
   Actionbar,
+  ActionbarSearch,
   AddressSelect,
   Badge,
   Balance,

--- a/js/src/ui/index.js
+++ b/js/src/ui/index.js
@@ -31,6 +31,7 @@ import muiTheme from './Theme';
 import Page from './Page';
 import ParityBackground from './ParityBackground';
 import SignerIcon from './SignerIcon';
+import Tags  from './Tags';
 import Tooltips, { Tooltip } from './Tooltips';
 import TxHash from './TxHash';
 
@@ -62,6 +63,7 @@ export {
   Page,
   ParityBackground,
   SignerIcon,
+  Tags,
   Tooltip,
   Tooltips,
   TxHash

--- a/js/src/ui/index.js
+++ b/js/src/ui/index.js
@@ -16,6 +16,7 @@
 
 import Actionbar from './Actionbar';
 import ActionbarSearch from './Actionbar/Search';
+import ActionbarSort from './Actionbar/Sort';
 import Badge from './Badge';
 import Balance from './Balance';
 import Button from './Button';
@@ -39,6 +40,7 @@ import TxHash from './TxHash';
 export {
   Actionbar,
   ActionbarSearch,
+  ActionbarSort,
   AddressSelect,
   Badge,
   Balance,

--- a/js/src/ui/index.js
+++ b/js/src/ui/index.js
@@ -31,7 +31,7 @@ import muiTheme from './Theme';
 import Page from './Page';
 import ParityBackground from './ParityBackground';
 import SignerIcon from './SignerIcon';
-import Tags  from './Tags';
+import Tags from './Tags';
 import Tooltips, { Tooltip } from './Tooltips';
 import TxHash from './TxHash';
 

--- a/js/src/views/Account/Header/header.css
+++ b/js/src/views/Account/Header/header.css
@@ -14,7 +14,7 @@
 /* You should have received a copy of the GNU General Public License
 /* along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 */
-.balances {
+.balances, .tags {
   clear: both;
 }
 

--- a/js/src/views/Account/Header/header.js
+++ b/js/src/views/Account/Header/header.js
@@ -16,7 +16,7 @@
 
 import React, { Component, PropTypes } from 'react';
 
-import { Balance, Container, ContainerTitle, IdentityIcon, IdentityName } from '../../../ui';
+import { Balance, Container, ContainerTitle, IdentityIcon, IdentityName, Tags } from '../../../ui';
 
 import styles from './header.css';
 
@@ -69,6 +69,9 @@ export default class Header extends Component {
             { meta.description }
           </div>
           { this.renderTxCount() }
+        </div>
+        <div className={ styles.tags }>
+          <Tags tags={ meta.tags } />
         </div>
         <div className={ styles.balances }>
           <Balance

--- a/js/src/views/Accounts/List/list.js
+++ b/js/src/views/Accounts/List/list.js
@@ -27,7 +27,8 @@ export default class List extends Component {
     balances: PropTypes.object,
     link: PropTypes.string,
     search: PropTypes.array,
-    empty: PropTypes.bool
+    empty: PropTypes.bool,
+    handleAddSearchToken: PropTypes.func
   };
 
   render () {
@@ -39,7 +40,7 @@ export default class List extends Component {
   }
 
   renderAccounts () {
-    const { accounts, balances, link, empty } = this.props;
+    const { accounts, balances, link, empty, handleAddSearchToken } = this.props;
 
     if (empty) {
       return (
@@ -64,7 +65,8 @@ export default class List extends Component {
           <Summary
             link={ link }
             account={ account }
-            balance={ balance } />
+            balance={ balance }
+            handleAddSearchToken={ handleAddSearchToken } />
         </div>
       );
     });

--- a/js/src/views/Accounts/List/list.js
+++ b/js/src/views/Accounts/List/list.js
@@ -28,6 +28,7 @@ export default class List extends Component {
     link: PropTypes.string,
     search: PropTypes.array,
     empty: PropTypes.bool,
+    order: PropTypes.string,
     handleAddSearchToken: PropTypes.func
   };
 
@@ -52,7 +53,7 @@ export default class List extends Component {
       );
     }
 
-    const addresses = this.getFilteredAddresses();
+    const addresses = this.getAddresses();
 
     return addresses.map((address, idx) => {
       const account = accounts[address] || {};
@@ -69,6 +70,44 @@ export default class List extends Component {
             handleAddSearchToken={ handleAddSearchToken } />
         </div>
       );
+    });
+  }
+
+  getAddresses () {
+    const filteredAddresses = this.getFilteredAddresses();
+    return this.sortAddresses(filteredAddresses);
+  }
+
+  sortAddresses (addresses) {
+    const { order } = this.props;
+
+    if (!order || ['tags', 'name'].indexOf(order) === -1) {
+      return addresses;
+    }
+
+    const { accounts } = this.props;
+
+    return addresses.sort((addressA, addressB) => {
+      const accountA = accounts[addressA];
+      const accountB = accounts[addressB];
+
+      if (order === 'name') {
+        return accountA.name.localeCompare(accountB.name);
+      }
+
+      if (order === 'tags') {
+        const tagsA = [].concat(accountA.meta.tags)
+          .filter(t => t)
+          .sort();
+        const tagsB = [].concat(accountB.meta.tags)
+          .filter(t => t)
+          .sort();
+
+        if (tagsA.length === 0) return 1;
+        if (tagsB.length === 0) return -1;
+
+        return tagsA.join('').localeCompare(tagsB.join(''));
+      }
     });
   }
 

--- a/js/src/views/Accounts/List/list.js
+++ b/js/src/views/Accounts/List/list.js
@@ -26,6 +26,7 @@ export default class List extends Component {
     accounts: PropTypes.object,
     balances: PropTypes.object,
     link: PropTypes.string,
+    search: PropTypes.string,
     empty: PropTypes.bool
   };
 
@@ -38,7 +39,7 @@ export default class List extends Component {
   }
 
   renderAccounts () {
-    const { accounts, balances, link, empty } = this.props;
+    const { accounts, balances, link, empty, search } = this.props;
 
     if (empty) {
       return (
@@ -50,7 +51,20 @@ export default class List extends Component {
       );
     }
 
-    return Object.keys(accounts).map((address, idx) => {
+    const searchValue = (search || '').toLowerCase();
+    const filteredAddresses = (searchValue && searchValue.length > 0)
+      ? Object.keys(accounts)
+          .filter((address) => {
+            const account = accounts[address];
+            const tags = account.meta.tags || [];
+
+            return tags
+              .filter((tag) => tag.toLowerCase().indexOf(searchValue) >= 0)
+              .length > 0;
+          })
+      : Object.keys(accounts);
+
+    return filteredAddresses.map((address, idx) => {
       const account = accounts[address] || {};
       const balance = balances[address] || {};
 

--- a/js/src/views/Accounts/Summary/summary.js
+++ b/js/src/views/Accounts/Summary/summary.js
@@ -48,12 +48,12 @@ export default class Summary extends Component {
 
     return (
       <Container>
+        <Tags tags={ tags } />
         <IdentityIcon
           address={ address } />
         <ContainerTitle
           title={ <Link to={ viewLink }>{ <IdentityName address={ address } unknown /> }</Link> }
           byline={ address } />
-        <Tags tags={ tags } />
         <Balance
           balance={ balance } />
         { children }

--- a/js/src/views/Accounts/Summary/summary.js
+++ b/js/src/views/Accounts/Summary/summary.js
@@ -28,7 +28,8 @@ export default class Summary extends Component {
     account: PropTypes.object.isRequired,
     balance: PropTypes.object.isRequired,
     link: PropTypes.string,
-    children: PropTypes.node
+    children: PropTypes.node,
+    handleAddSearchToken: PropTypes.func
   }
 
   state = {
@@ -36,7 +37,7 @@ export default class Summary extends Component {
   }
 
   render () {
-    const { account, balance, children, link } = this.props;
+    const { account, balance, children, link, handleAddSearchToken } = this.props;
     const { tags } = account.meta;
 
     if (!account) {
@@ -48,7 +49,7 @@ export default class Summary extends Component {
 
     return (
       <Container>
-        <Tags tags={ tags } />
+        <Tags tags={ tags } handleAddSearchToken={ handleAddSearchToken } />
         <IdentityIcon
           address={ address } />
         <ContainerTitle

--- a/js/src/views/Accounts/Summary/summary.js
+++ b/js/src/views/Accounts/Summary/summary.js
@@ -17,7 +17,7 @@
 import React, { Component, PropTypes } from 'react';
 import { Link } from 'react-router';
 
-import { Balance, Container, ContainerTitle, IdentityIcon, IdentityName } from '../../../ui';
+import { Balance, Container, ContainerTitle, IdentityIcon, IdentityName, Tags } from '../../../ui';
 
 export default class Summary extends Component {
   static contextTypes = {
@@ -37,6 +37,7 @@ export default class Summary extends Component {
 
   render () {
     const { account, balance, children, link } = this.props;
+    const { tags } = account.meta;
 
     if (!account) {
       return null;
@@ -52,6 +53,7 @@ export default class Summary extends Component {
         <ContainerTitle
           title={ <Link to={ viewLink }>{ <IdentityName address={ address } unknown /> }</Link> }
           byline={ address } />
+        <Tags tags={ tags } />
         <Balance
           balance={ balance } />
         { children }

--- a/js/src/views/Accounts/Summary/summary.js
+++ b/js/src/views/Accounts/Summary/summary.js
@@ -42,15 +42,16 @@ export default class Summary extends Component {
       return null;
     }
 
-    const viewLink = `/${link || 'account'}/${account.address}`;
+    const { address } = account;
+    const viewLink = `/${link || 'account'}/${address}`;
 
     return (
       <Container>
         <IdentityIcon
-          address={ account.address } />
+          address={ address } />
         <ContainerTitle
-          title={ <Link to={ viewLink }>{ <IdentityName address={ account.address } unknown /> }</Link> }
-          byline={ account.address } />
+          title={ <Link to={ viewLink }>{ <IdentityName address={ address } unknown /> }</Link> }
+          byline={ address } />
         <Balance
           balance={ balance } />
         { children }

--- a/js/src/views/Accounts/accounts.js
+++ b/js/src/views/Accounts/accounts.js
@@ -39,12 +39,12 @@ class Accounts extends Component {
   state = {
     addressBook: false,
     newDialog: false,
-    searchValue: ''
+    searchValues: []
   }
 
   render () {
     const { accounts, hasAccounts, balances } = this.props;
-    const { searchValue } = this.state;
+    const { searchValues } = this.state;
 
     return (
       <div className={ styles.accounts }>
@@ -52,7 +52,7 @@ class Accounts extends Component {
         { this.renderActionbar() }
         <Page>
           <List
-            search={ searchValue }
+            search={ searchValues }
             accounts={ accounts }
             balances={ balances }
             empty={ !hasAccounts } />
@@ -65,8 +65,8 @@ class Accounts extends Component {
   }
 
   renderSearchButton () {
-    const onChange = (value) => {
-      this.setState({ searchValue: value });
+    const onChange = (searchValues) => {
+      this.setState({ searchValues });
     };
 
     return (<ActionbarSearch

--- a/js/src/views/Accounts/accounts.js
+++ b/js/src/views/Accounts/accounts.js
@@ -73,10 +73,12 @@ class Accounts extends Component {
       this.setState({ searchValues });
     };
 
-    return (<ActionbarSearch
-      key='searchAccount'
-      tokens={ this.state.searchValues }
-      onChange={ onChange } />);
+    return (
+      <ActionbarSearch
+        key='searchAccount'
+        tokens={ this.state.searchValues }
+        onChange={ onChange } />
+    );
   }
 
   renderSortButton () {
@@ -84,10 +86,12 @@ class Accounts extends Component {
       this.setState({ sortOrder });
     };
 
-    return (<ActionbarSort
-      key='sortAccounts'
-      order={ this.state.sortOrder }
-      onChange={ onChange } />);
+    return (
+      <ActionbarSort
+        key='sortAccounts'
+        order={ this.state.sortOrder }
+        onChange={ onChange } />
+    );
   }
 
   renderActionbar () {

--- a/js/src/views/Accounts/accounts.js
+++ b/js/src/views/Accounts/accounts.js
@@ -18,6 +18,7 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import ContentAdd from 'material-ui/svg-icons/content/add';
+import { uniq } from 'lodash';
 
 import List from './List';
 import { CreateAccount } from '../../modals';
@@ -55,7 +56,8 @@ class Accounts extends Component {
             search={ searchValues }
             accounts={ accounts }
             balances={ balances }
-            empty={ !hasAccounts } />
+            empty={ !hasAccounts }
+            handleAddSearchToken={ this.onAddSearchToken } />
           <Tooltip
             className={ styles.accountTooltip }
             text='your accounts are visible for easy access, allowing you to edit the meta information, make transfers, view transactions and fund the account' />
@@ -71,6 +73,7 @@ class Accounts extends Component {
 
     return (<ActionbarSearch
       key='searchAccount'
+      tokens={ this.state.searchValues }
       onChange={ onChange } />);
   }
 
@@ -112,6 +115,12 @@ class Accounts extends Component {
         onClose={ this.onNewAccountClose }
         onUpdate={ this.onNewAccountUpdate } />
     );
+  }
+
+  onAddSearchToken = (token) => {
+    const { searchValues } = this.state;
+    const newSearchValues = uniq([].concat(searchValues, token));
+    this.setState({ searchValues: newSearchValues });
   }
 
   onNewAccountClick = () => {

--- a/js/src/views/Accounts/accounts.js
+++ b/js/src/views/Accounts/accounts.js
@@ -21,7 +21,7 @@ import ContentAdd from 'material-ui/svg-icons/content/add';
 
 import List from './List';
 import { CreateAccount } from '../../modals';
-import { Actionbar, Button, Page, Tooltip } from '../../ui';
+import { Actionbar, ActionbarSearch, Button, Page, Tooltip } from '../../ui';
 
 import styles from './accounts.css';
 
@@ -38,11 +38,13 @@ class Accounts extends Component {
 
   state = {
     addressBook: false,
-    newDialog: false
+    newDialog: false,
+    searchValue: ''
   }
 
   render () {
     const { accounts, hasAccounts, balances } = this.props;
+    const { searchValue } = this.state;
 
     return (
       <div className={ styles.accounts }>
@@ -50,6 +52,7 @@ class Accounts extends Component {
         { this.renderActionbar() }
         <Page>
           <List
+            search={ searchValue }
             accounts={ accounts }
             balances={ balances }
             empty={ !hasAccounts } />
@@ -61,13 +64,25 @@ class Accounts extends Component {
     );
   }
 
+  renderSearchButton () {
+    const onChange = (value) => {
+      this.setState({ searchValue: value });
+    };
+
+    return (<ActionbarSearch
+      key='searchAccount'
+      onChange={ onChange } />);
+  }
+
   renderActionbar () {
     const buttons = [
       <Button
         key='newAccount'
         icon={ <ContentAdd /> }
         label='new account'
-        onClick={ this.onNewAccountClick } />
+        onClick={ this.onNewAccountClick } />,
+
+      this.renderSearchButton()
     ];
 
     return (

--- a/js/src/views/Accounts/accounts.js
+++ b/js/src/views/Accounts/accounts.js
@@ -22,7 +22,7 @@ import { uniq } from 'lodash';
 
 import List from './List';
 import { CreateAccount } from '../../modals';
-import { Actionbar, ActionbarSearch, Button, Page, Tooltip } from '../../ui';
+import { Actionbar, ActionbarSearch, ActionbarSort, Button, Page, Tooltip } from '../../ui';
 
 import styles from './accounts.css';
 
@@ -40,12 +40,13 @@ class Accounts extends Component {
   state = {
     addressBook: false,
     newDialog: false,
+    sortOrder: '',
     searchValues: []
   }
 
   render () {
     const { accounts, hasAccounts, balances } = this.props;
-    const { searchValues } = this.state;
+    const { searchValues, sortOrder } = this.state;
 
     return (
       <div className={ styles.accounts }>
@@ -57,6 +58,7 @@ class Accounts extends Component {
             accounts={ accounts }
             balances={ balances }
             empty={ !hasAccounts }
+            order={ sortOrder }
             handleAddSearchToken={ this.onAddSearchToken } />
           <Tooltip
             className={ styles.accountTooltip }
@@ -77,6 +79,17 @@ class Accounts extends Component {
       onChange={ onChange } />);
   }
 
+  renderSortButton () {
+    const onChange = (sortOrder) => {
+      this.setState({ sortOrder });
+    };
+
+    return (<ActionbarSort
+      key='sortAccounts'
+      order={ this.state.sortOrder }
+      onChange={ onChange } />);
+  }
+
   renderActionbar () {
     const buttons = [
       <Button
@@ -85,7 +98,8 @@ class Accounts extends Component {
         label='new account'
         onClick={ this.onNewAccountClick } />,
 
-      this.renderSearchButton()
+      this.renderSearchButton(),
+      this.renderSortButton()
     ];
 
     return (

--- a/js/src/views/Addresses/addresses.js
+++ b/js/src/views/Addresses/addresses.js
@@ -18,6 +18,7 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import ContentAdd from 'material-ui/svg-icons/content/add';
+import { uniq } from 'lodash';
 
 import List from '../Accounts/List';
 import { AddAddress } from '../../modals';
@@ -55,19 +56,21 @@ class Addresses extends Component {
             search={ searchValues }
             accounts={ contacts }
             balances={ balances }
-            empty={ !hasContacts } />
+            empty={ !hasContacts }
+            handleAddSearchToken={ this.onAddSearchToken } />
         </Page>
       </div>
     );
   }
 
   renderSearchButton () {
-    const onChange = (values) => {
-      this.setState({ searchValues: values });
+    const onChange = (searchValues) => {
+      this.setState({ searchValues });
     };
 
     return (<ActionbarSearch
       key='searchAddress'
+      tokens={ this.state.searchValues }
       onChange={ onChange } />);
   }
 
@@ -103,6 +106,12 @@ class Addresses extends Component {
         contacts={ contacts }
         onClose={ this.onCloseAdd } />
     );
+  }
+
+  onAddSearchToken = (token) => {
+    const { searchValues } = this.state;
+    const newSearchValues = uniq([].concat(searchValues, token));
+    this.setState({ searchValues: newSearchValues });
   }
 
   onOpenAdd = () => {

--- a/js/src/views/Addresses/addresses.js
+++ b/js/src/views/Addresses/addresses.js
@@ -22,7 +22,7 @@ import { uniq } from 'lodash';
 
 import List from '../Accounts/List';
 import { AddAddress } from '../../modals';
-import { Actionbar, ActionbarSearch, Button, Page } from '../../ui';
+import { Actionbar, ActionbarSearch, ActionbarSort, Button, Page } from '../../ui';
 
 import styles from './addresses.css';
 
@@ -39,12 +39,13 @@ class Addresses extends Component {
 
   state = {
     showAdd: false,
+    sortOrder: '',
     searchValues: []
   }
 
   render () {
     const { balances, contacts, hasContacts } = this.props;
-    const { searchValues } = this.state;
+    const { searchValues, sortOrder } = this.state;
 
     return (
       <div className={ styles.addresses }>
@@ -57,10 +58,22 @@ class Addresses extends Component {
             accounts={ contacts }
             balances={ balances }
             empty={ !hasContacts }
+            order={ sortOrder }
             handleAddSearchToken={ this.onAddSearchToken } />
         </Page>
       </div>
     );
+  }
+
+  renderSortButton () {
+    const onChange = (sortOrder) => {
+      this.setState({ sortOrder });
+    };
+
+    return (<ActionbarSort
+      key='sortAccounts'
+      order={ this.state.sortOrder }
+      onChange={ onChange } />);
   }
 
   renderSearchButton () {
@@ -82,7 +95,8 @@ class Addresses extends Component {
         label='new address'
         onClick={ this.onOpenAdd } />,
 
-      this.renderSearchButton()
+      this.renderSearchButton(),
+      this.renderSortButton()
     ];
 
     return (

--- a/js/src/views/Addresses/addresses.js
+++ b/js/src/views/Addresses/addresses.js
@@ -21,7 +21,7 @@ import ContentAdd from 'material-ui/svg-icons/content/add';
 
 import List from '../Accounts/List';
 import { AddAddress } from '../../modals';
-import { Actionbar, Button, Page } from '../../ui';
+import { Actionbar, ActionbarSearch, Button, Page } from '../../ui';
 
 import styles from './addresses.css';
 
@@ -37,11 +37,13 @@ class Addresses extends Component {
   }
 
   state = {
-    showAdd: false
+    showAdd: false,
+    searchValue: ''
   }
 
   render () {
     const { balances, contacts, hasContacts } = this.props;
+    const { searchValue } = this.state;
 
     return (
       <div className={ styles.addresses }>
@@ -50,6 +52,7 @@ class Addresses extends Component {
         <Page>
           <List
             link='address'
+            search={ searchValue }
             accounts={ contacts }
             balances={ balances }
             empty={ !hasContacts } />
@@ -58,13 +61,25 @@ class Addresses extends Component {
     );
   }
 
+  renderSearchButton () {
+    const onChange = (value) => {
+      this.setState({ searchValue: value });
+    };
+
+    return (<ActionbarSearch
+      key='searchAddress'
+      onChange={ onChange } />);
+  }
+
   renderActionbar () {
     const buttons = [
       <Button
         key='newAddress'
         icon={ <ContentAdd /> }
         label='new address'
-        onClick={ this.onOpenAdd } />
+        onClick={ this.onOpenAdd } />,
+
+      this.renderSearchButton()
     ];
 
     return (

--- a/js/src/views/Addresses/addresses.js
+++ b/js/src/views/Addresses/addresses.js
@@ -38,12 +38,12 @@ class Addresses extends Component {
 
   state = {
     showAdd: false,
-    searchValue: ''
+    searchValues: []
   }
 
   render () {
     const { balances, contacts, hasContacts } = this.props;
-    const { searchValue } = this.state;
+    const { searchValues } = this.state;
 
     return (
       <div className={ styles.addresses }>
@@ -52,7 +52,7 @@ class Addresses extends Component {
         <Page>
           <List
             link='address'
-            search={ searchValue }
+            search={ searchValues }
             accounts={ contacts }
             balances={ balances }
             empty={ !hasContacts } />
@@ -62,8 +62,8 @@ class Addresses extends Component {
   }
 
   renderSearchButton () {
-    const onChange = (value) => {
-      this.setState({ searchValue: value });
+    const onChange = (values) => {
+      this.setState({ searchValues: values });
     };
 
     return (<ActionbarSearch

--- a/js/src/views/Addresses/addresses.js
+++ b/js/src/views/Addresses/addresses.js
@@ -70,10 +70,12 @@ class Addresses extends Component {
       this.setState({ sortOrder });
     };
 
-    return (<ActionbarSort
-      key='sortAccounts'
-      order={ this.state.sortOrder }
-      onChange={ onChange } />);
+    return (
+      <ActionbarSort
+        key='sortAccounts'
+        order={ this.state.sortOrder }
+        onChange={ onChange } />
+    );
   }
 
   renderSearchButton () {
@@ -81,10 +83,12 @@ class Addresses extends Component {
       this.setState({ searchValues });
     };
 
-    return (<ActionbarSearch
-      key='searchAddress'
-      tokens={ this.state.searchValues }
-      onChange={ onChange } />);
+    return (
+      <ActionbarSearch
+        key='searchAddress'
+        tokens={ this.state.searchValues }
+        onChange={ onChange } />
+    );
   }
 
   renderActionbar () {

--- a/js/src/views/Contracts/contracts.js
+++ b/js/src/views/Contracts/contracts.js
@@ -19,7 +19,7 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import ContentAdd from 'material-ui/svg-icons/content/add';
 
-import { Actionbar, Button, Page } from '../../ui';
+import { Actionbar, ActionbarSearch, Button, Page } from '../../ui';
 import { AddContract, DeployContract } from '../../modals';
 
 import List from '../Accounts/List';
@@ -40,11 +40,13 @@ class Contracts extends Component {
 
   state = {
     addContract: false,
-    deployContract: false
+    deployContract: false,
+    searchValue: ''
   }
 
   render () {
     const { contracts, hasContracts, balances } = this.props;
+    const { searchValue } = this.state;
 
     return (
       <div className={ styles.contracts }>
@@ -55,12 +57,23 @@ class Contracts extends Component {
         <Page>
           <List
             link='contract'
+            search={ searchValue }
             accounts={ contracts }
             balances={ balances }
             empty={ !hasContracts } />
         </Page>
       </div>
     );
+  }
+
+  renderSearchButton () {
+    const onChange = (value) => {
+      this.setState({ searchValue: value });
+    };
+
+    return (<ActionbarSearch
+      key='searchContract'
+      onChange={ onChange } />);
   }
 
   renderActionbar () {
@@ -74,7 +87,9 @@ class Contracts extends Component {
         key='deployContract'
         icon={ <ContentAdd /> }
         label='deploy contract'
-        onClick={ this.onDeployContract } />
+        onClick={ this.onDeployContract } />,
+
+        this.renderSearchButton()
     ];
 
     return (

--- a/js/src/views/Contracts/contracts.js
+++ b/js/src/views/Contracts/contracts.js
@@ -20,7 +20,7 @@ import { bindActionCreators } from 'redux';
 import ContentAdd from 'material-ui/svg-icons/content/add';
 import { uniq } from 'lodash';
 
-import { Actionbar, ActionbarSearch, Button, Page } from '../../ui';
+import { Actionbar, ActionbarSearch, ActionbarSort, Button, Page } from '../../ui';
 import { AddContract, DeployContract } from '../../modals';
 
 import List from '../Accounts/List';
@@ -42,12 +42,13 @@ class Contracts extends Component {
   state = {
     addContract: false,
     deployContract: false,
+    sortOrder: '',
     searchValues: []
   }
 
   render () {
     const { contracts, hasContracts, balances } = this.props;
-    const { searchValues } = this.state;
+    const { searchValues, sortOrder } = this.state;
 
     return (
       <div className={ styles.contracts }>
@@ -62,10 +63,22 @@ class Contracts extends Component {
             accounts={ contracts }
             balances={ balances }
             empty={ !hasContracts }
+            order={ sortOrder }
             handleAddSearchToken={ this.onAddSearchToken } />
         </Page>
       </div>
     );
+  }
+
+  renderSortButton () {
+    const onChange = (sortOrder) => {
+      this.setState({ sortOrder });
+    };
+
+    return (<ActionbarSort
+      key='sortAccounts'
+      order={ this.state.sortOrder }
+      onChange={ onChange } />);
   }
 
   renderSearchButton () {
@@ -92,7 +105,8 @@ class Contracts extends Component {
         label='deploy contract'
         onClick={ this.onDeployContract } />,
 
-      this.renderSearchButton()
+      this.renderSearchButton(),
+      this.renderSortButton()
     ];
 
     return (

--- a/js/src/views/Contracts/contracts.js
+++ b/js/src/views/Contracts/contracts.js
@@ -89,7 +89,7 @@ class Contracts extends Component {
         label='deploy contract'
         onClick={ this.onDeployContract } />,
 
-        this.renderSearchButton()
+      this.renderSearchButton()
     ];
 
     return (

--- a/js/src/views/Contracts/contracts.js
+++ b/js/src/views/Contracts/contracts.js
@@ -41,12 +41,12 @@ class Contracts extends Component {
   state = {
     addContract: false,
     deployContract: false,
-    searchValue: ''
+    searchValues: []
   }
 
   render () {
     const { contracts, hasContracts, balances } = this.props;
-    const { searchValue } = this.state;
+    const { searchValues } = this.state;
 
     return (
       <div className={ styles.contracts }>
@@ -57,7 +57,7 @@ class Contracts extends Component {
         <Page>
           <List
             link='contract'
-            search={ searchValue }
+            search={ searchValues }
             accounts={ contracts }
             balances={ balances }
             empty={ !hasContracts } />
@@ -67,8 +67,8 @@ class Contracts extends Component {
   }
 
   renderSearchButton () {
-    const onChange = (value) => {
-      this.setState({ searchValue: value });
+    const onChange = (values) => {
+      this.setState({ searchValues: values });
     };
 
     return (<ActionbarSearch

--- a/js/src/views/Contracts/contracts.js
+++ b/js/src/views/Contracts/contracts.js
@@ -75,10 +75,12 @@ class Contracts extends Component {
       this.setState({ sortOrder });
     };
 
-    return (<ActionbarSort
-      key='sortAccounts'
-      order={ this.state.sortOrder }
-      onChange={ onChange } />);
+    return (
+      <ActionbarSort
+        key='sortAccounts'
+        order={ this.state.sortOrder }
+        onChange={ onChange } />
+    );
   }
 
   renderSearchButton () {
@@ -86,10 +88,12 @@ class Contracts extends Component {
       this.setState({ searchValues });
     };
 
-    return (<ActionbarSearch
-      key='searchContract'
-      tokens={ this.state.searchValues }
-      onChange={ onChange } />);
+    return (
+      <ActionbarSearch
+        key='searchContract'
+        tokens={ this.state.searchValues }
+        onChange={ onChange } />
+    );
   }
 
   renderActionbar () {

--- a/js/src/views/Contracts/contracts.js
+++ b/js/src/views/Contracts/contracts.js
@@ -18,6 +18,7 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import ContentAdd from 'material-ui/svg-icons/content/add';
+import { uniq } from 'lodash';
 
 import { Actionbar, ActionbarSearch, Button, Page } from '../../ui';
 import { AddContract, DeployContract } from '../../modals';
@@ -60,19 +61,21 @@ class Contracts extends Component {
             search={ searchValues }
             accounts={ contracts }
             balances={ balances }
-            empty={ !hasContracts } />
+            empty={ !hasContracts }
+            handleAddSearchToken={ this.onAddSearchToken } />
         </Page>
       </div>
     );
   }
 
   renderSearchButton () {
-    const onChange = (values) => {
-      this.setState({ searchValues: values });
+    const onChange = (searchValues) => {
+      this.setState({ searchValues });
     };
 
     return (<ActionbarSearch
       key='searchContract'
+      tokens={ this.state.searchValues }
       onChange={ onChange } />);
   }
 
@@ -128,6 +131,12 @@ class Contracts extends Component {
         accounts={ accounts }
         onClose={ this.onDeployContractClose } />
     );
+  }
+
+  onAddSearchToken = (token) => {
+    const { searchValues } = this.state;
+    const newSearchValues = uniq([].concat(searchValues, token));
+    this.setState({ searchValues: newSearchValues });
   }
 
   onDeployContractClose = () => {

--- a/js/webpack.config.js
+++ b/js/webpack.config.js
@@ -81,10 +81,6 @@ module.exports = {
         loader: 'style!css'
       },
       {
-        test: /\.less$/,
-        loaders: [ 'happypack/loader?id=less' ]
-      },
-      {
         test: /\.(png|jpg|)$/,
         loader: 'file-loader'
       },
@@ -128,16 +124,6 @@ module.exports = {
         loaders: [
           'style',
           'css?modules&sourceMap&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]',
-          'postcss'
-        ]
-      }),
-      new HappyPack({
-        id: 'less',
-        threads: 4,
-        loaders: [
-          'style',
-          'css?modules&sourceMap&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]',
-          'less',
           'postcss'
         ]
       }),

--- a/js/webpack.config.js
+++ b/js/webpack.config.js
@@ -57,6 +57,11 @@ module.exports = {
         loaders: [ 'happypack/loader?id=js' ]
       },
       {
+        test: /\.js$/,
+        include: /node_modules\/material-ui-chip-input/,
+        loader: 'babel'
+      },
+      {
         test: /\.json$/,
         loaders: ['json']
       },

--- a/js/webpack.config.js
+++ b/js/webpack.config.js
@@ -82,11 +82,7 @@ module.exports = {
       },
       {
         test: /\.less$/,
-        loaders: [
-          'style',
-          'css',
-          'less'
-        ]
+        loaders: [ 'happypack/loader?id=less' ]
       },
       {
         test: /\.(png|jpg|)$/,
@@ -132,6 +128,16 @@ module.exports = {
         loaders: [
           'style',
           'css?modules&sourceMap&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]',
+          'postcss'
+        ]
+      }),
+      new HappyPack({
+        id: 'less',
+        threads: 4,
+        loaders: [
+          'style',
+          'css?modules&sourceMap&importLoaders=1&localIdentName=[name]__[local]___[hash:base64:5]',
+          'less',
           'postcss'
         ]
       }),


### PR DESCRIPTION
[Copy of PR #2697]

Closes #2643

This PR adds tagging capabilities to Accounts, Addresses and Contracts. Multiple can be added per item, and these can be searched. They can also be sorted by name or by tag.

Currently, the search accepts multiple tokens, that are joined with OR ; eg. if item 1 has tag foo and item 2 has tag bar, as search for the two tokens foo and bar will display item 1 and 2.
This can be changed easily to an AND behavior.

See it in action here: https://youtu.be/3UA-QI0G_UQ