### PR TITLE
Warp sync status display

### DIFF
--- a/js/src/api/format/output.js
+++ b/js/src/api/format/output.js
@@ -166,7 +166,7 @@ export function outSyncing (syncing) {
           break;
 
         case 'blockGap':
-          syncing[key] = syncing[key].map(outNumber);
+          syncing[key] = syncing[key] ? syncing[key].map(outNumber) : syncing[key];
           break;
       }
     });

--- a/js/src/ui/BlockStatus/blockStatus.css
+++ b/js/src/ui/BlockStatus/blockStatus.css
@@ -1,0 +1,22 @@
+/* Copyright 2015, 2016 Ethcore (UK) Ltd.
+/* This file is part of Parity.
+/*
+/* Parity is free software: you can redistribute it and/or modify
+/* it under the terms of the GNU General Public License as published by
+/* the Free Software Foundation, either version 3 of the License, or
+/* (at your option) any later version.
+/*
+/* Parity is distributed in the hope that it will be useful,
+/* but WITHOUT ANY WARRANTY; without even the implied warranty of
+/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+/* GNU General Public License for more details.
+/*
+/* You should have received a copy of the GNU General Public License
+/* along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+.blockNumber {
+}
+
+.syncStatus {
+}

--- a/js/src/ui/BlockStatus/index.js
+++ b/js/src/ui/BlockStatus/index.js
@@ -1,0 +1,17 @@
+// Copyright 2015, 2016 Ethcore (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+export default from './blockStatus';

--- a/js/src/ui/index.js
+++ b/js/src/ui/index.js
@@ -20,6 +20,7 @@ import ActionbarSearch from './Actionbar/Search';
 import ActionbarSort from './Actionbar/Sort';
 import Badge from './Badge';
 import Balance from './Balance';
+import BlockStatus from './BlockStatus';
 import Button from './Button';
 import ConfirmDialog from './ConfirmDialog';
 import Container, { Title as ContainerTitle } from './Container';
@@ -46,6 +47,7 @@ export {
   AddressSelect,
   Badge,
   Balance,
+  BlockStatus,
   Button,
   ConfirmDialog,
   Container,

--- a/js/src/views/Application/Status/status.css
+++ b/js/src/views/Application/Status/status.css
@@ -63,3 +63,6 @@
 
 .version {
 }
+
+.syncing {
+}


### PR DESCRIPTION
Closes https://github.com/ethcore/parity/issues/3040 - the first-generation. Second generation will have to be graphical.

![parity 2016-11-01 11-51-09](https://cloud.githubusercontent.com/assets/1424473/19887736/7b021bd2-a02a-11e6-86b7-ff040e5568ed.png)

![parity 2016-11-01 11-55-24](https://cloud.githubusercontent.com/assets/1424473/19887738/8086c7e2-a02a-11e6-85de-61c238757ce2.png)

![parity 2016-11-01 11-56-48](https://cloud.githubusercontent.com/assets/1424473/19887741/84985698-a02a-11e6-97c2-bf8d253b8582.png)

Sadly, the `eth_syncing` doesn't return the historic information when we are not syncing. (i.e. 3rd image above, historic blocks are still being downloaded we have no access to that status) Think when we move the namespace of this we should change it in conjunction with a proper graphical display