### PR TITLE
Fixed peer ping timeout

### DIFF
--- a/util/network/src/session.rs
+++ b/util/network/src/session.rs
@@ -32,7 +32,8 @@ use node_table::NodeId;
 use stats::NetworkStats;
 use time;
 
-const PING_TIMEOUT_SEC: u64 = 65;
+// Timeout must be less than (interval - 1).
+const PING_TIMEOUT_SEC: u64 = 15;
 const PING_INTERVAL_SEC: u64 = 30;
 
 /// Peer session over encrypted connection.


### PR DESCRIPTION
Was increased temporarily for snapshot sync testing and never reverted