### PR TITLE
Wallet files shouldn't give away the address

### DIFF
--- a/ethstore/src/dir/disk.rs
+++ b/ethstore/src/dir/disk.rs
@@ -20,6 +20,7 @@ use std::collections::HashMap;
 use time;
 use ethkey::Address;
 use {json, SafeAccount, Error};
+use json::UUID;
 use super::KeyDirectory;
 
 const IGNORED_FILES: &'static [&'static str] = &["thumbs.db", "address_book.json"];
@@ -112,7 +113,7 @@ impl KeyDirectory for DiskDirectory {
 		// build file path
 		let filename = account.filename.as_ref().cloned().unwrap_or_else(|| {
 			let timestamp = time::strftime("%Y-%m-%dT%H-%M-%S", &time::now_utc()).expect("Time-format string is valid.");
-			format!("UTC--{}Z--{:?}", timestamp, account.address)
+			format!("UTC--{}Z--{}", timestamp, UUID::from(account.id))
 		});
 
 		// update account filename


### PR DESCRIPTION
This immediately de-anonymises the JSON file and should never have gone in. Eventually we'll want to anonymise the files completely through storing the addresses encrypted, but that can come later.