### PR TITLE
Make transactions load

### DIFF
--- a/js/src/views/Account/Transactions/transactions.js
+++ b/js/src/views/Account/Transactions/transactions.js
@@ -48,9 +48,7 @@ class Transactions extends Component {
   }
 
   componentDidMount () {
-    if (this.props.traceMode !== undefined) {
-      this.getTransactions(this.props);
-    }
+    this.getTransactions(this.props);
   }
 
   componentWillReceiveProps (newProps) {


### PR DESCRIPTION
Trace mode is always undefined (currently not used in setState), this made the transactions list not load unless on the specific page and refreshing.