### PR TITLE
Snapshot and blockchain stability improvements

### DIFF
--- a/ethcore/src/blockchain/blockchain.rs
+++ b/ethcore/src/blockchain/blockchain.rs
@@ -405,9 +405,8 @@ impl<'a> Iterator for AncestryIter<'a> {
 		if self.current.is_zero() {
 			Option::None
 		} else {
-			let mut n = self.chain.block_details(&self.current).unwrap().parent;
-			mem::swap(&mut self.current, &mut n);
-			Some(n)
+			self.chain.block_details(&self.current)
+				.map(|mut details| mem::swap(&mut self.current, &mut n))
 		}
 	}
 }

--- a/ethcore/src/blockchain/blockchain.rs
+++ b/ethcore/src/blockchain/blockchain.rs
@@ -394,6 +394,8 @@ impl BlockProvider for BlockChain {
 	}
 }
 
+/// An iterator which walks the blockchain towards the genesis.
+#[derive(Clone)]
 pub struct AncestryIter<'a> {
 	current: H256,
 	chain: &'a BlockChain,
@@ -403,10 +405,10 @@ impl<'a> Iterator for AncestryIter<'a> {
 	type Item = H256;
 	fn next(&mut self) -> Option<H256> {
 		if self.current.is_zero() {
-			Option::None
+			None
 		} else {
 			self.chain.block_details(&self.current)
-				.map(|mut details| mem::swap(&mut self.current, &mut n))
+				.map(|details| mem::replace(&mut self.current, details.parent))
 		}
 	}
 }
@@ -998,17 +1000,29 @@ impl BlockChain {
 		if !self.is_known(parent) { return None; }
 
 		let mut excluded = HashSet::new();
-		for a in self.ancestry_iter(parent.clone()).unwrap().take(uncle_generations) {
-			excluded.extend(self.uncle_hashes(&a).unwrap().into_iter());
-			excluded.insert(a);
+		let ancestry = match self.ancestry_iter(parent.clone()) {
+			Some(iter) => iter,
+			None => return None,
+		};
+
+		for a in ancestry.clone().take(uncle_generations) {
+			if let Some(uncles) = self.uncle_hashes(&a) {
+				excluded.extend(uncles);
+				excluded.insert(a);
+			} else {
+				break
+			}
 		}
 
 		let mut ret = Vec::new();
-		for a in self.ancestry_iter(parent.clone()).unwrap().skip(1).take(uncle_generations) {
-			ret.extend(self.block_details(&a).unwrap().children.iter()
-				.filter(|h| !excluded.contains(h))
-			);
+		for a in ancestry.skip(1).take(uncle_generations) {
+			if let Some(details) = self.block_details(&a) {
+				ret.extend(details.children.iter().filter(|h| !excluded.contains(h)))
+			} else {
+				break
+			}
 		}
+
 		Some(ret)
 	}
 

--- a/ethcore/src/snapshot/tests/blocks.rs
+++ b/ethcore/src/snapshot/tests/blocks.rs
@@ -57,7 +57,7 @@ fn chunk_and_restore(amount: u64) {
 
 	// snapshot it.
 	let writer = Mutex::new(PackedWriter::new(&snapshot_path).unwrap());
-	let block_hashes = chunk_blocks(&bc, (amount, best_hash), &writer, &Progress::default()).unwrap();
+	let block_hashes = chunk_blocks(&bc, best_hash, &writer, &Progress::default()).unwrap();
 	writer.into_inner().finish(::snapshot::ManifestData {
 		state_hashes: Vec::new(),
 		block_hashes: block_hashes,

--- a/parity/informant.rs
+++ b/parity/informant.rs
@@ -45,6 +45,14 @@ pub struct Informant {
 	skipped: AtomicUsize,
 }
 
+/// Format byte counts to standard denominations.
+pub fn format_bytes(b: usize) -> String {
+	match binary_prefix(b as f64) {
+		Standalone(bytes)   => format!("{} bytes", bytes),
+		Prefixed(prefix, n) => format!("{:.0} {}B", n, prefix),
+	}
+}
+
 /// Something that can be converted to milliseconds.
 pub trait MillisecondDuration {
 	/// Get the value in milliseconds.
@@ -72,13 +80,6 @@ impl Informant {
 			net: net,
 			last_import: Mutex::new(Instant::now()),
 			skipped: AtomicUsize::new(0),
-		}
-	}
-
-	fn format_bytes(b: usize) -> String {
-		match binary_prefix(b as f64) {
-			Standalone(bytes)   => format!("{} bytes", bytes),
-			Prefixed(prefix, n) => format!("{:.0} {}B", n, prefix),
 		}
 	}
 
@@ -156,11 +157,11 @@ impl Informant {
 				_ => String::new(),
 			},
 			format!("{} db {} chain {} queue{}",
-				paint(Blue.bold(), format!("{:>8}", Informant::format_bytes(report.state_db_mem))),
-				paint(Blue.bold(), format!("{:>8}", Informant::format_bytes(cache_info.total()))),
-				paint(Blue.bold(), format!("{:>8}", Informant::format_bytes(queue_info.mem_used))),
+				paint(Blue.bold(), format!("{:>8}", format_bytes(report.state_db_mem))),
+				paint(Blue.bold(), format!("{:>8}", format_bytes(cache_info.total()))),
+				paint(Blue.bold(), format!("{:>8}", format_bytes(queue_info.mem_used))),
 				match sync_status {
-					Some(ref sync_info) => format!(" {} sync", paint(Blue.bold(), format!("{:>8}", Informant::format_bytes(sync_info.mem_used)))),
+					Some(ref sync_info) => format!(" {} sync", paint(Blue.bold(), format!("{:>8}", format_bytes(sync_info.mem_used)))),
 					_ => String::new(),
 				}
 			)

--- a/parity/snapshot.rs
+++ b/parity/snapshot.rs
@@ -232,9 +232,8 @@ impl SnapshotCommand {
 				let cur_size = p.size();
 				if cur_size != last_size {
 					last_size = cur_size;
-					info!("Snapshot: {} accounts {} blocks {} bytes", p.accounts(), p.blocks(), p.size());
-				} else {
-					info!("Snapshot: No progress since last update.");
+					let bytes = ::informant::format_bytes(p.size());
+					info!("Snapshot: {} accounts {} blocks {}", p.accounts(), p.blocks(), bytes);
 				}
 
 				::std::thread::sleep(Duration::from_secs(5));


### PR DESCRIPTION
Allows taking of snapshot from freshly-restored database without error, also makes `AncestryIter` and uncle-finding code more resilient to missing block data.