### PR TITLE
Display network status for finished Signer requests

### DIFF
--- a/js/src/ui/TxHash/txHash.css
+++ b/js/src/ui/TxHash/txHash.css
@@ -23,6 +23,7 @@
 
 .hash {
   padding-top: 1em;
+  word-break: break-all;
 }
 
 .confirm {
@@ -31,11 +32,13 @@
 }
 
 .progressbar {
-  margin: 0.5em !important;
+  margin: 0.5em 0 !important;
   width: 30% !important;
+  min-width: 220px;
   display: inline-block !important;
   height: 0.75em !important;
 }
 
 .progressinfo {
+  text-align: center;
 }

--- a/js/src/ui/TxHash/txHash.js
+++ b/js/src/ui/TxHash/txHash.js
@@ -29,7 +29,8 @@ class TxHash extends Component {
 
   static propTypes = {
     hash: PropTypes.string.isRequired,
-    isTest: PropTypes.bool
+    isTest: PropTypes.bool,
+    summary: PropTypes.bool
   }
 
   state = {
@@ -54,14 +55,21 @@ class TxHash extends Component {
   }
 
   render () {
-    const { hash, isTest } = this.props;
+    const { hash, isTest, summary } = this.props;
     const link = `https://${isTest ? 'testnet.' : ''}etherscan.io/tx/${hash}`;
+    let header = null;
 
-    return (
-      <div className={ styles.details }>
+    if (!summary) {
+      header = (
         <div className={ styles.header }>
           The transaction has been posted to the network with a transaction hash of
         </div>
+      );
+    }
+
+    return (
+      <div className={ styles.details }>
+        { header }
         <div className={ styles.hash }>
           <a href={ link } target='_blank'>{ hash }</a>
         </div>

--- a/js/src/views/Signer/components/TransactionFinished/TransactionFinished.css
+++ b/js/src/views/Signer/components/TransactionFinished/TransactionFinished.css
@@ -46,7 +46,8 @@
 }
 
 .isRejected {
-  opacity: 0.7;
+  opacity: 0.5;
+  padding-top: 2em;
 }
 
 .txHash {

--- a/js/src/views/Signer/components/TransactionFinished/TransactionFinished.css
+++ b/js/src/views/Signer/components/TransactionFinished/TransactionFinished.css
@@ -29,7 +29,7 @@
 
 .statusContainer {
   width: 220px;
-  padding: 20px 40px 0 40px;
+  padding: 0 40px 0 40px;
   /*border-left: 1px solid #aaa;*/
   position: absolute;
   top: 0;

--- a/js/src/views/Signer/components/TransactionFinished/TransactionFinished.js
+++ b/js/src/views/Signer/components/TransactionFinished/TransactionFinished.js
@@ -17,6 +17,9 @@
 import React, { Component, PropTypes } from 'react';
 
 import CircularProgress from 'material-ui/CircularProgress';
+
+import { TxHash } from '../../../../ui';
+
 import TransactionMainDetails from '../TransactionMainDetails';
 import TxHashLink from '../TxHashLink';
 import TransactionSecondaryDetails from '../TransactionSecondaryDetails';
@@ -57,7 +60,7 @@ export default class TransactionFinished extends Component {
   };
 
   componentWillMount () {
-    const { gas, gasPrice, value } = this.props;
+    const { from, to, gas, gasPrice, value } = this.props;
     const fee = tUtil.getFee(gas, gasPrice); // BigNumber object
     const totalValue = tUtil.getTotalValue(fee, value);
     this.setState({ totalValue });
@@ -70,9 +73,10 @@ export default class TransactionFinished extends Component {
         console.error('could not fetch chain', err);
       });
 
-    const { from, to } = this.props;
     this.fetchBalance(from, 'fromBalance');
-    if (to) this.fetchBalance(to, 'toBalance');
+    if (to) {
+      this.fetchBalance(to, 'toBalance');
+    }
   }
 
   render () {
@@ -109,13 +113,20 @@ export default class TransactionFinished extends Component {
   }
 
   renderStatus () {
-    const { status } = this.props;
-    const klass = status === 'confirmed' ? styles.isConfirmed : styles.isRejected;
+    const { status, txHash } = this.props;
+
+    if (status !== 'confirmed') {
+      return (
+        <div>
+          <span className={ styles.isRejected }>{ capitalize(status) }</span>
+        </div>
+      );
+    }
+
     return (
-      <div>
-        <span className={ klass }>{ capitalize(status) }</span>
-        { this.renderTxHash() }
-      </div>
+      <TxHash
+        summary
+        hash={ txHash } />
     );
   }
 


### PR DESCRIPTION
- Display confirmations/status, Closes https://github.com/ethcore/parity/issues/2345
- Don't display confusing "Confirmed", Closes https://github.com/ethcore/parity/issues/2946

![parity 2016-10-30 10-18-12](https://cloud.githubusercontent.com/assets/1424473/19835565/35a442cc-9e8b-11e6-9d35-dbd41c7be318.png)
