### PR TITLE
Fixing possible race in ethcore_hashContent

### DIFF
--- a/rpc/src/v1/impls/ethcore.rs
+++ b/rpc/src/v1/impls/ethcore.rs
@@ -302,7 +302,9 @@ impl<C, M, S: ?Sized, F> Ethcore for EthcoreClient<C, M, S, F> where
 							.map(Into::into);
 
 					// Receive ready and invoke with result.
-					let ready: Ready<H256> = rx.try_recv().expect("When on_done is invoked ready object is always sent.");
+					let ready: Ready<H256> = rx.recv().expect(
+						"recv() fails when `tx` has been dropped, if this closure is invoked `tx` is not dropped (`res == Ok()`); qed"
+					);
 					ready.ready(result);
 				}));
 
@@ -310,7 +312,9 @@ impl<C, M, S: ?Sized, F> Ethcore for EthcoreClient<C, M, S, F> where
 				if let Err(e) = res {
 					ready.ready(Err(errors::from_fetch_error(e)));
 				} else {
-					tx.send(ready).expect("Rx end is sent to on_done closure.");
+					tx.send(ready).expect(
+						"send() fails when `rx` end is dropped, if `res == Ok()`: `rx` is moved to the closure; qed"
+					);
 				}
 			}
 		}


### PR DESCRIPTION
Was happening especially in tests (when `TestFetch` was spawning and executing the thread before `ready` handle was transmitted.