### PR TITLE
Fixing small files fetching

### DIFF
--- a/util/https-fetch/src/http.rs
+++ b/util/https-fetch/src/http.rs
@@ -52,9 +52,12 @@ impl HttpProcessor {
 		}
 	}
 
-	#[cfg(test)]
 	pub fn status(&self) -> Option<&String> {
 		self.status.as_ref()
+	}
+
+	pub fn status_is_ok(&self) -> bool {
+		self.status == Some("HTTP/1.1 200 OK".into())
 	}
 
 	#[cfg(test)]
@@ -189,7 +192,11 @@ impl HttpProcessor {
 							continue;
 						}
 					}
-					try!(self.body_writer.write_all(&self.buffer.get_ref()[0..left]));
+					{
+						let chunk = &self.buffer.get_ref()[0..left];
+						trace!("Writing chunk: {:?}", String::from_utf8_lossy(chunk));
+						try!(self.body_writer.write_all(chunk));
+					}
 					self.buffer_consume(left + BREAK_LEN);
 
 					self.set_state(State::WaitingForChunk);
@@ -200,7 +207,7 @@ impl HttpProcessor {
 				State::Finished => {
 					let len = self.buffer.get_ref().len();
 					self.buffer_consume(len);
-					return Ok(());
+					return self.body_writer.flush();
 				},
 			}
 		}

--- a/util/https-fetch/src/tlsclient.rs
+++ b/util/https-fetch/src/tlsclient.rs
@@ -137,8 +137,11 @@ impl TlsClient {
 			trace!("Connection closed");
 			let callback = &mut self.callback;
 			callback(match self.error.take() {
+				None if self.writer.status_is_ok() => Ok(()),
 				Some(err) => Err(err.into()),
-				None => Ok(()),
+				None => {
+					Err(FetchError::UnexpectedStatus(format!("{:?}", self.writer.status())))
+				},
 			});
 
 			return true;


### PR DESCRIPTION
Last chunk could remain unflushed - forcing flush when all chunks from response are read
Also:
1. Adding `User-Agent` out of courtesy
2. Returning an error on non-200 response.