### PR TITLE
Don't auto-unsubscribe when subscriber callback throws

### DIFF
--- a/js/src/api/contract/contract.js
+++ b/js/src/api/contract/contract.js
@@ -309,7 +309,6 @@ export default class Contract {
           try {
             subscriptions[idx].callback(null, this.parseEventLogs(logs));
           } catch (error) {
-            this.unsubscribe(idx);
             console.error('_sendSubscriptionChanges', error);
           }
         });

--- a/js/src/api/subscriptions/manager.js
+++ b/js/src/api/subscriptions/manager.js
@@ -107,7 +107,6 @@ export default class Manager {
       callback(error, data);
     } catch (error) {
       console.error(`Unable to update callback for subscriptionId ${subscriptionId}`, error);
-      this.unsubscribe(subscriptionId);
     }
   }
 


### PR DESCRIPTION
- Closes https://github.com/ethcore/parity/issues/3374
- Unsubscribing mid-stream has several unintended consequences e.g. auto-updates stop working (balances not updating, events not showing)
- UI should be clean of errors, but mistakes do happen and this stops future successful updates

(EDIT: Unable to find jsapi Module, this is not UI related but rather on the API layer affecting all users)