### PR TITLE
Remove addresses, display non-refundable warning on registries

### DIFF
--- a/js/src/dapps/registry/Application/application.css
+++ b/js/src/dapps/registry/Application/application.css
@@ -49,3 +49,15 @@
     padding-bottom: 0 !important;
   }
 }
+
+.warning {
+  background: #f80;
+  bottom: 0;
+  color: #fff;
+  left: 0;
+  opacity: 1;
+  padding: 1.5em;
+  position: fixed;
+  right: 50%;
+  z-index: 100;
+}

--- a/js/src/dapps/registry/Application/application.js
+++ b/js/src/dapps/registry/Application/application.js
@@ -53,6 +53,7 @@ export default class Application extends Component {
   };
 
   render () {
+    const { api } = window.parity;
     const {
       actions,
       accounts, contacts,
@@ -60,9 +61,11 @@ export default class Application extends Component {
       lookup,
       events
     } = this.props;
+    let warning = null;
 
     return (
       <div>
+        { warning }
         <div className={ styles.header }>
           <h1>RΞgistry</h1>
           <Accounts { ...accounts } actions={ actions.accounts } />
@@ -70,13 +73,11 @@ export default class Application extends Component {
         { contract && fee ? (
           <div>
             <Lookup { ...lookup } accounts={ accounts.all } contacts={ contacts } actions={ actions.lookup } />
-
             { this.renderActions() }
-
             <Events { ...events } accounts={ accounts.all } contacts={ contacts } actions={ actions.events } />
-            <p className={ styles.address }>
-              The Registry is provided by the contract at <code>{ contract.address }.</code>
-            </p>
+            <div className={ styles.warning }>
+              WARNING: The name registry is experimental. Please ensure that you understand the risks, benefits & consequences of registering a name before doing so. A non-refundable fee of { api.util.fromWei(fee).toFormat(3) }<small>ETH</small> is required for all registrations.
+            </div>
           </div>
         ) : (
           <CircularProgress size={ 60 } />

--- a/js/src/dapps/tokenreg/Application/application.css
+++ b/js/src/dapps/tokenreg/Application/application.css
@@ -20,3 +20,15 @@
   flex-direction: column;
   align-items: center;
 }
+
+.warning {
+  background: #f80;
+  bottom: 0;
+  color: #fff;
+  left: 0;
+  opacity: 1;
+  padding: 1.5em;
+  position: fixed;
+  right: 50%;
+  z-index: 100;
+}

--- a/js/src/dapps/tokenreg/Application/application.js
+++ b/js/src/dapps/tokenreg/Application/application.js
@@ -17,6 +17,8 @@
 import React, { Component, PropTypes } from 'react';
 import getMuiTheme from 'material-ui/styles/getMuiTheme';
 
+import { api } from '../parity';
+
 import Loading from '../Loading';
 import Status from '../Status';
 import Tokens from '../Tokens';
@@ -59,6 +61,9 @@ export default class Application extends Component {
         <Actions />
 
         <Tokens />
+        <div className={ styles.warning }>
+          WARNING: The token registry is experimental. Please ensure that you understand the steps, risks, benefits & consequences of registering a token before doing so. A non-refundable fee of { api.util.fromWei(contract.fee).toFormat(3) }<small>ETH</small> is required for all registrations.
+        </div>
       </div>
     );
   }

--- a/js/src/dapps/tokenreg/Status/status.css
+++ b/js/src/dapps/tokenreg/Status/status.css
@@ -31,6 +31,12 @@
 .title {
   font-size: 3rem;
   font-weight: 300;
-  margin-top: 0;
+  margin: 0;
   text-transform: uppercase;
+}
+
+.byline {
+  font-size: 1.25em;
+  opacity: 0.75;
+  margin: 0 0 1.75em 0;
 }

--- a/js/src/dapps/tokenreg/Status/status.js
+++ b/js/src/dapps/tokenreg/Status/status.js
@@ -29,17 +29,12 @@ export default class Status extends Component {
   };
 
   render () {
-    const { address, fee } = this.props;
+    const { fee } = this.props;
 
     return (
       <div className={ styles.status }>
         <h1 className={ styles.title }>Token Registry</h1>
-
-        <Chip
-          isAddress
-          value={ address }
-          label='Address' />
-
+        <h3 className={ styles.byline }>A global registry of all recognised tokens on the network</h3>
         <Chip
           isAddress={ false }
           value={ api.util.fromWei(fee).toFixed(3) + 'ETH' }


### PR DESCRIPTION
For both Registry & TokenReg

- Remove contract addresses (technical, confuses users - we already had 2 cases of users copying those addresses) - Closes https://github.com/ethcore/parity/issues/3319 
- Display overlay warnings about experimental dapps & non-refundable fees - Closes https://github.com/ethcore/parity/issues/3351

![parity 2016-11-12 18-01-36](https://cloud.githubusercontent.com/assets/1424473/20239532/8f59a0d8-a902-11e6-9c8e-259465008566.png)

![parity 2016-11-12 18-02-02](https://cloud.githubusercontent.com/assets/1424473/20239536/93c70bba-a902-11e6-8266-19efe91afeef.png)
