### PR TITLE
Trigger accounts/contracts search on search input change

### DIFF
--- a/js/src/modals/EditMeta/editMeta.js
+++ b/js/src/modals/EditMeta/editMeta.js
@@ -36,7 +36,7 @@ export default class EditMeta extends Component {
   }
 
   state = {
-    meta: this.props.account.meta,
+    meta: Object.assign({}, this.props.account.meta),
     metaErrors: {},
     name: this.props.account.name,
     nameError: null

--- a/js/src/modals/EditMeta/editMeta.js
+++ b/js/src/modals/EditMeta/editMeta.js
@@ -141,8 +141,11 @@ export default class EditMeta extends Component {
 
     const tokens = value.split(/[\s,;]+/);
 
-    const newTokens = tokens.slice(0, -1);
-    const inputValue = tokens.slice(-1)[0];
+    const newTokens = tokens
+      .slice(0, -1)
+      .filter(t => t.length > 0);
+
+    const inputValue = tokens.slice(-1)[0].trim();
 
     this.onMetaChange('tags', [].concat(tags, newTokens));
     this.refs.tagsInput.setState({ inputValue });

--- a/js/src/modals/EditMeta/editMeta.js
+++ b/js/src/modals/EditMeta/editMeta.js
@@ -102,18 +102,50 @@ export default class EditMeta extends Component {
   renderTags () {
     const { meta } = this.state;
     const { tags } = meta || [];
-    const onChange = (chips) => this.onMetaChange('tags', chips);
 
     return (
       <ChipInput
-        defaultValue={ tags }
-        onChange={ onChange }
+        ref='tagsInput'
+        value={ tags }
+        onRequestAdd={ this.onAddTag }
+        onRequestDelete={ this.onDeleteTag }
         floatingLabelText='(optional) tags'
         hintText='press <Enter> to add a tag'
+        onUpdateInput={ this.onTagsInputChange }
         floatingLabelFixed
         fullWidth
       />
     );
+  }
+
+  onAddTag = (tag) => {
+    const { meta } = this.state;
+    const { tags } = meta || [];
+
+    this.onMetaChange('tags', [].concat(tags, tag));
+  }
+
+  onDeleteTag = (tag) => {
+    const { meta } = this.state;
+    const { tags } = meta || [];
+
+    const newTags = tags
+      .filter(t => t !== tag);
+
+    this.onMetaChange('tags', newTags);
+  }
+
+  onTagsInputChange = (value) => {
+    const { meta } = this.state;
+    const { tags } = meta || [];
+
+    const tokens = value.split(/[\s,;]+/);
+
+    const newTokens = tokens.slice(0, -1);
+    const inputValue = tokens.slice(-1)[0];
+
+    this.onMetaChange('tags', [].concat(tags, newTokens));
+    this.refs.tagsInput.setState({ inputValue });
   }
 
   onNameChange = (name) => {

--- a/js/src/ui/Actionbar/Search/search.css
+++ b/js/src/ui/Actionbar/Search/search.css
@@ -41,3 +41,11 @@
   width: 0;
   height: 0;
 }
+
+.chip > svg {
+  width: 1.2rem !important;
+  height: 1.2rem !important;
+  margin: initial !important;
+  margin-right: 4px !important;
+  padding: 4px 0 !important;
+}

--- a/js/src/ui/Actionbar/Search/search.css
+++ b/js/src/ui/Actionbar/Search/search.css
@@ -27,19 +27,6 @@
   width: 500px !important;
 }
 
-.input > div:nth-child(2) {
-  bottom: 16px !important;
-  left: 2px;
-}
-
-.input > div:nth-child(3) {
-  margin-bottom: 18px !important;
-}
-
-.input > div:nth-child(3) > div:first-child {
-  height: 42px !important;
-}
-
 .inputContainer {
   transition: width 450ms ease-in-out 0ms, height 0ms ease-in-out 0ms;
   white-space: nowrap;

--- a/js/src/ui/Actionbar/Search/search.css
+++ b/js/src/ui/Actionbar/Search/search.css
@@ -29,6 +29,7 @@
 
 .input > div:nth-child(2) {
   bottom: 16px !important;
+  left: 2px;
 }
 
 .input > div:nth-child(3) {

--- a/js/src/ui/Actionbar/Search/search.css
+++ b/js/src/ui/Actionbar/Search/search.css
@@ -27,6 +27,18 @@
   width: 500px !important;
 }
 
+.input > div:nth-child(2) {
+  bottom: 16px !important;
+}
+
+.input > div:nth-child(3) {
+  margin-bottom: 18px !important;
+}
+
+.input > div:nth-child(3) > div:first-child {
+  height: 42px !important;
+}
+
 .inputContainer {
   transition: width 450ms ease-in-out 0ms, height 0ms ease-in-out 0ms;
   white-space: nowrap;

--- a/js/src/ui/Actionbar/Search/search.js
+++ b/js/src/ui/Actionbar/Search/search.js
@@ -175,8 +175,6 @@ export default class ActionbarSearch extends Component {
       .concat(searchTokens || tokens, inputValue)
       .filter(v => v.length > 0);
 
-    console.log('handleSearchChange', newSearchTokens, newSearchValues);
-
     onChange(newSearchTokens, newSearchValues);
   }
 

--- a/js/src/ui/Actionbar/Search/search.js
+++ b/js/src/ui/Actionbar/Search/search.js
@@ -79,15 +79,24 @@ export default class ActionbarSearch extends Component {
             className={ styles.input }
             chipRenderer={ this.chipRenderer }
             hintText='Enter search input...'
-            hintStyle={ {
-              transition: 'none'
-            } }
             ref='searchInput'
             value={ tokens }
             onBlur={ this.handleSearchBlur }
             onRequestAdd={ this.handleTokenAdd }
             onRequestDelete={ this.handleTokenDelete }
-            onUpdateInput={ this.handleInputChange } />
+            onUpdateInput={ this.handleInputChange }
+            hintStyle={ {
+              bottom: 16,
+              left: 2,
+              transition: 'none'
+            } }
+            inputStyle={ {
+              marginBottom: 18
+            } }
+            textFieldStyle={ {
+              height: 42
+            } }
+          />
         </div>
 
         <Button

--- a/js/src/ui/Actionbar/Search/search.js
+++ b/js/src/ui/Actionbar/Search/search.js
@@ -45,6 +45,10 @@ export default class ActionbarSearch extends Component {
     if (tokens.length > 0 && this.props.tokens.length === 0) {
       this.handleOpenSearch(true, true);
     }
+
+    if (tokens.length !== this.props.tokens.length) {
+      this.handleSearchChange(tokens);
+    }
   }
 
   componentWillUnmount () {
@@ -127,10 +131,6 @@ export default class ActionbarSearch extends Component {
 
     const newSearchTokens = uniq([].concat(tokens, value));
 
-    this.setState({
-      inputValue: ''
-    });
-
     this.handleSearchChange(newSearchTokens);
   }
 
@@ -141,10 +141,6 @@ export default class ActionbarSearch extends Component {
       .concat(tokens)
       .filter(v => v !== value);
 
-    this.setState({
-      inputValue: ''
-    });
-
     this.handleSearchChange(newSearchTokens);
     this.refs.searchInput.focus();
   }
@@ -154,27 +150,34 @@ export default class ActionbarSearch extends Component {
 
     const inputValue = (splitTokens.length <= 1)
       ? value
-      : splitTokens.slice(-1)[0];
-
-    if (splitTokens.length > 1) {
-      const tokensToAdd = splitTokens.slice(0, -1);
-      tokensToAdd.forEach(token => this.handleTokenAdd(token));
-    }
+      : splitTokens.slice(-1)[0].trim();
 
     this.refs.searchInput.setState({ inputValue });
-    this.setState({ inputValue });
-
-    if (inputValue && inputValue.length > 0) {
-      const { tokens, onChange } = this.props;
-      onChange(tokens, [].concat(tokens, inputValue));
-    }
+    this.setState({ inputValue }, () => {
+      if (splitTokens.length > 1) {
+        const tokensToAdd = splitTokens.slice(0, -1);
+        tokensToAdd.forEach(token => this.handleTokenAdd(token));
+      } else {
+        this.handleSearchChange();
+      }
+    });
   }
 
   handleSearchChange = (searchTokens) => {
-    const { onChange } = this.props;
-    const newSearchTokens = searchTokens.filter(v => v.length > 0);
+    const { onChange, tokens } = this.props;
+    const { inputValue } = this.state;
 
-    onChange(newSearchTokens, newSearchTokens);
+    const newSearchTokens = []
+      .concat(searchTokens || tokens)
+      .filter(v => v.length > 0);
+
+    const newSearchValues = []
+      .concat(searchTokens || tokens, inputValue)
+      .filter(v => v.length > 0);
+
+    console.log('handleSearchChange', newSearchTokens, newSearchValues);
+
+    onChange(newSearchTokens, newSearchValues);
   }
 
   handleSearchClick = () => {

--- a/js/src/ui/Actionbar/Search/search.js
+++ b/js/src/ui/Actionbar/Search/search.js
@@ -125,19 +125,19 @@ export default class ActionbarSearch extends Component {
   handleTokenAdd = (value) => {
     const { tokens } = this.props;
 
-    const newSearchValues = uniq([].concat(tokens, value));
+    const newSearchTokens = uniq([].concat(tokens, value));
 
     this.setState({
       inputValue: ''
     });
 
-    this.handleSearchChange(newSearchValues);
+    this.handleSearchChange(newSearchTokens);
   }
 
   handleTokenDelete = (value) => {
     const { tokens } = this.props;
 
-    const newSearchValues = []
+    const newSearchTokens = []
       .concat(tokens)
       .filter(v => v !== value);
 
@@ -145,34 +145,36 @@ export default class ActionbarSearch extends Component {
       inputValue: ''
     });
 
-    this.handleSearchChange(newSearchValues);
+    this.handleSearchChange(newSearchTokens);
     this.refs.searchInput.focus();
   }
 
   handleInputChange = (value) => {
-    const tokens = value.split(/[\s,;]/);
+    const splitTokens = value.split(/[\s,;]/);
 
-    const inputValue = (tokens.length <= 1)
+    const inputValue = (splitTokens.length <= 1)
       ? value
-      : tokens.slice(-1)[0];
+      : splitTokens.slice(-1)[0];
 
-    if (tokens.length > 1) {
-      const tokensToAdd = tokens.slice(0, -1);
+    if (splitTokens.length > 1) {
+      const tokensToAdd = splitTokens.slice(0, -1);
       tokensToAdd.forEach(token => this.handleTokenAdd(token));
     }
 
-    this.refs.searchInput.setState({
-      inputValue
-    });
-
+    this.refs.searchInput.setState({ inputValue });
     this.setState({ inputValue });
+
+    if (inputValue && inputValue.length > 0) {
+      const { tokens, onChange } = this.props;
+      onChange(tokens, [].concat(tokens, inputValue));
+    }
   }
 
-  handleSearchChange = (searchValues) => {
+  handleSearchChange = (searchTokens) => {
     const { onChange } = this.props;
-    const newSearchValues = searchValues.filter(v => v.length > 0);
+    const newSearchTokens = searchTokens.filter(v => v.length > 0);
 
-    onChange(newSearchValues);
+    onChange(newSearchTokens, newSearchTokens);
   }
 
   handleSearchClick = () => {

--- a/js/src/ui/Actionbar/Search/search.js
+++ b/js/src/ui/Actionbar/Search/search.js
@@ -150,7 +150,22 @@ export default class ActionbarSearch extends Component {
   }
 
   handleInputChange = (value) => {
-    this.setState({ inputValue: value });
+    const tokens = value.split(/[\s,;]/);
+
+    const inputValue = (tokens.length <= 1)
+      ? value
+      : tokens.slice(-1)[0];
+
+    if (tokens.length > 1) {
+      const tokensToAdd = tokens.slice(0, -1);
+      tokensToAdd.forEach(token => this.handleTokenAdd(token));
+    }
+
+    this.refs.searchInput.setState({
+      inputValue
+    });
+
+    this.setState({ inputValue });
   }
 
   handleSearchChange = (searchValues) => {

--- a/js/src/ui/Actionbar/Search/search.js
+++ b/js/src/ui/Actionbar/Search/search.js
@@ -15,6 +15,8 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 import React, { Component, PropTypes } from 'react';
+import { Chip } from 'material-ui';
+import { blue300 } from 'material-ui/styles/colors';
 // import ChipInput from 'material-ui-chip-input';
 import ChipInput from 'material-ui-chip-input/src/ChipInput';
 import ActionSearch from 'material-ui/svg-icons/action/search';
@@ -71,6 +73,7 @@ export default class ActionbarSearch extends Component {
           <ChipInput
             clearOnBlur={ false }
             className={ styles.input }
+            chipRenderer={ this.chipRenderer }
             hintText='Enter search input...'
             hintStyle={ {
               transition: 'none'
@@ -89,6 +92,33 @@ export default class ActionbarSearch extends Component {
           label=''
           onClick={ this.handleSearchClick } />
       </div>
+    );
+  }
+
+  chipRenderer = (state, key) => {
+    const { value, isFocused, isDisabled, handleClick, handleRequestDelete } = state;
+
+    return (
+      <Chip
+        key={ key }
+        className={ styles.chip }
+        style={ {
+          margin: '8px 8px 0 0',
+          float: 'left',
+          pointerEvents: isDisabled ? 'none' : undefined,
+          alignItems: 'center'
+        } }
+        labelStyle={ {
+          paddingRight: 6,
+          fontSize: '0.9rem',
+          lineHeight: 'initial'
+        } }
+        backgroundColor={ isFocused ? blue300 : 'rgba(0, 0, 0, 0.73)' }
+        onTouchTap={ handleClick }
+        onRequestDelete={ handleRequestDelete }
+      >
+        { value }
+      </Chip>
     );
   }
 

--- a/js/src/views/Accounts/accounts.js
+++ b/js/src/views/Accounts/accounts.js
@@ -41,7 +41,8 @@ class Accounts extends Component {
     addressBook: false,
     newDialog: false,
     sortOrder: '',
-    searchValues: []
+    searchValues: [],
+    searchTokens: []
   }
 
   render () {
@@ -69,14 +70,14 @@ class Accounts extends Component {
   }
 
   renderSearchButton () {
-    const onChange = (searchValues) => {
-      this.setState({ searchValues });
+    const onChange = (searchTokens, searchValues) => {
+      this.setState({ searchTokens, searchValues });
     };
 
     return (
       <ActionbarSearch
         key='searchAccount'
-        tokens={ this.state.searchValues }
+        tokens={ this.state.searchTokens }
         onChange={ onChange } />
     );
   }
@@ -136,9 +137,9 @@ class Accounts extends Component {
   }
 
   onAddSearchToken = (token) => {
-    const { searchValues } = this.state;
-    const newSearchValues = uniq([].concat(searchValues, token));
-    this.setState({ searchValues: newSearchValues });
+    const { searchTokens } = this.state;
+    const newSearchTokens = uniq([].concat(searchTokens, token));
+    this.setState({ searchTokens: newSearchTokens });
   }
 
   onNewAccountClick = () => {

--- a/js/src/views/Accounts/accounts.js
+++ b/js/src/views/Accounts/accounts.js
@@ -139,7 +139,7 @@ class Accounts extends Component {
   onAddSearchToken = (token) => {
     const { searchTokens } = this.state;
     const newSearchTokens = uniq([].concat(searchTokens, token));
-    this.setState({ searchTokens: newSearchTokens, searchValues: newSearchTokens });
+    this.setState({ searchTokens: newSearchTokens });
   }
 
   onNewAccountClick = () => {

--- a/js/src/views/Accounts/accounts.js
+++ b/js/src/views/Accounts/accounts.js
@@ -139,7 +139,7 @@ class Accounts extends Component {
   onAddSearchToken = (token) => {
     const { searchTokens } = this.state;
     const newSearchTokens = uniq([].concat(searchTokens, token));
-    this.setState({ searchTokens: newSearchTokens });
+    this.setState({ searchTokens: newSearchTokens, searchValues: newSearchTokens });
   }
 
   onNewAccountClick = () => {

--- a/js/src/views/Addresses/addresses.js
+++ b/js/src/views/Addresses/addresses.js
@@ -40,7 +40,8 @@ class Addresses extends Component {
   state = {
     showAdd: false,
     sortOrder: '',
-    searchValues: []
+    searchValues: [],
+    searchTokens: []
   }
 
   render () {
@@ -79,14 +80,14 @@ class Addresses extends Component {
   }
 
   renderSearchButton () {
-    const onChange = (searchValues) => {
-      this.setState({ searchValues });
+    const onChange = (searchTokens, searchValues) => {
+      this.setState({ searchTokens, searchValues });
     };
 
     return (
       <ActionbarSearch
         key='searchAddress'
-        tokens={ this.state.searchValues }
+        tokens={ this.state.searchTokens }
         onChange={ onChange } />
     );
   }
@@ -127,9 +128,9 @@ class Addresses extends Component {
   }
 
   onAddSearchToken = (token) => {
-    const { searchValues } = this.state;
-    const newSearchValues = uniq([].concat(searchValues, token));
-    this.setState({ searchValues: newSearchValues });
+    const { searchTokens } = this.state;
+    const newSearchTokens = uniq([].concat(searchTokens, token));
+    this.setState({ searchTokens: newSearchTokens });
   }
 
   onOpenAdd = () => {

--- a/js/src/views/Contracts/contracts.js
+++ b/js/src/views/Contracts/contracts.js
@@ -43,7 +43,8 @@ class Contracts extends Component {
     addContract: false,
     deployContract: false,
     sortOrder: '',
-    searchValues: []
+    searchValues: [],
+    searchTokens: []
   }
 
   render () {
@@ -84,14 +85,14 @@ class Contracts extends Component {
   }
 
   renderSearchButton () {
-    const onChange = (searchValues) => {
-      this.setState({ searchValues });
+    const onChange = (searchTokens, searchValues) => {
+      this.setState({ searchTokens, searchValues });
     };
 
     return (
       <ActionbarSearch
         key='searchContract'
-        tokens={ this.state.searchValues }
+        tokens={ this.state.searchTokens }
         onChange={ onChange } />
     );
   }
@@ -152,9 +153,9 @@ class Contracts extends Component {
   }
 
   onAddSearchToken = (token) => {
-    const { searchValues } = this.state;
-    const newSearchValues = uniq([].concat(searchValues, token));
-    this.setState({ searchValues: newSearchValues });
+    const { searchTokens } = this.state;
+    const newSearchTokens = uniq([].concat(searchTokens, token));
+    this.setState({ searchTokens: newSearchTokens });
   }
 
   onDeployContractClose = () => {


### PR DESCRIPTION
Fixes #2766 

Triggers the search in the Accounts/Contracts list views whenever the input changes
Adds a new token to the search with `enter`, `space` and `comma`
Re-styling of the search tokens