### PR TITLE
Bump ws-rs

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1926,7 +1926,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "ws"
 version = "0.5.3"
-source = "git+https://github.com/ethcore/ws-rs.git?branch=mio-upstream-stable#0cd6c5e3e9d5e61a37d53eb8dcbad523dcc69314"
+source = "git+https://github.com/ethcore/ws-rs.git?branch=mio-upstream-stable#f5c0b35d660244d1b7500693c8cc28277ce1d418"
 dependencies = [
  "bytes 0.4.0-dev (git+https://github.com/carllerche/bytes)",
  "httparse 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
Closes #3361 (Force closing connections while in `Inactive` state)
Addresses #3375 (Adding `ws_comm` log target to investigate mio event loop communication)

Changes:
1. https://github.com/ethcore/ws-rs/commit/05a4865a1502e61bf48d5b19c087dc3117495f2b
2. https://github.com/ethcore/ws-rs/commit/709534cc9d5c16e1fb91ae9faf210f800dca6dbb