### PR TITLE
Implements Trace API Formatter

### DIFF
--- a/js/src/api/format/output.js
+++ b/js/src/api/format/output.js
@@ -163,3 +163,50 @@ export function outTransaction (tx) {
 
   return tx;
 }
+
+export function outTrace (trace) {
+  if (trace) {
+    if (trace.action) {
+      Object.keys(trace.action).forEach(key => {
+        switch (key) {
+          case 'gas':
+          case 'value':
+            trace.action[key] = outNumber(trace.action[key]);
+            break;
+
+          case 'from':
+          case 'to':
+            trace.action[key] = outAddress(trace.action[key]);
+            break;
+        }
+      });
+    }
+
+    if (trace.result) {
+      Object.keys(trace.result).forEach(key => {
+        switch (key) {
+          case 'gasUsed':
+            trace.result[key] = outNumber(trace.result[key]);
+            break;
+        }
+      });
+    }
+
+    if (trace.traceAddress) {
+      trace.traceAddress.forEach((address, index) => {
+        trace.traceAddress[index] = outNumber(address);
+      });
+    }
+
+    Object.keys(trace).forEach((key) => {
+      switch (key) {
+        case 'transactionPosition':
+        case 'blockNumber':
+          trace[key] = outNumber(trace[key]);
+          break;
+      }
+    });
+  }
+
+  return trace;
+}

--- a/js/src/api/format/output.js
+++ b/js/src/api/format/output.js
@@ -171,11 +171,14 @@ export function outTrace (trace) {
         switch (key) {
           case 'gas':
           case 'value':
+          case 'balance':
             trace.action[key] = outNumber(trace.action[key]);
             break;
 
           case 'from':
           case 'to':
+          case 'address':
+          case 'refundAddress':
             trace.action[key] = outAddress(trace.action[key]);
             break;
         }
@@ -187,6 +190,10 @@ export function outTrace (trace) {
         switch (key) {
           case 'gasUsed':
             trace.result[key] = outNumber(trace.result[key]);
+            break;
+
+          case 'address':
+            trace.action[key] = outAddress(trace.action[key]);
             break;
         }
       });
@@ -200,6 +207,7 @@ export function outTrace (trace) {
 
     Object.keys(trace).forEach((key) => {
       switch (key) {
+        case 'subtraces':
         case 'transactionPosition':
         case 'blockNumber':
           trace[key] = outNumber(trace[key]);

--- a/js/src/api/format/output.spec.js
+++ b/js/src/api/format/output.spec.js
@@ -16,7 +16,7 @@
 
 import BigNumber from 'bignumber.js';
 
-import { outBlock, outAccountInfo, outAddress, outDate, outNumber, outPeers, outReceipt, outTransaction } from './output';
+import { outBlock, outAccountInfo, outAddress, outDate, outNumber, outPeers, outReceipt, outTransaction, outTrace } from './output';
 import { isAddress, isBigNumber, isInstanceOf } from '../../../test/types';
 
 describe('api/format/output', () => {
@@ -242,6 +242,49 @@ describe('api/format/output', () => {
         value: new BigNumber('0x105'),
         extraData: 'someExtraStuffInHere'
       });
+    });
+  });
+
+  describe('outTrace', () => {
+    it('ignores and passes through unknown keys', () => {
+      expect(outTrace({ someRandom: 'someRandom' })).to.deep.equal({ someRandom: 'someRandom' });
+    });
+
+    it('formats a trace with all the info converted', () => {
+      const formatted = outTrace({
+        type: 'call',
+        action: {
+          from: address,
+          to: address,
+          value: '0x06',
+          gas: '0x07',
+          input: '0x1234',
+          callType: 'call'
+        },
+        result: {
+          gasUsed: '0x08',
+          output: '0x5678'
+        },
+        traceAddress: [ '0x2' ],
+        subtraces: 3,
+        transactionPosition: '0xb',
+        transactionHash: '0x000000000000000000000000000000000000000000000000000000000000000c',
+        blockNumber: '0x0d',
+        blockHash: '0x000000000000000000000000000000000000000000000000000000000000000e'
+      });
+
+      expect(isBigNumber(formatted.action.gas)).to.be.true;
+      expect(formatted.action.gas.toNumber()).to.equal(7);
+      expect(isBigNumber(formatted.action.value)).to.be.true;
+      expect(formatted.action.value.toNumber()).to.equal(6);
+
+      expect(formatted.action.from).to.equal(checksum);
+      expect(formatted.action.to).to.equal(checksum);
+
+      expect(isBigNumber(formatted.blockNumber)).to.be.true;
+      expect(formatted.blockNumber.toNumber()).to.equal(13);
+      expect(isBigNumber(formatted.transactionPosition)).to.be.true;
+      expect(formatted.transactionPosition.toNumber()).to.equal(11);
     });
   });
 });

--- a/js/src/api/rpc/trace/trace.js
+++ b/js/src/api/rpc/trace/trace.js
@@ -15,6 +15,7 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 import { inBlockNumber, inHex, inNumber16 } from '../../format/input';
+import { outTrace } from '../../format/output';
 
 export default class Trace {
   constructor (transport) {
@@ -23,21 +24,25 @@ export default class Trace {
 
   filter (filterObj) {
     return this._transport
-      .execute('trace_filter', filterObj);
+      .execute('trace_filter', filterObj)
+      .then(traces => traces.map(trace => outTrace(trace)));
   }
 
   get (txHash, position) {
     return this._transport
-      .execute('trace_get', inHex(txHash), inNumber16(position));
+      .execute('trace_get', inHex(txHash), inNumber16(position))
+      .then(trace => outTrace(trace));
   }
 
   transaction (txHash) {
     return this._transport
-      .execute('trace_transaction', inHex(txHash));
+      .execute('trace_transaction', inHex(txHash))
+      .then(traces => traces.map(trace => outTrace(trace)));
   }
 
   block (blockNumber = 'latest') {
     return this._transport
-      .execute('trace_block', inBlockNumber(blockNumber));
+      .execute('trace_block', inBlockNumber(blockNumber))
+      .then(traces => traces.map(trace => outTrace(trace)));
   }
 }


### PR DESCRIPTION
Closes #2700 

Adds an output formatter to the trace API endpoints in the JS API.