### PR TITLE
Push precompiled for beta/stable, npm only master

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -383,6 +383,8 @@ js-release:
   image: ethcore/javascript:latest
   only:
     - master
+    - beta
+    - stable
   before_script:
     - ./js/scripts/install-deps.sh
   script:

--- a/js/scripts/release.sh
+++ b/js/scripts/release.sh
@@ -65,16 +65,18 @@ git add Cargo.lock js/package.json
 git commit -m "[ci skip] js-precompiled $UTCDATE"
 git push origin HEAD:refs/heads/$BRANCH 2>$GITLOG
 
-echo "*** Building packages for npmjs"
-cd js
-# echo -e "$NPM_USERNAME\n$NPM_PASSWORD\n$NPM_EMAIL" | npm login
-echo "$NPM_TOKEN" >> ~/.npmrc
-npm run ci:build:npm
+if [ "$BRANCH" == "master" ]; then
+  echo "*** Building packages for npmjs"
+  cd js
+  # echo -e "$NPM_USERNAME\n$NPM_PASSWORD\n$NPM_EMAIL" | npm login
+  echo "$NPM_TOKEN" >> ~/.npmrc
+  npm run ci:build:npm
 
-echo "*** Publishing $PACKAGE to npmjs"
-cd .npmjs
-npm publish --access public
-cd ..
+  echo "*** Publishing $PACKAGE to npmjs"
+  cd .npmjs
+  npm publish --access public
+  cd ..
+fi
 
 # back to root
 echo "*** Release completed"

--- a/js/scripts/release.sh
+++ b/js/scripts/release.sh
@@ -50,22 +50,12 @@ setup_git_user
 git remote set-url origin $GIT_PARITY
 git reset --hard origin/$BRANCH 2>$GITLOG
 
-echo "*** Bumping package.json patch version"
-cd js
-npm --no-git-tag-version version
-npm version patch
-cd ..
-
-echo "*** Updating cargo parity-ui-precompiled#$PRECOMPILED_HASH"
-cargo update -p parity-ui-precompiled
-# --precise "$PRECOMPILED_HASH"
-
-echo "*** Committing updated files"
-git add Cargo.lock js/package.json
-git commit -m "[ci skip] js-precompiled $UTCDATE"
-git push origin HEAD:refs/heads/$BRANCH 2>$GITLOG
-
 if [ "$BRANCH" == "master" ]; then
+  cd js
+  echo "*** Bumping package.json patch version"
+  npm --no-git-tag-version version
+  npm version patch
+
   echo "*** Building packages for npmjs"
   cd js
   # echo -e "$NPM_USERNAME\n$NPM_PASSWORD\n$NPM_EMAIL" | npm login
@@ -77,6 +67,15 @@ if [ "$BRANCH" == "master" ]; then
   npm publish --access public
   cd ..
 fi
+
+echo "*** Updating cargo parity-ui-precompiled#$PRECOMPILED_HASH"
+cargo update -p parity-ui-precompiled
+# --precise "$PRECOMPILED_HASH"
+
+echo "*** Committing updated files"
+git add .
+git commit -m "[ci skip] js-precompiled $UTCDATE"
+git push origin HEAD:refs/heads/$BRANCH 2>$GITLOG
 
 # back to root
 echo "*** Release completed"


### PR DESCRIPTION
Update gitlab.yml to -

- also push to js-precompiled on the beta and stable branches (stable will be applicable on 1.5)
- update Cargo files with js-precompiled on applicable branch (part of normal release.sh process)

Update the release script to -

- only publish to npm on the master branch