### PR TITLE
Allow empty/non-existant input arrays for ABIs in contract view

### DIFF
--- a/js/src/modals/ExecuteContract/DetailsStep/detailsStep.js
+++ b/js/src/modals/ExecuteContract/DetailsStep/detailsStep.js
@@ -74,7 +74,7 @@ export default class DetailsStep extends Component {
       .filter((func) => !func.constant)
       .sort((a, b) => a.name.localeCompare(b.name))
       .map((func) => {
-        const params = func.abi.inputs
+        const params = (func.abi.inputs || [])
           .map((input, index) => {
             return (
               <span key={ input.name }>
@@ -97,7 +97,7 @@ export default class DetailsStep extends Component {
           <MenuItem
             key={ func.signature }
             value={ func.signature }
-            label={ func.name }>
+            label={ func.name || '()' }>
             { name }
           </MenuItem>
         );
@@ -122,7 +122,7 @@ export default class DetailsStep extends Component {
       return null;
     }
 
-    return func.abi.inputs.map((input, index) => {
+    return (func.abi.inputs || []).map((input, index) => {
       const onChange = (event, value) => onValueChange(event, index, value);
       const onSubmit = (value) => onValueChange(null, index, value);
       const label = `${input.name}: ${input.type}`;


### PR DESCRIPTION
Newer versions of Solidity creates ABIs with no input arrays for fallback functions. General fix to ignore non-existent inputs (treat as empty) to make the rendering logic more robust.

As reported by https://github.com/chevdor