### PR TITLE
Fixing stalled sync

### DIFF
--- a/sync/src/chain.rs
+++ b/sync/src/chain.rs
@@ -1058,7 +1058,7 @@ impl ChainSync {
 					}
 
 					let have_latest = io.chain().block_status(BlockID::Hash(peer_latest)) != BlockStatus::Unknown;
-					if !have_latest && (higher_difficulty || force) {
+					if !have_latest && (higher_difficulty || force || self.state == SyncState::NewBlocks) {
 						// check if got new blocks to download
 						if let Some(request) = self.new_blocks.request_blocks(io) {
 							self.request_blocks(io, peer_id, request, BlockSet::NewBlocks);


### PR DESCRIPTION
New unknown block should be downloaded from all peers that report them, not just the first once. This was broken in the refactoring.