### PR TITLE
Update fork detection block

### DIFF
--- a/ethcore/res/ethereum/frontier.json
+++ b/ethcore/res/ethereum/frontier.json
@@ -139,8 +139,8 @@
 		"maximumExtraDataSize": "0x20",
 		"minGasLimit": "0x1388",
 		"networkID" : "0x1",
-		"forkBlock": "0x1d4c00",
-		"forkCanonHash": "0x4985f5ca3d2afbec36529aa96f74de3cc10a2a4a6c44f2157a57d2c6059a11bb"
+		"forkBlock": "0x26c1e0",
+		"forkCanonHash": "0xc69f02dc1388c42ad17631a77487dc954adce458d72441b6415b13e6e122509b"
 	},
 	"genesis": {
 		"seal": {


### PR DESCRIPTION
Set the fork detection block to 2540000 to prevent full sync from running into a large fork around 2430000