### PR TITLE
Fix dapp account selection

### DIFF
--- a/js/src/dapps/githubhint/services.js
+++ b/js/src/dapps/githubhint/services.js
@@ -28,26 +28,26 @@ export function attachInterface () {
       return Promise
         .all([
           registry.getAddress.call({}, [api.util.sha3('githubhint'), 'A']),
-          api.eth.accounts(),
           api.parity.accounts()
         ]);
     })
-    .then(([address, addresses, accountsInfo]) => {
-      accountsInfo = accountsInfo || {};
+    .then(([address, accountsInfo]) => {
       console.log(`githubhint was found at ${address}`);
 
       const contract = api.newContract(abis.githubhint, address);
-      const accounts = addresses.reduce((obj, address) => {
-        const info = accountsInfo[address] || {};
+      const accounts = Object
+        .keys(accountsInfo)
+        .filter((address) => accountsInfo[address].uuid)
+        .reduce((obj, address) => {
+          const account = accountsInfo[address];
 
-        return Object.assign(obj, {
-          [address]: {
-            address,
-            name: info.name,
-            uuid: info.uuid
-          }
-        });
-      }, {});
+          return Object.assign(obj, {
+            [address]: {
+              address,
+              name: account.name
+            }
+          });
+        }, {});
       const fromAddress = Object.keys(accounts)[0];
 
       return {

--- a/js/src/dapps/registry/addresses/actions.js
+++ b/js/src/dapps/registry/addresses/actions.js
@@ -19,18 +19,16 @@ import { api } from '../parity';
 export const set = (addresses) => ({ type: 'addresses set', addresses });
 
 export const fetch = () => (dispatch) => {
-  return Promise
-    .all([
-      api.eth.accounts(),
-      api.parity.accounts()
-    ])
-    .then(([ accounts, data ]) => {
-      data = data || {};
-      const addresses = Object.keys(data)
-        .filter((address) => data[address] && !data[address].meta.deleted)
+  return api.parity
+    .accounts()
+    .then((accountsInfo) => {
+      const addresses = Object
+        .keys(accountsInfo)
+        .filter((address) => accountsInfo[address] && !accountsInfo[address].meta.deleted)
         .map((address) => ({
-          ...data[address], address,
-          isAccount: accounts.includes(address)
+          ...accountsInfo[address],
+          address,
+          isAccount: !!accountsInfo[address].uuid
         }));
       dispatch(set(addresses));
     })

--- a/js/src/dapps/signaturereg/Import/import.js
+++ b/js/src/dapps/signaturereg/Import/import.js
@@ -146,7 +146,7 @@ export default class Import extends Component {
   }
 
   sortFunctions = (a, b) => {
-    return a.name.localeCompare(b.name);
+    return (a.name || '').localeCompare(b.name || '');
   }
 
   countFunctions () {

--- a/js/src/dapps/signaturereg/services.js
+++ b/js/src/dapps/signaturereg/services.js
@@ -49,26 +49,26 @@ export function attachInterface (callback) {
       return Promise
         .all([
           registry.getAddress.call({}, [api.util.sha3('signaturereg'), 'A']),
-          api.eth.accounts(),
           api.parity.accounts()
         ]);
     })
-    .then(([address, addresses, accountsInfo]) => {
-      accountsInfo = accountsInfo || {};
+    .then(([address, accountsInfo]) => {
       console.log(`signaturereg was found at ${address}`);
 
       const contract = api.newContract(abis.signaturereg, address);
-      const accounts = addresses.reduce((obj, address) => {
-        const info = accountsInfo[address] || {};
+      const accounts = Object
+        .keys(accountsInfo)
+        .filter((address) => accountsInfo[address].uuid)
+        .reduce((obj, address) => {
+          const info = accountsInfo[address] || {};
 
-        return Object.assign(obj, {
-          [address]: {
-            address,
-            name: info.name || 'Unnamed',
-            uuid: info.uuid
-          }
-        });
-      }, {});
+          return Object.assign(obj, {
+            [address]: {
+              address,
+              name: info.name || 'Unnamed'
+            }
+          });
+        }, {});
       const fromAddress = Object.keys(accounts)[0];
 
       return {

--- a/js/src/dapps/tokenreg/Accounts/actions.js
+++ b/js/src/dapps/tokenreg/Accounts/actions.js
@@ -35,16 +35,13 @@ export const setSelectedAccount = (address) => ({
 });
 
 export const loadAccounts = () => (dispatch) => {
-  Promise
-    .all([
-      api.eth.accounts(),
-      api.parity.accounts()
-    ])
-    .then(([ accounts, accountsInfo ]) => {
-      accountsInfo = accountsInfo || {};
-
-      const accountsList = accounts
-        .map(address => ({
+  api.parity
+    .accounts()
+    .then((accountsInfo) => {
+      const accountsList = Object
+        .keys(accountsInfo)
+        .filter((address) => accountsInfo[address].uuid)
+        .map((address) => ({
           ...accountsInfo[address],
           address
         }));


### PR DESCRIPTION
- All dapps (only Basiccoin not affected) displayed a full list of all addresses, not only available accounts - Fixes https://github.com/ethcore/parity/issues/3370
- SignatureReg now handles ABIs without a valid function name correctly - Fixes https://github.com/ethcore/parity/issues/3398

Gavcoin is also affected by this issue when using master, deployment will happen separately to Morden & Homestead when fix has been tested