### PR TITLE
Make the footer a bit less ugly.

### DIFF
--- a/js/src/views/Application/Status/status.css
+++ b/js/src/views/Application/Status/status.css
@@ -15,12 +15,10 @@
 /* along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 */
 .status {
-  padding: 1.5em;
-  text-align: right;
-  color: #ddd;
-  display: flex;
-  flex-direction: column;
-  align-items: flex-end;
+  padding: 0.5em;
+  font-size: x-small;
+  color: #ccc;
+  background-color: rgba(0, 0, 0, 0.2)
 }
 
 .title {
@@ -29,12 +27,13 @@
 
 .enode {
   word-wrap: break-word;
-  margin: 0.5em 0 0.25em 0;
+  float: right;
 }
 
 .enode > * {
   display: inline-block;
-  margin-left: .5em;
+  margin: 0.25em 0.5em;
+  vertical-align: top;
 }
 
 .block {
@@ -43,9 +42,7 @@
 .netinfo {
   display: flex;
   align-items: center;
-  flex-direction: row;
-  justify-content: flex-end;
-  margin-top: 0.25em;
+  color: #ddd;  
 }
 
 .netinfo > * {
@@ -73,6 +70,8 @@
 }
 
 .version {
+  padding: 0.25em 0.5em;
+  float: left;
 }
 
 .syncing {

--- a/js/src/views/Application/Status/status.js
+++ b/js/src/views/Application/Status/status.js
@@ -48,15 +48,13 @@ class Status extends Component {
         </div>
         { this.renderEnode() }
         <div className={ styles.netinfo }>
-          <div>
             <BlockStatus />
-            <div className={ styles.peers }>
-              { netPeers.active.toFormat() }/{ netPeers.connected.toFormat() }/{ netPeers.max.toFormat() } peers
-            </div>
-          </div>
           <div className={ netStyle }>
             { isTest ? 'test' : netChain }
           </div>
+            <div className={ styles.peers }>
+              { netPeers.active.toFormat() }/{ netPeers.connected.toFormat() }/{ netPeers.max.toFormat() } peers
+            </div>
         </div>
       </div>
     );

--- a/js/src/views/Application/Status/status.js
+++ b/js/src/views/Application/Status/status.js
@@ -48,13 +48,13 @@ class Status extends Component {
         </div>
         { this.renderEnode() }
         <div className={ styles.netinfo }>
-            <BlockStatus />
+          <BlockStatus />
           <div className={ netStyle }>
             { isTest ? 'test' : netChain }
           </div>
-            <div className={ styles.peers }>
-              { netPeers.active.toFormat() }/{ netPeers.connected.toFormat() }/{ netPeers.max.toFormat() } peers
-            </div>
+          <div className={ styles.peers }>
+            { netPeers.active.toFormat() }/{ netPeers.connected.toFormat() }/{ netPeers.max.toFormat() } peers
+          </div>
         </div>
       </div>
     );


### PR DESCRIPTION
Not perfect by any means, but bandaid for 1.4 release.

1.5 should see all of this moved to a permanent home in the status page. Network ID, best block and peers may stay, but should probably be moved to the top menu bar and be given a more graphical rendering ala iPhone topbar.

![image](https://cloud.githubusercontent.com/assets/138296/19987873/8312a068-a21d-11e6-8168-9b4af8976b79.png)
