### PR TITLE
Disable personal APIs by default for security reasons

### DIFF
--- a/parity/cli/config.full.toml
+++ b/parity/cli/config.full.toml
@@ -38,13 +38,13 @@ disable = false
 port = 8545
 interface = "local"
 cors = "null"
-apis = ["web3", "eth", "net", "personal", "ethcore", "traces", "rpc"]
+apis = ["web3", "eth", "net", "ethcore", "traces", "rpc"]
 hosts = ["none"]
 
 [ipc]
 disable = false
 path = "$HOME/.parity/jsonrpc.ipc"
-apis = ["web3", "eth", "net", "personal", "ethcore", "traces", "rpc"]
+apis = ["web3", "eth", "net", "ethcore", "traces", "rpc"]
 
 [dapps]
 disable = false

--- a/parity/cli/mod.rs
+++ b/parity/cli/mod.rs
@@ -139,7 +139,7 @@ usage! {
 			or |c: &Config| otry!(c.rpc).interface.clone(),
 		flag_jsonrpc_cors: Option<String> = None,
 			or |c: &Config| otry!(c.rpc).cors.clone().map(Some),
-		flag_jsonrpc_apis: String = "web3,eth,net,ethcore,personal,traces,rpc",
+		flag_jsonrpc_apis: String = "web3,eth,net,ethcore,traces,rpc",
 			or |c: &Config| otry!(c.rpc).apis.clone().map(|vec| vec.join(",")),
 		flag_jsonrpc_hosts: String = "none",
 			or |c: &Config| otry!(c.rpc).hosts.clone().map(|vec| vec.join(",")),
@@ -149,7 +149,7 @@ usage! {
 			or |c: &Config| otry!(c.ipc).disable.clone(),
 		flag_ipc_path: String = "$HOME/.parity/jsonrpc.ipc",
 			or |c: &Config| otry!(c.ipc).path.clone(),
-		flag_ipc_apis: String = "web3,eth,net,ethcore,personal,traces,rpc",
+		flag_ipc_apis: String = "web3,eth,net,ethcore,traces,rpc",
 			or |c: &Config| otry!(c.ipc).apis.clone().map(|vec| vec.join(",")),
 
 		// DAPPS
@@ -507,13 +507,13 @@ mod tests {
 			flag_jsonrpc_port: 8545u16,
 			flag_jsonrpc_interface: "local".into(),
 			flag_jsonrpc_cors: Some("null".into()),
-			flag_jsonrpc_apis: "web3,eth,net,personal,ethcore,traces,rpc".into(),
+			flag_jsonrpc_apis: "web3,eth,net,ethcore,traces,rpc".into(),
 			flag_jsonrpc_hosts: "none".into(),
 
 			// IPC
 			flag_no_ipc: false,
 			flag_ipc_path: "$HOME/.parity/jsonrpc.ipc".into(),
-			flag_ipc_apis: "web3,eth,net,personal,ethcore,traces,rpc".into(),
+			flag_ipc_apis: "web3,eth,net,ethcore,traces,rpc".into(),
 
 			// DAPPS
 			flag_no_dapps: false,

--- a/parity/rpc_apis.rs
+++ b/parity/rpc_apis.rs
@@ -131,10 +131,10 @@ impl ApiSet {
 		match *self {
 			ApiSet::List(ref apis) => apis.clone(),
 			ApiSet::UnsafeContext => {
-				vec![Api::Web3, Api::Net, Api::Eth, Api::Personal, Api::Ethcore, Api::Traces, Api::Rpc]
+				vec![Api::Web3, Api::Net, Api::Eth, Api::Ethcore, Api::Traces, Api::Rpc]
 					.into_iter().collect()
 			},
-			_ => {
+			ApiSet::SafeContext => {
 				vec![Api::Web3, Api::Net, Api::Eth, Api::Personal, Api::Signer, Api::Ethcore, Api::EthcoreSet, Api::Traces, Api::Rpc]
 					.into_iter().collect()
 			},
@@ -233,7 +233,7 @@ mod test {
 
 	#[test]
 	fn test_api_set_unsafe_context() {
-		let expected = vec![Api::Web3, Api::Net, Api::Eth, Api::Personal, Api::Ethcore, Api::Traces, Api::Rpc]
+		let expected = vec![Api::Web3, Api::Net, Api::Eth, Api::Ethcore, Api::Traces, Api::Rpc]
 			.into_iter().collect();
 		assert_eq!(ApiSet::UnsafeContext.list_apis(), expected);
 	}


### PR DESCRIPTION
Closes #2780 

@jacogr Please confirm that builtin dapps using unsecure connection are not using any `personal_*` stuff.