### PR TITLE
Updated blance display with max decimals

### DIFF
--- a/js/src/ui/Balance/balance.css
+++ b/js/src/ui/Balance/balance.css
@@ -44,7 +44,7 @@
 }
 
 .balanceValue {
-  margin: 0 1em 0 0;
+  margin: 0 0.5em 0 0;
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;

--- a/js/src/ui/Balance/balance.js
+++ b/js/src/ui/Balance/balance.js
@@ -44,15 +44,30 @@ class Balance extends Component {
       .filter((balance) => new BigNumber(balance.value).gt(0))
       .map((balance) => {
         const token = balance.token;
-        const value = token.format
-          ? new BigNumber(balance.value).div(new BigNumber(token.format)).toFormat(3)
-          : api.util.fromWei(balance.value).toFormat(3);
+
+        let value;
+        if (token.format) {
+          const bnf = new BigNumber(token.format);
+
+          let decimals = 0;
+          if (bnf.gte(1000)) {
+            decimals = 3;
+          } else if (bnf.gte(100)) {
+            decimals = 2;
+          } else if (bnf.gte(10)) {
+            decimals = 1;
+          }
+
+          value = new BigNumber(balance.value).div(bnf).toFormat(decimals);
+        } else {
+          value = api.util.fromWei(balance.value).toFormat(3);
+        }
+
         let imagesrc = token.image;
         if (!imagesrc) {
-          imagesrc =
-            images[token.address]
-              ? `${api.dappsUrl}${images[token.address]}`
-              : unknownImage;
+          imagesrc = images[token.address]
+            ? `${api.dappsUrl}${images[token.address]}`
+            : unknownImage;
         }
 
         return (


### PR DESCRIPTION
Don't display decimals in balances where none is available, i.e. Unicorn tokens has no decimals but we still displayed `1.000`, now the display would be `1`

 Closes https://github.com/ethcore/parity/issues/3130

![parity 2016-11-08 14-12-53](https://cloud.githubusercontent.com/assets/1424473/20100382/903414ae-a5bd-11e6-9f11-c64c91b7193d.png)
