### PR TITLE
Fixes currency symbol font size in Shapeshift modal

### DIFF
--- a/js/src/modals/Shapeshift/OptionsStep/optionsStep.css
+++ b/js/src/modals/Shapeshift/OptionsStep/optionsStep.css
@@ -18,7 +18,7 @@
 }
 
 .accept {
-  padding: 1.5em 0;
+  margin: 1.5em 0;
 }
 
 .coinselector {

--- a/js/src/modals/Shapeshift/Value/value.css
+++ b/js/src/modals/Shapeshift/Value/value.css
@@ -26,5 +26,5 @@
 .symbol {
   font-variant: small-caps;
   margin-left: 0.1rem;
-  font-size: 0.7rem;
+  font-size: 0.8em;
 }

--- a/js/src/modals/Shapeshift/Value/value.css
+++ b/js/src/modals/Shapeshift/Value/value.css
@@ -22,3 +22,9 @@
 .amount {
   display: inline-block;
 }
+
+.symbol {
+  font-variant: small-caps;
+  margin-left: 0.1rem;
+  font-size: 0.7rem;
+}

--- a/js/src/modals/Shapeshift/Value/value.js
+++ b/js/src/modals/Shapeshift/Value/value.js
@@ -38,7 +38,8 @@ export default class Value extends Component {
 
     return (
       <div className={ styles.body }>
-        <span>{ value }</span><small>{ symbol || 'ETH' }</small>
+        <span>{ value } </span>
+        <span className={ styles.symbol }>{ symbol || 'ETH' }</span>
       </div>
     );
   }

--- a/js/src/views/Dapps/AddDapps/AddDapps.js
+++ b/js/src/views/Dapps/AddDapps/AddDapps.js
@@ -21,7 +21,7 @@ import Checkbox from 'material-ui/Checkbox';
 
 import { Modal, Button } from '../../../ui';
 
-import styles from './addDapps.css';
+import styles from './AddDapps.css';
 
 export default class AddDapps extends Component {
   static propTypes = {

--- a/js/src/views/Dapps/AddDapps/index.js
+++ b/js/src/views/Dapps/AddDapps/index.js
@@ -14,4 +14,4 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-export default from './addDapps';
+export default from './AddDapps';


### PR DESCRIPTION
Fixes #2718 
Small text and space on the left.

![parity - shapeshit curr](https://cloud.githubusercontent.com/assets/2864519/19642473/bdb69b06-99e5-11e6-9a46-eb5da702055b.png)
