### PR TITLE
fix background of embedded signer

### DIFF
--- a/js/src/ui/Container/container.css
+++ b/js/src/ui/Container/container.css
@@ -17,7 +17,7 @@
 .container {
   flex: 1;
   padding: 0em;
-  background: rgba(0, 0, 0, 0.8) !important;
+  background: rgba(0, 0, 0, 0.8);
 }
 
 .compact,

--- a/js/src/views/ParityBar/parityBar.css
+++ b/js/src/views/ParityBar/parityBar.css
@@ -54,6 +54,7 @@
   flex: 1;
   overflow: auto;
   display: flex;
+  background: rgba(0, 0, 0, 0.8);
 }
 
 .corner {

--- a/js/src/views/Signer/containers/Embedded/embedded.js
+++ b/js/src/views/Signer/containers/Embedded/embedded.js
@@ -40,7 +40,7 @@ class Embedded extends Component {
 
   render () {
     return (
-      <Container>
+      <Container style={ { background: 'transparent' } }>
         <div className={ styles.signer }>
           { this.renderPendingRequests() }
         </div>


### PR DESCRIPTION
This PR fixes the background of the embedded signer.

![before](https://cloud.githubusercontent.com/assets/5072613/19865345/243f2a9e-9f9c-11e6-8776-e1c6d470aa69.png)

![after](https://cloud.githubusercontent.com/assets/5072613/19865346/267df6be-9f9c-11e6-9e7f-ae2bb4b19663.png)

:exclamation: This removes `!important` form `ui/Container` -> `.container`. I checked all the occurrences of `ui/Container` I could find visually. Please check if you find something. :)