### PR TITLE
fix contract deployments not showing up

### DIFF
--- a/js/src/views/Signer/components/TransactionPending/TransactionPending.js
+++ b/js/src/views/Signer/components/TransactionPending/TransactionPending.js
@@ -79,7 +79,7 @@ export default class TransactionPending extends Component {
 
   render () {
     const { chain, fromBalance, toBalance } = this.state;
-    if (!chain || !fromBalance || !toBalance) {
+    if (!chain) {
       return (
         <div className={ `${styles.container} ${className}` }>
           <CircularProgress size={ 1 } />

--- a/js/src/views/Signer/components/TransactionPending/TransactionPending.js
+++ b/js/src/views/Signer/components/TransactionPending/TransactionPending.js
@@ -78,8 +78,7 @@ export default class TransactionPending extends Component {
   }
 
   render () {
-    const { chain, fromBalance, toBalance } = this.state;
-    if (!chain) {
+    if (!this.state.chain) {
       return (
         <div className={ `${styles.container} ${className}` }>
           <CircularProgress size={ 1 } />


### PR DESCRIPTION
> I'm really not happy with this.
> 
> Since the Signer consists of many, deeply nested, components, which in many cases
just pass props through, it's hard to trace this. `<TransactionPending>` is
supposed to fetch data from Parity (smart component) and pass it on to its (dumb)
children. For that, it needs to know implementation details of them.

@jacogr 