### PR TITLE
Fixing config values for pruning_history

### DIFF
--- a/parity/cli/mod.rs
+++ b/parity/cli/mod.rs
@@ -446,6 +446,20 @@ mod tests {
 	}
 
 	#[test]
+	fn should_use_config_if_cli_is_missing() {
+		let mut config = Config::default();
+		let mut footprint = Footprint::default();
+		footprint.pruning_history = Some(128);
+		config.footprint = Some(footprint);
+
+		// when
+		let args = Args::parse_with_config(&["parity"], config).unwrap();
+
+		// then
+		assert_eq!(args.flag_pruning_history, 128);
+	}
+
+	#[test]
 	fn should_parse_full_config() {
 		// given
 		let config = toml::decode_str(include_str!("./config.full.toml")).unwrap();

--- a/parity/cli/usage.txt
+++ b/parity/cli/usage.txt
@@ -225,7 +225,7 @@ Footprint Options:
                            auto - use the method most recently synced or
                            default to fast if none synced (default: {flag_pruning}).
   --pruning-history NUM    Set a number of recent states to keep when pruning
-                           is active. [default: {flag_pruning_history}].
+                           is active. (default: {flag_pruning_history}).
   --cache-size-db MB       Override database cache size (default: {flag_cache_size_db}).
   --cache-size-blocks MB   Specify the prefered size of the blockchain cache in
                            megabytes (default: {flag_cache_size_blocks}).


### PR DESCRIPTION
`usage.txt` file can no longer contain any `[default: ]` (it should be `(default:`) otherwise DocOpt doesn't let you distinguish between: "Flag was specified" and "Flag wasn't specified, default was used" - This distinction is required to load a value from a config file iff the flag as not specified.