### PR TITLE
Remove eventName in unsubscribe API arguments

### DIFF
--- a/js/src/api/api.js
+++ b/js/src/api/api.js
@@ -90,8 +90,8 @@ export default class Api {
     return this._subscriptions.subscribe(subscriptionName, callback);
   }
 
-  unsubscribe (subscriptionName, subscriptionId) {
-    return this._subscriptions.unsubscribe(subscriptionName, subscriptionId);
+  unsubscribe (subscriptionId) {
+    return this._subscriptions.unsubscribe(subscriptionId);
   }
 
   pollMethod (method, input, validate) {

--- a/js/src/ui/TxHash/txHash.js
+++ b/js/src/ui/TxHash/txHash.js
@@ -50,7 +50,7 @@ class TxHash extends Component {
     const { api } = this.context;
     const { subscriptionId } = this.state;
 
-    api.unsubscribe('eth_blockNumber', subscriptionId);
+    api.unsubscribe(subscriptionId);
   }
 
   render () {

--- a/js/src/views/Contract/contract.js
+++ b/js/src/views/Contract/contract.js
@@ -87,7 +87,7 @@ class Contract extends Component {
     const { api } = this.context;
     const { subscriptionId, blockSubscriptionId, contract } = this.state;
 
-    api.unsubscribe('eth_blockNumber', blockSubscriptionId);
+    api.unsubscribe(blockSubscriptionId);
     contract.unsubscribe(subscriptionId);
   }
 


### PR DESCRIPTION
Closes #2364 

Instead of `api.unsubscribe('eth_blockNumber', subId)` use  `api.unsubscribe(subId)`