### PR TITLE
Fixing parsing passwords from file

### DIFF
--- a/parity/helpers.rs
+++ b/parity/helpers.rs
@@ -429,7 +429,7 @@ ignored
 but the first password is trimmed
 
 "#).unwrap();
-		assert_eq!(&password_from_file(path.as_str().into()).unwrap(), "password with trailing whitepsace");
+		assert_eq!(&password_from_file(path.as_str().into()).unwrap(), "password with trailing whitespace");
 	}
 
 	#[test]


### PR DESCRIPTION
Makes it consistent with reading (uses the first password instead of the whole file).

Closes #3334