### PR TITLE
Dapps errors embeddable on signer

### DIFF
--- a/dapps/src/handlers/content.rs
+++ b/dapps/src/handlers/content.rs
@@ -48,11 +48,7 @@ impl ContentHandler {
 		Self::new_embeddable(code, content, mime!(Text/Html), embeddable_at)
 	}
 
-	pub fn error(code: StatusCode, title: &str, message: &str, details: Option<&str>) -> Self {
-		Self::error_embeddable(code, title, message, details, None)
-	}
-
-	pub fn error_embeddable(code: StatusCode, title: &str, message: &str, details: Option<&str>, embeddable_at: Option<u16>) -> Self {
+	pub fn error(code: StatusCode, title: &str, message: &str, details: Option<&str>, embeddable_at: Option<u16>) -> Self {
 		Self::html(code, format!(
 			include_str!("../error_tpl.html"),
 			title=title,

--- a/dapps/src/page/handler.rs
+++ b/dapps/src/page/handler.rs
@@ -59,7 +59,7 @@ pub enum ServedFile<T: Dapp> {
 
 impl<T: Dapp> ServedFile<T> {
 	pub fn new(embeddable_at: Option<u16>) -> Self {
-		ServedFile::Error(ContentHandler::error_embeddable(
+		ServedFile::Error(ContentHandler::error(
 			StatusCode::NotFound,
 			"404 Not Found",
 			"Requested dapp resource was not found.",

--- a/dapps/src/router/auth.rs
+++ b/dapps/src/router/auth.rs
@@ -59,7 +59,8 @@ impl Authorization for HttpBasicAuth {
 					status::StatusCode::Unauthorized,
 					"Unauthorized",
 					"You need to provide valid credentials to access this page.",
-					None
+					None,
+					None,
 				)))
 			},
 			Access::AuthRequired => {

--- a/dapps/src/router/host_validation.rs
+++ b/dapps/src/router/host_validation.rs
@@ -41,6 +41,7 @@ pub fn host_invalid_response() -> Box<server::Handler<HttpStream> + Send> {
 	Box::new(ContentHandler::error(StatusCode::Forbidden,
 		"Current Host Is Disallowed",
 		"You are trying to access your node using incorrect address.",
-		Some("Use allowed URL or specify different <code>hosts</code> CLI options.")
+		Some("Use allowed URL or specify different <code>hosts</code> CLI options."),
+		None,
 	))
 }

--- a/dapps/src/router/mod.rs
+++ b/dapps/src/router/mod.rs
@@ -117,6 +117,7 @@ impl<A: Authorization + 'static> server::Handler<HttpStream> for Router<A> {
 					"404 Not Found",
 					"Requested content was not found.",
 					None,
+					self.signer_port,
 				))
 			},
 			// Redirect any other GET request to signer.
@@ -131,6 +132,7 @@ impl<A: Authorization + 'static> server::Handler<HttpStream> for Router<A> {
 						"404 Not Found",
 						"Your homepage is not available when Trusted Signer is disabled.",
 						Some("You can still access dapps by writing a correct address, though. Re-enabled Signer to get your homepage back."),
+						self.signer_port,
 					))
 				}
 			},

--- a/dapps/src/tests/fetch.rs
+++ b/dapps/src/tests/fetch.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-use tests::helpers::{serve_with_registrar, serve_with_registrar_and_sync, request, assert_security_headers};
+use tests::helpers::{serve_with_registrar, serve_with_registrar_and_sync, request, assert_security_headers_for_embed};
 
 #[test]
 fn should_resolve_dapp() {
@@ -34,7 +34,7 @@ fn should_resolve_dapp() {
 	// then
 	assert_eq!(response.status, "HTTP/1.1 404 Not Found".to_owned());
 	assert_eq!(registrar.calls.lock().len(), 2);
-	assert_security_headers(&response.headers);
+	assert_security_headers_for_embed(&response.headers);
 }
 
 #[test]
@@ -63,5 +63,5 @@ fn should_return_503_when_syncing_but_should_make_the_calls() {
 	// then
 	assert_eq!(response.status, "HTTP/1.1 503 Service Unavailable".to_owned());
 	assert_eq!(registrar.calls.lock().len(), 4);
-	assert_security_headers(&response.headers);
+	assert_security_headers_for_embed(&response.headers);
 }

--- a/dapps/src/tests/redirection.rs
+++ b/dapps/src/tests/redirection.rs
@@ -14,7 +14,7 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-use tests::helpers::{serve, request, assert_security_headers};
+use tests::helpers::{serve, request, assert_security_headers, assert_security_headers_for_embed};
 
 #[test]
 fn should_redirect_to_home() {
@@ -93,7 +93,7 @@ fn should_display_404_on_invalid_dapp() {
 
 	// then
 	assert_eq!(response.status, "HTTP/1.1 404 Not Found".to_owned());
-	assert_security_headers(&response.headers);
+	assert_security_headers_for_embed(&response.headers);
 }
 
 #[test]
@@ -113,7 +113,7 @@ fn should_display_404_on_invalid_dapp_with_domain() {
 
 	// then
 	assert_eq!(response.status, "HTTP/1.1 404 Not Found".to_owned());
-	assert_security_headers(&response.headers);
+	assert_security_headers_for_embed(&response.headers);
 }
 
 #[test]


### PR DESCRIPTION
Example: When trying to load GavCoin (it's a network dapp now) and the node is still syncing the error should be displayed, but you see a white page because it's prevented from being embedded in an iframe.