### PR TITLE
Trace filtering fix

### DIFF
--- a/ethcore/src/types/trace_types/filter.rs
+++ b/ethcore/src/types/trace_types/filter.rs
@@ -42,12 +42,7 @@ impl From<Vec<Address>> for AddressesFilter {
 impl AddressesFilter {
 	/// Returns true if address matches one of the searched addresses.
 	pub fn matches(&self, address: &Address) -> bool {
-		self.matches_all() || self.strictly_matches(address)
-	}
-
-	/// Returns true if address matches at least one of the searched addresses.
-	pub fn strictly_matches(&self, address: &Address) -> bool {
-		self.list.contains(address)
+		self.matches_all() || self.list.contains(address)
 	}
 
 	/// Returns true if this address filter matches everything.

--- a/ethcore/src/types/trace_types/filter.rs
+++ b/ethcore/src/types/trace_types/filter.rs
@@ -42,8 +42,13 @@ impl From<Vec<Address>> for AddressesFilter {
 impl AddressesFilter {
 	/// Returns true if address matches one of the searched addresses.
 	pub fn matches(&self, address: &Address) -> bool {
-		self.matches_all() || self.list.contains(address)
-	}
+		self.matches_all() || self.stricly_matches(address)
+    }
+
+    /// Returns true if address matches at least one of the searched addresses.
+    pub fn stricly_matches(&self, address: &Address) -> bool {
+        self.list.contains(address)
+    }
 
 	/// Returns true if this address filter matches everything.
 	pub fn matches_all(&self) -> bool {
@@ -127,7 +132,7 @@ impl Filter {
 		};
 
 		action || match trace.result {
-			Res::Create(ref create) => self.to_address.matches(&create.address),
+			Res::Create(ref create) => self.to_address.stricly_matches(&create.address),
 			_ => false
 		}
 	}

--- a/ethcore/src/types/trace_types/filter.rs
+++ b/ethcore/src/types/trace_types/filter.rs
@@ -42,13 +42,13 @@ impl From<Vec<Address>> for AddressesFilter {
 impl AddressesFilter {
 	/// Returns true if address matches one of the searched addresses.
 	pub fn matches(&self, address: &Address) -> bool {
-		self.matches_all() || self.stricly_matches(address)
-    }
+		self.matches_all() || self.strictly_matches(address)
+	}
 
-    /// Returns true if address matches at least one of the searched addresses.
-    pub fn stricly_matches(&self, address: &Address) -> bool {
-        self.list.contains(address)
-    }
+	/// Returns true if address matches at least one of the searched addresses.
+	pub fn strictly_matches(&self, address: &Address) -> bool {
+		self.list.contains(address)
+	}
 
 	/// Returns true if this address filter matches everything.
 	pub fn matches_all(&self) -> bool {
@@ -132,7 +132,7 @@ impl Filter {
 		};
 
 		action || match trace.result {
-			Res::Create(ref create) => self.to_address.stricly_matches(&create.address),
+			Res::Create(ref create) => self.to_address.strictly_matches(&create.address),
 			_ => false
 		}
 	}


### PR DESCRIPTION
Fixes #2751 

Don't test contract address against empty `toAddress` array in trace filtering.