### PR TITLE
Clarify error message about disabled Signer

### DIFF
--- a/dapps/src/router/mod.rs
+++ b/dapps/src/router/mod.rs
@@ -131,7 +131,7 @@ impl<A: Authorization + 'static> server::Handler<HttpStream> for Router<A> {
 						StatusCode::NotFound,
 						"404 Not Found",
 						"Your homepage is not available when Trusted Signer is disabled.",
-						Some("You can still access dapps by writing a correct address, though. Re-enabled Signer to get your homepage back."),
+						Some("You can still access dapps by writing a correct address, though. Re-enable Signer to get your homepage back."),
 						self.signer_address.clone(),
 					))
 				}


### PR DESCRIPTION
Text as written seems to indicate that Signer *was* re-enabled, not that it *needs* to be re-enabled.

(Sure would be nice to *how* to do that.)