### PR TITLE
Allow operation when no registry is available

### DIFF
--- a/js/src/redux/providers/balances.js
+++ b/js/src/redux/providers/balances.js
@@ -79,7 +79,6 @@ export default class Balances {
     this._api.ethcore
       .registryAddress()
       .then((registryAddress) => {
-        registryAddress = '0x0';
         const registry = this._api.newContract(abis.registry, registryAddress);
 
         return registry.instance.getAddress.call({}, [this._api.util.sha3('tokenreg'), 'A']);

--- a/js/src/redux/providers/balances.js
+++ b/js/src/redux/providers/balances.js
@@ -32,6 +32,7 @@ export default class Balances {
     this._api = api;
     this._store = store;
     this._accountsInfo = null;
+    this._tokens = [];
   }
 
   start () {
@@ -50,7 +51,10 @@ export default class Balances {
         this._retrieveBalances();
       })
       .then((subscriptionId) => {
-        console.log('balances._subscribeAccountsInfo', 'subscriptionId', subscriptionId);
+        console.log('_subscribeAccountsInfo', 'subscriptionId', subscriptionId);
+      })
+      .catch((error) => {
+        console.warn('_subscribeAccountsInfo', error);
       });
   }
 
@@ -64,7 +68,10 @@ export default class Balances {
         this._retrieveTokens();
       })
       .then((subscriptionId) => {
-        console.log('balances._subscribeBlockNumber', 'subscriptionId', subscriptionId);
+        console.log('_subscribeBlockNumber', 'subscriptionId', subscriptionId);
+      })
+      .catch((error) => {
+        console.warn('_subscribeBlockNumber', error);
       });
   }
 
@@ -72,6 +79,7 @@ export default class Balances {
     this._api.ethcore
       .registryAddress()
       .then((registryAddress) => {
+        registryAddress = '0x0';
         const registry = this._api.newContract(abis.registry, registryAddress);
 
         return registry.instance.getAddress.call({}, [this._api.util.sha3('tokenreg'), 'A']);
@@ -130,12 +138,13 @@ export default class Balances {
         this._retrieveBalances();
       })
       .catch((error) => {
-        console.error('balances._retrieveTokens', error);
+        console.warn('_retrieveTokens', error);
+        this._retrieveBalances();
       });
   }
 
   _retrieveBalances () {
-    if (!this._accountsInfo || !this._tokens) {
+    if (!this._accountsInfo) {
       return;
     }
 
@@ -186,7 +195,7 @@ export default class Balances {
         this._store.dispatch(getBalances(this._balances));
       })
       .catch((error) => {
-        console.error('balances._retrieveBalances', error);
+        console.warn('_retrieveBalances', error);
       });
   }
 }

--- a/js/src/views/Dapps/available.js
+++ b/js/src/views/Dapps/available.js
@@ -14,9 +14,11 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity. If not, see <http://www.gnu.org/licenses/>.
 
+import BigNumber from 'bignumber.js';
+
 import { parityNode } from '../../environment';
 
-const builtinApps = [
+const apps = [
   {
     id: '0xf9f2d620c2e08f83e45555247146c62185e4ab7cf82a4b9002a265a0d020348f',
     url: 'basiccoin',
@@ -73,7 +75,7 @@ const builtinApps = [
   }
 ];
 
-export default function () {
+export default function (api) {
   return fetch(`${parityNode}/api/apps`)
     .then((response) => {
       return response.ok
@@ -85,8 +87,19 @@ export default function () {
       return [];
     })
     .then((localApps) => {
-      return builtinApps
-        .concat(localApps.filter((app) => !['ui'].includes(app.id)))
-        .sort((a, b) => a.name.localeCompare(b.name));
+      return api.ethcore
+        .registryAddress()
+        .then((registryAddress) => {
+          if (new BigNumber(registryAddress).eq(0)) {
+            return [];
+          }
+
+          return apps;
+        })
+        .then((builtinApps) => {
+          return builtinApps
+            .concat(localApps.filter((app) => !['ui'].includes(app.id)))
+            .sort((a, b) => a.name.localeCompare(b.name));
+        });
     });
 }

--- a/js/src/views/Dapps/dapps.js
+++ b/js/src/views/Dapps/dapps.js
@@ -42,16 +42,14 @@ export default class Dapps extends Component {
   }
 
   componentDidMount () {
-    fetchAvailable()
-    .then((available) => {
+    const { api } = this.context;
+
+    fetchAvailable(api).then((available) => {
       this.setState({
         available,
         hidden: readHiddenApps()
       });
       this.loadImages();
-    })
-    .catch((err) => {
-      console.error('error fetching available apps', err);
     });
   }
 


### PR DESCRIPTION
- Allows the display of native network balances even when Tokens are not available, Fixes https://github.com/ethcore/parity/issues/2975 (Registry -> TokenReg)
- Remove built-in dapps when no registry is found, Fixes https://github.com/ethcore/parity/issues/2979
