### PR TITLE
Auto-bump js-precompiled on release

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,7 +3,7 @@ stages:
   - test
 variables:
   GIT_DEPTH: "3"
-  SIMPLECOV: "true" 
+  SIMPLECOV: "true"
   RUST_BACKTRACE: "1"
 cache:
   key: "$CI_BUILD_NAME/$CI_BUILD_REF_NAME"
@@ -20,7 +20,7 @@ linux-stable:
     - cargo build --release --verbose
     - strip target/release/parity
     - md5sum target/release/parity >> parity.md5
-    - aws configure set aws_access_key_id $s3_key 
+    - aws configure set aws_access_key_id $s3_key
     - aws configure set aws_secret_access_key $s3_secret
     - aws s3api put-object --bucket builds-parity --key $CI_BUILD_REF_NAME/x86_64-unknown-linux-gnu/parity --body target/release/parity
     - aws s3api put-object --bucket builds-parity --key $CI_BUILD_REF_NAME/x86_64-unknown-linux-gnu/parity.md5 --body parity.md5
@@ -43,7 +43,7 @@ linux-stable-14.04:
     - cargo build --release --verbose
     - strip target/release/parity
     - md5sum target/release/parity >> parity.md5
-    - aws configure set aws_access_key_id $s3_key 
+    - aws configure set aws_access_key_id $s3_key
     - aws configure set aws_secret_access_key $s3_secret
     - aws s3api put-object --bucket builds-parity --key $CI_BUILD_REF_NAME/x86_64-unknown-ubuntu_14_04-gnu/parity --body target/release/parity
     - aws s3api put-object --bucket builds-parity --key $CI_BUILD_REF_NAME/x86_64-unknown-ubuntu_14_04-gnu/parity.md5 --body parity.md5
@@ -106,7 +106,7 @@ linux-centos:
     - cargo build --release --verbose
     - strip target/release/parity
     - md5sum target/release/parity >> parity.md5
-    - aws configure set aws_access_key_id $s3_key 
+    - aws configure set aws_access_key_id $s3_key
     - aws configure set aws_secret_access_key $s3_secret
     - aws s3api put-object --bucket builds-parity --key $CI_BUILD_REF_NAME/x86_64-unknown-centos-gnu/parity --body target/release/parity
     - aws s3api put-object --bucket builds-parity --key $CI_BUILD_REF_NAME/x86_64-unknown-centos-gnu/parity.md5 --body parity.md5
@@ -133,7 +133,7 @@ linux-armv7:
     - cargo build --target armv7-unknown-linux-gnueabihf --release --verbose
     - arm-linux-gnueabihf-strip target/armv7-unknown-linux-gnueabihf/release/parity
     - md5sum target/armv7-unknown-linux-gnueabihf/release/parity >> parity.md5
-    - aws configure set aws_access_key_id $s3_key 
+    - aws configure set aws_access_key_id $s3_key
     - aws configure set aws_secret_access_key $s3_secret
     - aws s3api put-object --bucket builds-parity --key $CI_BUILD_REF_NAME/armv7-unknown-linux-gnueabihf/parity --body target/armv7-unknown-linux-gnueabihf/release/parity
     - aws s3api put-object --bucket builds-parity --key $CI_BUILD_REF_NAME/armv7-unknown-linux-gnueabihf/parity.md5 --body parity.md5
@@ -161,7 +161,7 @@ linux-arm:
     - cargo build --target arm-unknown-linux-gnueabihf --release --verbose
     - arm-linux-gnueabihf-strip target/arm-unknown-linux-gnueabihf/release/parity
     - md5sum target/arm-unknown-linux-gnueabihf/release/parity >> parity.md5
-    - aws configure set aws_access_key_id $s3_key 
+    - aws configure set aws_access_key_id $s3_key
     - aws configure set aws_secret_access_key $s3_secret
     - aws s3api put-object --bucket builds-parity --key $CI_BUILD_REF_NAME/arm-unknown-linux-gnueabihf/parity --body target/arm-unknown-linux-gnueabihf/release/parity
     - aws s3api put-object --bucket builds-parity --key $CI_BUILD_REF_NAME/arm-unknown-linux-gnueabihf/parity.md5 --body parity.md5
@@ -188,8 +188,8 @@ linux-armv6:
     - cat .cargo/config
     - cargo build --target arm-unknown-linux-gnueabi --release --verbose
     - arm-linux-gnueabi-strip target/arm-unknown-linux-gnueabi/release/parity
-    - md5sum target/arm-unknown-linux-gnueabi/release/parity >> parity.md5 
-    - aws configure set aws_access_key_id $s3_key 
+    - md5sum target/arm-unknown-linux-gnueabi/release/parity >> parity.md5
+    - aws configure set aws_access_key_id $s3_key
     - aws configure set aws_secret_access_key $s3_secret
     - aws s3api put-object --bucket builds-parity --key $CI_BUILD_REF_NAME/arm-unknown-linux-gnueabi/parity --body target/arm-unknown-linux-gnueabi/release/parity
     - aws s3api put-object --bucket builds-parity --key $CI_BUILD_REF_NAME/arm-unknown-linux-gnueabi/parity.md5 --body parity.md5
@@ -217,7 +217,7 @@ linux-aarch64:
     - cargo build --target aarch64-unknown-linux-gnu --release --verbose
     - aarch64-linux-gnu-strip target/aarch64-unknown-linux-gnu/release/parity
     - md5sum target/aarch64-unknown-linux-gnu/release/parity >> parity.md5
-    - aws configure set aws_access_key_id $s3_key 
+    - aws configure set aws_access_key_id $s3_key
     - aws configure set aws_secret_access_key $s3_secret
     - aws s3api put-object --bucket builds-parity --key $CI_BUILD_REF_NAME/aarch64-unknown-linux-gnu/parity --body target/aarch64-unknown-linux-gnu/release/parity
     - aws s3api put-object --bucket builds-parity --key $CI_BUILD_REF_NAME/aarch64-unknown-linux-gnu/parity.md5 --body parity.md5
@@ -239,7 +239,7 @@ darwin:
   script:
     - cargo build --release --verbose
     - md5sum target/release/parity >> parity.md5
-    - aws configure set aws_access_key_id $s3_key 
+    - aws configure set aws_access_key_id $s3_key
     - aws configure set aws_secret_access_key $s3_secret
     - aws s3api put-object --bucket builds-parity --key $CI_BUILD_REF_NAME/x86_64-apple-darwin/parity --body target/release/parity
     - aws s3api put-object --bucket builds-parity --key $CI_BUILD_REF_NAME/x86_64-apple-darwin/parity.md5 --body parity.md5
@@ -314,7 +314,7 @@ js-release:
   stage: build
   image: ethcore/javascript:latest
   only:
-    - js
+    - jg-auto-bump-precompiled
     - master
     - beta
     - tags

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -314,7 +314,6 @@ js-release:
   stage: build
   image: ethcore/javascript:latest
   only:
-    - jg-auto-bump-precompiled
     - master
     - beta
     - tags

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1207,7 +1207,7 @@ dependencies = [
 [[package]]
 name = "parity-ui-precompiled"
 version = "1.4.0"
-source = "git+https://github.com/ethcore/js-precompiled.git#eba8fdcb29c2230868b6604dd341513b5beceba9"
+source = "git+https://github.com/ethcore/js-precompiled.git#28ab89f9944d4ec8943868c4147db98d853d88e4"
 dependencies = [
  "parity-dapps-glue 1.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/js/scripts/build.sh
+++ b/js/scripts/build.sh
@@ -6,6 +6,7 @@ cd ..
 
 # run build (production) and store the exit code
 EXITCODE=0
+rm -rf .build
 npm run ci:build || EXITCODE=1
 
 # back to root

--- a/js/scripts/release.sh
+++ b/js/scripts/release.sh
@@ -18,7 +18,7 @@ UTCDATE=`date -u "+%Y%m%d-%H%M%S"`
 
 # Create proper directory structure
 mkdir -p build
-mv * build || true
+mv *.* build
 mkdir -p src
 
 # Copy rust files

--- a/js/scripts/release.sh
+++ b/js/scripts/release.sh
@@ -1,6 +1,14 @@
 #!/bin/bash
 set -e
 
+# setup the git user defaults for the current repo
+function setup_git_user {
+  git config push.default simple
+  git config merge.ours.driver true
+  git config user.email "jaco+gitlab@ethcore.io"
+  git config user.name "GitLab Build Bot"
+}
+
 # change into the build directory
 pushd `dirname $0`
 cd ../.build
@@ -22,13 +30,8 @@ cp ../src/lib.rs* ./src/
 rm -rf ./.git
 git init
 
-# our user details
-git config push.default simple
-git config merge.ours.driver true
-git config user.email "jaco+gitlab@ethcore.io"
-git config user.name "GitLab Build Bot"
-
 # add local files and send it up
+setup_git_user
 git remote add origin https://${GITHUB_JS_PRECOMPILED}:@github.com/ethcore/js-precompiled.git
 git fetch origin
 git checkout -b $CI_BUILD_REF_NAME
@@ -39,6 +42,17 @@ git push origin $CI_BUILD_REF_NAME
 
 # back to root
 popd
+
+# bump js-precompiled
+cargo update -p parity-ui-precompiled
+
+# add to git and push
+setup_git_user
+git remote add origin https://${GITHUB_JS_PRECOMPILED}:@github.com/ethcore/parity.git
+git fetch origin
+git add .
+git commit -m "[ci skip] js-precompiled $UTCDATE"
+git push origin
 
 # exit with exit code
 exit 0

--- a/js/scripts/release.sh
+++ b/js/scripts/release.sh
@@ -48,7 +48,7 @@ cargo update -p parity-ui-precompiled
 
 # add to git and push
 setup_git_user
-git remote add origin https://${GITHUB_JS_PRECOMPILED}:@github.com/ethcore/parity.git
+git remote set-url origin https://${GITHUB_JS_PRECOMPILED}:@github.com/ethcore/parity.git
 git fetch origin
 git add .
 git commit -m "[ci skip] js-precompiled $UTCDATE"

--- a/js/scripts/release.sh
+++ b/js/scripts/release.sh
@@ -50,9 +50,9 @@ cargo update -p parity-ui-precompiled
 setup_git_user
 git remote set-url origin https://${GITHUB_JS_PRECOMPILED}:@github.com/ethcore/parity.git
 git fetch origin
-git add .
-git commit -m "[ci skip] js-precompiled $UTCDATE"
-git push origin
+git add . || true
+git commit -m "[ci skip] js-precompiled $UTCDATE" || true
+git push origin || true
 
 # exit with exit code
 exit 0


### PR DESCRIPTION
Closes https://github.com/ethcore/parity/issues/2827

1. Will only work if user/key can push from CI to master/branch being built
2. Will probably need to update the key with a different CI-specific user (currently tied to me)