### PR TITLE
Redirecting /home to new UI

### DIFF
--- a/dapps/src/router/mod.rs
+++ b/dapps/src/router/mod.rs
@@ -105,8 +105,12 @@ impl<A: Authorization + 'static> server::Handler<HttpStream> for Router<A> {
 				trace!(target: "dapps", "Resolving to fetchable content.");
 				self.fetch.to_async_handler(path.clone(), control)
 			},
+			// NOTE [todr] /home is redirected to home page since some users may have the redirection cached
+			// (in the past we used 301 instead of 302)
+			// It should be safe to remove it in (near) future.
+			//
 			// 404 for non-existent content
-			(Some(_), _) if *req.method() == hyper::method::Method::Get => {
+			(Some(ref path), _) if *req.method() == hyper::Method::Get && path.app_id != "home" => {
 				trace!(target: "dapps", "Resolving to 404.");
 				Box::new(ContentHandler::error(
 					StatusCode::NotFound,
@@ -116,7 +120,7 @@ impl<A: Authorization + 'static> server::Handler<HttpStream> for Router<A> {
 				))
 			},
 			// Redirect any other GET request to signer.
-			_ if *req.method() == hyper::method::Method::Get => {
+			_ if *req.method() == hyper::Method::Get => {
 				if let Some(port) = self.signer_port {
 					trace!(target: "dapps", "Redirecting to signer interface.");
 					Redirection::boxed(&format!("http://{}", signer_address(port)))

--- a/dapps/src/tests/redirection.rs
+++ b/dapps/src/tests/redirection.rs
@@ -57,6 +57,26 @@ fn should_redirect_to_home_when_trailing_slash_is_missing() {
 }
 
 #[test]
+fn should_redirect_to_home_for_users_with_cached_redirection() {
+	// given
+	let server = serve();
+
+	// when
+	let response = request(server,
+		"\
+			GET /home/ HTTP/1.1\r\n\
+			Host: 127.0.0.1:8080\r\n\
+			Connection: close\r\n\
+			\r\n\
+		"
+	);
+
+	// then
+	assert_eq!(response.status, "HTTP/1.1 302 Found".to_owned());
+	assert_eq!(response.headers.get(0).unwrap(), "Location: http://127.0.0.1:18180");
+}
+
+#[test]
 fn should_display_404_on_invalid_dapp() {
 	// given
 	let server = serve();


### PR DESCRIPTION
```
jacogr [3:49 PM]  
Arkardiy has just compiled Parity on Windows, However, going to localhost:8080 tries to open localhost:8080/home/
Going to 127.0.0.:8180 works.
On IE it works, however not on Chrome, just tried to redirect to /home/ and the 404’s
He just disabled cache, now it works as expected.
If we find it internally, worried the same may persist out there.
Any ideas?
```