### PR TITLE
Add read-only inputs to UI plus Copy to Clipboard buttons

### DIFF
--- a/js/src/modals/CreateAccount/AccountDetails/accountDetails.js
+++ b/js/src/modals/CreateAccount/AccountDetails/accountDetails.js
@@ -31,7 +31,8 @@ export default class AccountDetails extends Component {
     return (
       <Form>
         <Input
-          disabled
+          readOnly
+          copiable
           hint='a descriptive name for the account'
           label='account name'
           value={ name } />
@@ -55,6 +56,7 @@ export default class AccountDetails extends Component {
     return (
       <Input
         readOnly
+        copiable
         hint='the account recovery phrase'
         label='account recovery phrase (keep safe)'
         value={ phrase } />

--- a/js/src/modals/CreateAccount/AccountDetails/accountDetails.js
+++ b/js/src/modals/CreateAccount/AccountDetails/accountDetails.js
@@ -32,7 +32,7 @@ export default class AccountDetails extends Component {
       <Form>
         <Input
           readOnly
-          copiable
+          allowCopy
           hint='a descriptive name for the account'
           label='account name'
           value={ name } />
@@ -56,7 +56,7 @@ export default class AccountDetails extends Component {
     return (
       <Input
         readOnly
-        copiable
+        allowCopy
         hint='the account recovery phrase'
         label='account recovery phrase (keep safe)'
         value={ phrase } />

--- a/js/src/modals/CreateAccount/AccountDetails/accountDetails.js
+++ b/js/src/modals/CreateAccount/AccountDetails/accountDetails.js
@@ -54,7 +54,7 @@ export default class AccountDetails extends Component {
 
     return (
       <Input
-        disabled
+        readOnly
         hint='the account recovery phrase'
         label='account recovery phrase (keep safe)'
         value={ phrase } />

--- a/js/src/modals/CreateAccount/NewAccount/newAccount.js
+++ b/js/src/modals/CreateAccount/NewAccount/newAccount.js
@@ -84,7 +84,6 @@ export default class CreateAccount extends Component {
         <div className={ styles.passwords }>
           <div className={ styles.password }>
             <Input
-              className={ styles.password }
               label='password'
               hint='a strong, unique password'
               type='password'
@@ -94,7 +93,6 @@ export default class CreateAccount extends Component {
           </div>
           <div className={ styles.password }>
             <Input
-              className={ styles.password }
               label='password (repeat)'
               hint='verify your password'
               type='password'

--- a/js/src/modals/CreateAccount/NewImport/newImport.js
+++ b/js/src/modals/CreateAccount/NewImport/newImport.js
@@ -72,7 +72,6 @@ export default class NewImport extends Component {
         <div className={ styles.passwords }>
           <div className={ styles.password }>
             <Input
-              className={ styles.password }
               label='password'
               hint='the password to unlock the wallet'
               type='password'

--- a/js/src/modals/CreateAccount/RawKey/rawKey.js
+++ b/js/src/modals/CreateAccount/RawKey/rawKey.js
@@ -75,7 +75,6 @@ export default class RawKey extends Component {
         <div className={ styles.passwords }>
           <div className={ styles.password }>
             <Input
-              className={ styles.password }
               label='password'
               hint='a strong, unique password'
               type='password'
@@ -85,7 +84,6 @@ export default class RawKey extends Component {
           </div>
           <div className={ styles.password }>
             <Input
-              className={ styles.password }
               label='password (repeat)'
               hint='verify your password'
               type='password'

--- a/js/src/modals/CreateAccount/RecoveryPhrase/recoveryPhrase.js
+++ b/js/src/modals/CreateAccount/RecoveryPhrase/recoveryPhrase.js
@@ -72,7 +72,6 @@ export default class RecoveryPhrase extends Component {
         <div className={ styles.passwords }>
           <div className={ styles.password }>
             <Input
-              className={ styles.password }
               label='password'
               hint='a strong, unique password'
               type='password'
@@ -82,7 +81,6 @@ export default class RecoveryPhrase extends Component {
           </div>
           <div className={ styles.password }>
             <Input
-              className={ styles.password }
               label='password (repeat)'
               hint='verify your password'
               type='password'

--- a/js/src/modals/CreateAccount/createAccount.css
+++ b/js/src/modals/CreateAccount/createAccount.css
@@ -21,6 +21,15 @@
 .password {
   flex: 0 1 50%;
   width: 50%;
+  box-sizing: border-box;
+
+  &:nth-child(odd) {
+    padding-right: 0.25rem;
+  }
+
+  &:nth-child(even) {
+    padding-left: 0.25rem;
+  }
 }
 
 .passwords {

--- a/js/src/ui/Container/Title/title.css
+++ b/js/src/ui/Container/Title/title.css
@@ -15,7 +15,6 @@
 /* along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 */
 .byline {
-  color: #aaa;
   overflow: hidden;
   position: relative;
   line-height: 1.2em;
@@ -24,6 +23,12 @@
   display: -webkit-box;
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
+
+  color: #aaa;
+
+  * {
+    color: #aaa !important;
+  }
 }
 
 .title {

--- a/js/src/ui/Container/Title/title.js
+++ b/js/src/ui/Container/Title/title.js
@@ -26,7 +26,7 @@ export default class Title extends Component {
     ]),
     byline: PropTypes.oneOfType([
       PropTypes.string, PropTypes.node
-    ]),
+    ])
   }
 
   state = {

--- a/js/src/ui/Container/Title/title.js
+++ b/js/src/ui/Container/Title/title.js
@@ -24,7 +24,9 @@ export default class Title extends Component {
     title: PropTypes.oneOfType([
       PropTypes.string, PropTypes.node
     ]),
-    byline: PropTypes.string
+    byline: PropTypes.oneOfType([
+      PropTypes.string, PropTypes.node
+    ]),
   }
 
   state = {
@@ -34,15 +36,21 @@ export default class Title extends Component {
   render () {
     const { className, title, byline } = this.props;
 
+    const byLine = typeof byline === 'string'
+      ? (
+      <span title={ byline }>
+        { byline }
+      </span>
+      )
+      : byline;
+
     return (
       <div className={ className }>
         <h3 className={ styles.title }>
           { title }
         </h3>
         <div className={ styles.byline }>
-          <span title={ byline }>
-            { byline }
-          </span>
+          { byLine }
         </div>
       </div>
     );

--- a/js/src/ui/Form/Input/input.css
+++ b/js/src/ui/Form/Input/input.css
@@ -1,0 +1,37 @@
+/* Copyright 2015, 2016 Ethcore (UK) Ltd.
+/* This file is part of Parity.
+/*
+/* Parity is free software: you can redistribute it and/or modify
+/* it under the terms of the GNU General Public License as published by
+/* the Free Software Foundation, either version 3 of the License, or
+/* (at your option) any later version.
+/*
+/* Parity is distributed in the hope that it will be useful,
+/* but WITHOUT ANY WARRANTY; without even the implied warranty of
+/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+/* GNU General Public License for more details.
+/*
+/* You should have received a copy of the GNU General Public License
+/* along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+.container {
+  position: relative;
+}
+
+.copy {
+  position: absolute;
+  bottom: 11px;
+
+  svg {
+    transition: all .5s ease-in-out;
+  }
+
+  &.right {
+    right: 0;
+  }
+
+  &.left {
+    left: 0;
+  }
+}

--- a/js/src/ui/Form/Input/input.css
+++ b/js/src/ui/Form/Input/input.css
@@ -16,21 +16,16 @@
 */
 
 .container {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-end;
   position: relative;
 }
 
 .copy {
-  position: absolute;
+  margin-right: 0.5em;
 
   svg {
     transition: all .5s ease-in-out;
-  }
-
-  &.right {
-    right: 0;
-  }
-
-  &.left {
-    left: 0;
   }
 }

--- a/js/src/ui/Form/Input/input.css
+++ b/js/src/ui/Form/Input/input.css
@@ -21,7 +21,6 @@
 
 .copy {
   position: absolute;
-  bottom: 11px;
 
   svg {
     transition: all .5s ease-in-out;

--- a/js/src/ui/Form/Input/input.js
+++ b/js/src/ui/Form/Input/input.js
@@ -62,6 +62,7 @@ export default class Input extends Component {
     rows: PropTypes.number,
     type: PropTypes.string,
     submitOnBlur: PropTypes.bool,
+    hideUnderline: PropTypes.bool,
     value: PropTypes.oneOfType([
       PropTypes.number, PropTypes.string
     ])
@@ -71,7 +72,8 @@ export default class Input extends Component {
     submitOnBlur: true,
     readOnly: false,
     copiable: false,
-    copyPosition: 'left'
+    copyPosition: 'left',
+    hideUnderline: false
   }
 
   state = {
@@ -96,11 +98,12 @@ export default class Input extends Component {
 
   render () {
     const { value } = this.state;
-    const { children, className, copiable, copyPosition, disabled, error, label, hint, multiLine, rows, type } = this.props;
+    const { children, className, copiable, copyPosition, hideUnderline, disabled, error, label, hint, multiLine, rows, type } = this.props;
 
     const readOnly = this.props.readOnly || disabled;
 
-    const inputStyle = {};
+    const inputStyle = { overflow: 'hidden' };
+    const textFieldStyle = {};
 
     if (readOnly) {
       inputStyle.cursor = 'text';
@@ -110,11 +113,16 @@ export default class Input extends Component {
       inputStyle.paddingLeft = 24;
     }
 
+    if (hideUnderline && !hint) {
+      textFieldStyle.height = 'initial';
+    }
+
     return (
       <div className={ styles.container }>
         <TextField
           autoComplete='off'
           className={ className }
+          style={ textFieldStyle }
 
           readOnly={ readOnly }
 
@@ -131,6 +139,7 @@ export default class Input extends Component {
           underlineDisabledStyle={ UNDERLINE_DISABLED }
           underlineStyle={ readOnly ? UNDERLINE_READONLY : UNDERLINE_NORMAL }
           underlineFocusStyle={ readOnly ? { display: 'none' } : null }
+          underlineShow={ !hideUnderline }
           value={ value }
           onBlur={ this.onBlur }
           onChange={ this.onChange }
@@ -145,12 +154,16 @@ export default class Input extends Component {
   }
 
   renderCopyButton () {
-    const { copiable, copyPosition } = this.props;
+    const { copiable, copyPosition, hideUnderline, label, hint } = this.props;
     const { copied, value } = this.state;
 
     if (!copiable) {
       return null;
     }
+
+    const style = {
+      bottom: 13
+    };
 
     const text = typeof copiable === 'string'
       ? copiable
@@ -163,8 +176,16 @@ export default class Input extends Component {
     const scale = copied ? 'scale(1.15)' : 'scale(1)';
     const classes = [ styles.copy, styles[copyPosition] ];
 
+    if (hideUnderline && !label) {
+      style.bottom = 2;
+    } else if (label && !hint) {
+      style.bottom = 4;
+    } else if (label && hint) {
+      style.bottom = 10;
+    }
+
     return (
-      <div className={ classes.join(' ') }>
+      <div className={ classes.join(' ') } style={ style }>
         <CopyToClipboard
           onCopy={ this.handleCopy }
           text={ text } >

--- a/js/src/ui/Form/Input/input.js
+++ b/js/src/ui/Form/Input/input.js
@@ -46,7 +46,7 @@ export default class Input extends Component {
     className: PropTypes.string,
     disabled: PropTypes.bool,
     readOnly: PropTypes.bool,
-    copiable: PropTypes.oneOfType([
+    allowCopy: PropTypes.oneOfType([
       PropTypes.string,
       PropTypes.bool
     ]),
@@ -71,7 +71,7 @@ export default class Input extends Component {
   static defaultProps = {
     submitOnBlur: true,
     readOnly: false,
-    copiable: false,
+    allowCopy: false,
     copyPosition: 'left',
     hideUnderline: false
   }
@@ -98,7 +98,7 @@ export default class Input extends Component {
 
   render () {
     const { value } = this.state;
-    const { children, className, copiable, copyPosition, hideUnderline, disabled, error, label, hint, multiLine, rows, type } = this.props;
+    const { children, className, allowCopy, copyPosition, hideUnderline, disabled, error, label, hint, multiLine, rows, type } = this.props;
 
     const readOnly = this.props.readOnly || disabled;
 
@@ -109,7 +109,7 @@ export default class Input extends Component {
       inputStyle.cursor = 'text';
     }
 
-    if (copiable && copyPosition === 'left') {
+    if (allowCopy && copyPosition === 'left') {
       inputStyle.paddingLeft = 24;
     }
 
@@ -154,10 +154,10 @@ export default class Input extends Component {
   }
 
   renderCopyButton () {
-    const { copiable, copyPosition, hideUnderline, label, hint } = this.props;
+    const { allowCopy, copyPosition, hideUnderline, label, hint } = this.props;
     const { copied, value } = this.state;
 
-    if (!copiable) {
+    if (!allowCopy) {
       return null;
     }
 
@@ -165,8 +165,8 @@ export default class Input extends Component {
       bottom: 13
     };
 
-    const text = typeof copiable === 'string'
-      ? copiable
+    const text = typeof allowCopy === 'string'
+      ? allowCopy
       : value;
 
     const tooltipPosition = copyPosition === 'left'

--- a/js/src/ui/Form/Input/input.js
+++ b/js/src/ui/Form/Input/input.js
@@ -50,7 +50,7 @@ export default class Input extends Component {
       PropTypes.string,
       PropTypes.bool
     ]),
-    copyPosition: PropTypes.oneOf([ 'left', 'right' ]),
+    floatCopy: PropTypes.bool,
     error: PropTypes.string,
     hint: PropTypes.string,
     label: PropTypes.string,
@@ -72,8 +72,8 @@ export default class Input extends Component {
     submitOnBlur: true,
     readOnly: false,
     allowCopy: false,
-    copyPosition: 'left',
-    hideUnderline: false
+    hideUnderline: false,
+    floatCopy: false
   }
 
   state = {
@@ -98,7 +98,7 @@ export default class Input extends Component {
 
   render () {
     const { value } = this.state;
-    const { children, className, allowCopy, copyPosition, hideUnderline, disabled, error, label, hint, multiLine, rows, type } = this.props;
+    const { children, className, hideUnderline, disabled, error, label, hint, multiLine, rows, type } = this.props;
 
     const readOnly = this.props.readOnly || disabled;
 
@@ -109,16 +109,13 @@ export default class Input extends Component {
       inputStyle.cursor = 'text';
     }
 
-    if (allowCopy && copyPosition === 'left') {
-      inputStyle.paddingLeft = 24;
-    }
-
     if (hideUnderline && !hint) {
       textFieldStyle.height = 'initial';
     }
 
     return (
       <div className={ styles.container }>
+        { this.renderCopyButton() }
         <TextField
           autoComplete='off'
           className={ className }
@@ -148,13 +145,12 @@ export default class Input extends Component {
         >
           { children }
         </TextField>
-        { this.renderCopyButton() }
       </div>
     );
   }
 
   renderCopyButton () {
-    const { allowCopy, copyPosition, hideUnderline, label, hint } = this.props;
+    const { allowCopy, hideUnderline, label, hint, floatCopy } = this.props;
     const { copied, value } = this.state;
 
     if (!allowCopy) {
@@ -162,36 +158,38 @@ export default class Input extends Component {
     }
 
     const style = {
-      bottom: 13
+      marginBottom: 13
     };
 
     const text = typeof allowCopy === 'string'
       ? allowCopy
       : value;
 
-    const tooltipPosition = copyPosition === 'left'
-      ? 'bottom-right'
-      : 'top-left';
-
     const scale = copied ? 'scale(1.15)' : 'scale(1)';
-    const classes = [ styles.copy, styles[copyPosition] ];
 
     if (hideUnderline && !label) {
-      style.bottom = 2;
+      style.marginBottom = 2;
     } else if (label && !hint) {
-      style.bottom = 4;
+      style.marginBottom = 4;
     } else if (label && hint) {
-      style.bottom = 10;
+      style.marginBottom = 10;
+    }
+
+    if (floatCopy) {
+      style.position = 'absolute';
+      style.left = -24;
+      style.bottom = style.marginBottom;
+      style.marginBottom = 0;
     }
 
     return (
-      <div className={ classes.join(' ') } style={ style }>
+      <div className={ styles.copy } style={ style }>
         <CopyToClipboard
           onCopy={ this.handleCopy }
           text={ text } >
           <IconButton
             tooltip={ `${copied ? 'Copied' : 'Copy'} to clipboard` }
-            tooltipPosition={ tooltipPosition }
+            tooltipPosition='bottom-right'
             style={ {
               width: 16,
               height: 16,

--- a/js/src/ui/Form/Input/input.js
+++ b/js/src/ui/Form/Input/input.js
@@ -16,7 +16,10 @@
 
 import React, { Component, PropTypes } from 'react';
 
-import { TextField } from 'material-ui';
+import CopyToClipboard from 'react-copy-to-clipboard';
+import CopyIcon from 'material-ui/svg-icons/content/content-copy';
+import { TextField, IconButton } from 'material-ui';
+import { lightWhite, fullWhite } from 'material-ui/styles/colors';
 
 // TODO: duplicated in Select
 const UNDERLINE_DISABLED = {
@@ -41,6 +44,10 @@ export default class Input extends Component {
     className: PropTypes.string,
     disabled: PropTypes.bool,
     readOnly: PropTypes.bool,
+    copiable: PropTypes.oneOfType([
+      PropTypes.string,
+      PropTypes.bool
+    ]),
     error: PropTypes.string,
     hint: PropTypes.string,
     label: PropTypes.string,
@@ -59,11 +66,13 @@ export default class Input extends Component {
 
   static defaultProps = {
     submitOnBlur: true,
-    readOnly: false
+    readOnly: false,
+    copiable: false
   }
 
   state = {
-    value: this.props.value || ''
+    value: this.props.value || '',
+    copied: false
   }
 
   componentWillReceiveProps (newProps) {
@@ -105,8 +114,53 @@ export default class Input extends Component {
         inputStyle={ readOnly ? { cursor: 'text' } : null }
       >
         { children }
+        { this.renderCopyButton() }
       </TextField>
     );
+  }
+
+  renderCopyButton () {
+    const { copiable } = this.props;
+    const { copied, value } = this.state;
+
+    if (!copiable) {
+      return null;
+    }
+
+    const text = typeof copiable === 'string'
+      ? copiable
+      : value;
+
+    return (
+      <CopyToClipboard
+        onCopy={ this.handleCopy }
+        text={ text } >
+        <IconButton
+          tooltip='Copy to clipboard'
+          tooltipPosition='top-center'
+          style={ {
+            width: 32,
+            height: 16,
+            padding: 0
+          } }
+          iconStyle={ {
+            width: 16,
+            height: 16
+          } }>
+          <CopyIcon
+            color={ copied ? lightWhite : fullWhite }
+          />
+        </IconButton>
+      </CopyToClipboard>
+    );
+  }
+
+  handleCopy = () => {
+    this.setState({ copied: true }, () => {
+      window.setTimeout(() => {
+        this.setState({ copied: false });
+      }, 4000);
+    });
   }
 
   onChange = (event, value) => {
@@ -145,8 +199,6 @@ export default class Input extends Component {
   }
 
   setValue (value) {
-    this.setState({
-      value
-    });
+    this.setState({ value });
   }
 }

--- a/js/src/ui/Form/Input/input.js
+++ b/js/src/ui/Form/Input/input.js
@@ -20,7 +20,13 @@ import { TextField } from 'material-ui';
 
 // TODO: duplicated in Select
 const UNDERLINE_DISABLED = {
-  borderColor: 'rgba(255, 255, 255, 0.298039)' // 'transparent' // 'rgba(255, 255, 255, 0.298039)'
+  borderBottom: 'dotted 2px',
+  borderColor: 'rgba(255, 255, 255, 0.125)' // 'transparent' // 'rgba(255, 255, 255, 0.298039)'
+};
+
+const UNDERLINE_READONLY = {
+  ...UNDERLINE_DISABLED,
+  cursor: 'text'
 };
 
 const UNDERLINE_NORMAL = {
@@ -34,6 +40,7 @@ export default class Input extends Component {
     children: PropTypes.node,
     className: PropTypes.string,
     disabled: PropTypes.bool,
+    readOnly: PropTypes.bool,
     error: PropTypes.string,
     hint: PropTypes.string,
     label: PropTypes.string,
@@ -48,10 +55,11 @@ export default class Input extends Component {
     value: PropTypes.oneOfType([
       PropTypes.number, PropTypes.string
     ])
-  }
+  };
 
   static defaultProps = {
-    submitOnBlur: true
+    submitOnBlur: true,
+    readOnly: false
   }
 
   state = {
@@ -68,11 +76,15 @@ export default class Input extends Component {
     const { value } = this.state;
     const { children, className, disabled, error, label, hint, multiLine, rows, type } = this.props;
 
+    const readOnly = this.props.readOnly || disabled;
+
     return (
       <TextField
         autoComplete='off'
         className={ className }
-        disabled={ disabled }
+
+        readOnly={ readOnly }
+
         errorText={ error }
         floatingLabelFixed
         floatingLabelText={ label }
@@ -84,11 +96,14 @@ export default class Input extends Component {
         rows={ rows }
         type={ type || 'text' }
         underlineDisabledStyle={ UNDERLINE_DISABLED }
-        underlineStyle={ UNDERLINE_NORMAL }
+        underlineStyle={ readOnly ? UNDERLINE_READONLY : UNDERLINE_NORMAL }
+        underlineFocusStyle={ readOnly ? { display: 'none' } : null }
         value={ value }
         onBlur={ this.onBlur }
         onChange={ this.onChange }
-        onKeyDown={ this.onKeyDown }>
+        onKeyDown={ this.onKeyDown }
+        inputStyle={ readOnly ? { cursor: 'text' } : null }
+      >
         { children }
       </TextField>
     );

--- a/js/src/ui/Form/InputAddress/inputAddress.css
+++ b/js/src/ui/Form/InputAddress/inputAddress.css
@@ -29,4 +29,5 @@
 .icon {
   position: absolute;
   top: 35px;
+  left: 24px;
 }

--- a/js/src/ui/Form/InputAddress/inputAddress.js
+++ b/js/src/ui/Form/InputAddress/inputAddress.js
@@ -62,7 +62,6 @@ class InputAddress extends Component {
           onChange={ this.handleInputChange }
           onSubmit={ onSubmit }
           allowCopy={ disabled ? value : false }
-          copyPosition='right'
         />
         { icon }
       </div>

--- a/js/src/ui/Form/InputAddress/inputAddress.js
+++ b/js/src/ui/Form/InputAddress/inputAddress.js
@@ -60,7 +60,10 @@ class InputAddress extends Component {
           error={ error }
           value={ text && hasAccount ? account.name : value }
           onChange={ this.handleInputChange }
-          onSubmit={ onSubmit } />
+          onSubmit={ onSubmit }
+          copiable={ disabled ? value : false }
+          copyPosition='right'
+        />
         { icon }
       </div>
     );

--- a/js/src/ui/Form/InputAddress/inputAddress.js
+++ b/js/src/ui/Form/InputAddress/inputAddress.js
@@ -61,7 +61,7 @@ class InputAddress extends Component {
           value={ text && hasAccount ? account.name : value }
           onChange={ this.handleInputChange }
           onSubmit={ onSubmit }
-          copiable={ disabled ? value : false }
+          allowCopy={ disabled ? value : false }
           copyPosition='right'
         />
         { icon }

--- a/js/src/ui/MethodDecoding/methodDecoding.js
+++ b/js/src/ui/MethodDecoding/methodDecoding.js
@@ -268,7 +268,8 @@ class MethodDecoding extends Component {
         default:
           return (
             <Input
-              disabled
+              readOnly
+              allowCopy
               key={ index }
               className={ styles.input }
               value={ this.renderValue(input.value) }

--- a/js/src/ui/Tooltips/tooltips.js
+++ b/js/src/ui/Tooltips/tooltips.js
@@ -49,7 +49,6 @@ class Tooltips extends Component {
   redirect (props = this.props) {
     const { currentId } = props;
 
-    console.log('c', { currentId });
     if (currentId !== undefined && currentId !== -1) {
       const viewLink = '/accounts/';
       this.context.router.push(viewLink);

--- a/js/src/views/Accounts/Summary/summary.js
+++ b/js/src/views/Accounts/Summary/summary.js
@@ -17,7 +17,7 @@
 import React, { Component, PropTypes } from 'react';
 import { Link } from 'react-router';
 
-import { Balance, Container, ContainerTitle, IdentityIcon, IdentityName, Tags } from '../../../ui';
+import { Balance, Container, ContainerTitle, IdentityIcon, IdentityName, Tags, Input } from '../../../ui';
 
 export default class Summary extends Component {
   static contextTypes = {
@@ -47,6 +47,16 @@ export default class Summary extends Component {
     const { address } = account;
     const viewLink = `/${link || 'account'}/${address}`;
 
+    const addressComponent = (
+      <Input
+        readOnly
+        hideUnderline
+        value={ address }
+        copiable={ address }
+        copyPosition='left'
+      />
+    );
+
     return (
       <Container>
         <Tags tags={ tags } handleAddSearchToken={ handleAddSearchToken } />
@@ -54,7 +64,7 @@ export default class Summary extends Component {
           address={ address } />
         <ContainerTitle
           title={ <Link to={ viewLink }>{ <IdentityName address={ address } unknown /> }</Link> }
-          byline={ address } />
+          byline={ addressComponent } />
         <Balance
           balance={ balance } />
         { children }

--- a/js/src/views/Accounts/Summary/summary.js
+++ b/js/src/views/Accounts/Summary/summary.js
@@ -52,7 +52,7 @@ export default class Summary extends Component {
         readOnly
         hideUnderline
         value={ address }
-        copiable={ address }
+        allowCopy={ address }
         copyPosition='left'
       />
     );

--- a/js/src/views/Accounts/Summary/summary.js
+++ b/js/src/views/Accounts/Summary/summary.js
@@ -53,7 +53,6 @@ export default class Summary extends Component {
         hideUnderline
         value={ address }
         allowCopy={ address }
-        copyPosition='left'
       />
     );
 

--- a/js/src/views/Application/application.js
+++ b/js/src/views/Application/application.js
@@ -42,7 +42,8 @@ class Application extends Component {
     children: PropTypes.node,
     netChain: PropTypes.string,
     isTest: PropTypes.bool,
-    pending: PropTypes.array
+    pending: PropTypes.array,
+    blockNumber: PropTypes.object
   }
 
   state = {
@@ -73,7 +74,7 @@ class Application extends Component {
   }
 
   renderApp () {
-    const { children, pending, netChain, isTest } = this.props;
+    const { children, pending, netChain, isTest, blockNumber } = this.props;
     const { showFirstRun } = this.state;
 
     return (
@@ -85,7 +86,7 @@ class Application extends Component {
           isTest={ isTest }
           pending={ pending } />
         { children }
-        <Status />
+        { blockNumber ? (<Status />) : null }
       </Container>
     );
   }
@@ -124,7 +125,7 @@ class Application extends Component {
 }
 
 function mapStateToProps (state) {
-  const { netChain, isTest } = state.nodeStatus;
+  const { netChain, isTest, blockNumber } = state.nodeStatus;
   const { hasAccounts } = state.personal;
   const { pending } = state.signer;
 
@@ -132,7 +133,8 @@ function mapStateToProps (state) {
     hasAccounts,
     netChain,
     isTest,
-    pending
+    pending,
+    blockNumber
   };
 }
 

--- a/js/src/views/Contract/Events/Event/event.js
+++ b/js/src/views/Contract/Events/Event/event.js
@@ -129,10 +129,12 @@ class Event extends Component {
 
         return (
           <Input
-            disabled
+            readOnly
+            copiable
             className={ styles.input }
             value={ value }
-            label={ name } />
+            label={ name }
+          />
         );
     }
   }

--- a/js/src/views/Contract/Events/Event/event.js
+++ b/js/src/views/Contract/Events/Event/event.js
@@ -130,7 +130,7 @@ class Event extends Component {
         return (
           <Input
             readOnly
-            copiable
+            allowCopy
             className={ styles.input }
             value={ value }
             label={ name }

--- a/js/src/views/Contract/Queries/inputQuery.js
+++ b/js/src/views/Contract/Queries/inputQuery.js
@@ -112,7 +112,7 @@ export default class InputQuery extends Component {
           <Input
             className={ styles.queryValue }
             readOnly
-            copiable
+            allowCopy
             value={ out.display }
           />
           <br />

--- a/js/src/views/Contract/Queries/inputQuery.js
+++ b/js/src/views/Contract/Queries/inputQuery.js
@@ -16,7 +16,6 @@
 
 import BigNumber from 'bignumber.js';
 import React, { Component, PropTypes } from 'react';
-import Chip from 'material-ui/Chip';
 import LinearProgress from 'material-ui/LinearProgress';
 import { Card, CardActions, CardTitle, CardText } from 'material-ui/Card';
 
@@ -104,13 +103,21 @@ export default class InputQuery extends Component {
         display: this.renderValue(results[index])
       }))
       .sort((outA, outB) => outA.display.length - outB.display.length)
-      .map((out, index) => (<div key={ index }>
-        <div className={ styles.queryResultName }>{ out.name }</div>
-        <Chip className={ styles.queryValue }>
-          { out.display }
-        </Chip>
-        <br />
-      </div>));
+      .map((out, index) => (
+        <div key={ index }>
+          <div className={ styles.queryResultName }>
+            { out.name }
+          </div>
+
+          <Input
+            className={ styles.queryValue }
+            readOnly
+            copiable
+            value={ out.display }
+          />
+          <br />
+        </div>
+      ));
   }
 
   renderInput (input) {

--- a/js/src/views/Contract/Queries/queries.css
+++ b/js/src/views/Contract/Queries/queries.css
@@ -63,25 +63,25 @@
 }
 
 .methodResults > div {
-  margin: 0.5rem;
+  padding: 0.25rem 0.5rem;
   display: flex;
   flex-direction: column;
   align-items: center;
-  max-width: 100%;
+  flex: 1 1 50%;
+  box-sizing: border-box;
+
+  & > div {
+    width: 100%;
+  }
+}
+
+.queryValue {
+  width: 100%;
 }
 
 .queryValue, .queryValue * {
-  user-select: text !important;
-  max-width: 100%;
-  box-sizing: border-box;
   white-space: normal !important;
   overflow-wrap: break-word !important;
-}
-
-.queryValue:hover {
-  cursor: text !important;
-}
-
-.queryResultName {
-  margin-bottom: 0.25rem;
+  max-width: 100%;
+  box-sizing: border-box;
 }

--- a/js/src/views/Contract/Queries/queries.js
+++ b/js/src/views/Contract/Queries/queries.js
@@ -129,7 +129,7 @@ export default class Queries extends Component {
         className={ styles.queryValue }
         value={ valueToDisplay }
         readOnly
-        copiable
+        allowCopy
       />
     );
   }

--- a/js/src/views/Contract/Queries/queries.js
+++ b/js/src/views/Contract/Queries/queries.js
@@ -16,11 +16,10 @@
 
 import BigNumber from 'bignumber.js';
 import React, { Component, PropTypes } from 'react';
-import Chip from 'material-ui/Chip';
 import { Card, CardTitle, CardText } from 'material-ui/Card';
 
 import InputQuery from './inputQuery';
-import { Container, ContainerTitle } from '../../../ui';
+import { Container, ContainerTitle, Input } from '../../../ui';
 
 import styles from './queries.css';
 
@@ -126,9 +125,12 @@ export default class Queries extends Component {
     }
 
     return (
-      <Chip className={ styles.queryValue }>
-        { valueToDisplay }
-      </Chip>
+      <Input
+        className={ styles.queryValue }
+        value={ valueToDisplay }
+        readOnly
+        copiable
+      />
     );
   }
 

--- a/js/src/views/Settings/Background/background.js
+++ b/js/src/views/Settings/Background/background.js
@@ -82,9 +82,9 @@ class Background extends Component {
     const { settings } = this.props;
     const { seeds } = this.state;
 
-    return seeds.map((seed) => {
+    return seeds.map((seed, index) => {
       return (
-        <div className={ styles.bgflex } key={ seed }>
+        <div className={ styles.bgflex } key={ index }>
           <div className={ styles.bgseed }>
             <ParityBackground
               className={ settings.backgroundSeed === seed ? styles.seedactive : styles.seed }

--- a/js/src/views/Status/components/MiningSettings/MiningSettings.js
+++ b/js/src/views/Status/components/MiningSettings/MiningSettings.js
@@ -45,7 +45,7 @@ export default class MiningSettings extends Component {
           hint='the mining author'
           value={ coinbase }
           onSubmit={ this.onAuthorChange }
-          copiable
+          allowCopy
           { ...this._test('author') } />
         <Input
           label='extradata'

--- a/js/src/views/Status/components/MiningSettings/MiningSettings.js
+++ b/js/src/views/Status/components/MiningSettings/MiningSettings.js
@@ -46,26 +46,40 @@ export default class MiningSettings extends Component {
           value={ coinbase }
           onSubmit={ this.onAuthorChange }
           allowCopy
-          { ...this._test('author') } />
+          floatCopy
+          { ...this._test('author') }
+        />
+
         <Input
           label='extradata'
           hint='extra data for mined blocks'
           value={ decodeExtraData(extraData) }
           onSubmit={ this.onExtraDataChange }
           defaultValue={ decodeExtraData(defaultExtraData) }
-          { ...this._test('extra-data') } />
+          allowCopy
+          floatCopy
+          { ...this._test('extra-data') }
+        />
+
         <Input
           label='minimal gas price'
           hint='the minimum gas price for mining'
           value={ toNiceNumber(minGasPrice) }
           onSubmit={ this.onMinGasPriceChange }
-          { ...this._test('min-gas-price') } />
+          allowCopy={ minGasPrice.toString() }
+          floatCopy
+          { ...this._test('min-gas-price') }
+        />
+
         <Input
           label='gas floor target'
           hint='the gas floor target for mining'
           value={ toNiceNumber(gasFloorTarget) }
           onSubmit={ this.onGasFloorTargetChange }
-          { ...this._test('gas-floor-target') } />
+          allowCopy={ gasFloorTarget.toString() }
+          floatCopy
+          { ...this._test('gas-floor-target') }
+        />
       </div>
     );
   }

--- a/js/src/views/Status/components/MiningSettings/MiningSettings.js
+++ b/js/src/views/Status/components/MiningSettings/MiningSettings.js
@@ -45,6 +45,7 @@ export default class MiningSettings extends Component {
           hint='the mining author'
           value={ coinbase }
           onSubmit={ this.onAuthorChange }
+          copiable
           { ...this._test('author') } />
         <Input
           label='extradata'

--- a/js/src/views/Status/components/Status/Status.js
+++ b/js/src/views/Status/components/Status/Status.js
@@ -133,7 +133,7 @@ export default class Status extends Component {
           </div>
           <div className={ styles.col6 }>
             <Input
-              disabled
+              readOnly
               label='rpc port'
               value={ rpcSettings.port.toString() }
               { ...this._test('rpc-port') } />

--- a/js/src/views/Status/components/Status/Status.js
+++ b/js/src/views/Status/components/Status/Status.js
@@ -134,7 +134,6 @@ export default class Status extends Component {
           <div className={ styles.col6 }>
             <Input
               readOnly
-              copiable
               label='rpc port'
               value={ rpcSettings.port.toString() }
               { ...this._test('rpc-port') } />

--- a/js/src/views/Status/components/Status/Status.js
+++ b/js/src/views/Status/components/Status/Status.js
@@ -97,21 +97,21 @@ export default class Status extends Component {
       <div { ...this._test('settings') }>
         <ContainerTitle title='network settings' />
         <Input
-          disabled
+          readOnly
           label='chain'
           value={ nodeStatus.netChain }
           { ...this._test('chain') } />
         <div className={ styles.row }>
           <div className={ styles.col6 }>
             <Input
-              disabled
+              readOnly
               label='peers'
               value={ peers }
               { ...this._test('peers') } />
           </div>
           <div className={ styles.col6 }>
             <Input
-              disabled
+              readOnly
               label='network port'
               value={ nodeStatus.netPort.toString() }
               { ...this._test('network-port') } />
@@ -119,14 +119,14 @@ export default class Status extends Component {
         </div>
 
         <Input
-          disabled
+          readOnly
           label='rpc enabled'
           value={ rpcSettings.enabled ? 'yes' : 'no' }
           { ...this._test('rpc-enabled') } />
         <div className={ styles.row }>
           <div className={ styles.col6 }>
             <Input
-              disabled
+              readOnly
               label='rpc interface'
               value={ rpcSettings.interface }
               { ...this._test('rpc-interface') } />

--- a/js/src/views/Status/components/Status/Status.js
+++ b/js/src/views/Status/components/Status/Status.js
@@ -134,6 +134,7 @@ export default class Status extends Component {
           <div className={ styles.col6 }>
             <Input
               readOnly
+              copiable
               label='rpc port'
               value={ rpcSettings.port.toString() }
               { ...this._test('rpc-port') } />


### PR DESCRIPTION
This should fix #3066 #3052 and #3009 

`disabled` inputs are converted to `readonly` inputs.
New props can be added to `Input` components to render a _Copy to Clipboard_ button.
This has been added in Contracts/Accounts/Events/Account Creation....