### PR TITLE
Networking and syncing tweaks

### DIFF
--- a/parity/run.rs
+++ b/parity/run.rs
@@ -53,7 +53,7 @@ use url;
 const SNAPSHOT_PERIOD: u64 = 10000;
 
 // how many blocks to wait before starting a periodic snapshot.
-const SNAPSHOT_HISTORY: u64 = 500;
+const SNAPSHOT_HISTORY: u64 = 100;
 
 #[derive(Debug, PartialEq)]
 pub struct RunCmd {

--- a/sync/src/block_sync.rs
+++ b/sync/src/block_sync.rs
@@ -29,7 +29,7 @@ use sync_io::SyncIo;
 use blocks::BlockCollection;
 
 const MAX_HEADERS_TO_REQUEST: usize = 128;
-const MAX_BODIES_TO_REQUEST: usize = 128;
+const MAX_BODIES_TO_REQUEST: usize = 64;
 const MAX_RECEPITS_TO_REQUEST: usize = 128;
 const SUBCHAIN_SIZE: u64 = 256;
 const MAX_ROUND_PARENTS: usize = 32;


### PR DESCRIPTION
* Decreased number of blocks requested at once to prevent sync from stalling on a slow network.
* Reduced snapshot taking delay to 100 blocks so that smaller `--pruning-history` is required.
* Prevent connecting peers over the limit if no incoming connections are allowed.
