### PR TITLE
drop spec when no longer useful

### DIFF
--- a/parity/blockchain.rs
+++ b/parity/blockchain.rs
@@ -165,6 +165,9 @@ fn execute_import(cmd: ImportBlockchain) -> Result<String, String> {
 		Arc::new(Miner::with_spec(&spec)),
 	).map_err(|e| format!("Client service error: {:?}", e)));
 
+	// free up the spec in memory.
+	drop(spec);
+
 	panic_handler.forward_from(&service);
 	let client = service.client();
 
@@ -311,6 +314,8 @@ fn execute_export(cmd: ExportBlockchain) -> Result<String, String> {
 		&cmd.dirs.ipc_path(),
 		Arc::new(Miner::with_spec(&spec)),
 	).map_err(|e| format!("Client service error: {:?}", e)));
+
+	drop(spec);
 
 	panic_handler.forward_from(&service);
 	let client = service.client();

--- a/parity/run.rs
+++ b/parity/run.rs
@@ -235,6 +235,9 @@ pub fn execute(cmd: RunCmd, logger: Arc<RotatingLogger>) -> Result<(), String> {
 		miner.clone(),
 	).map_err(|e| format!("Client service error: {:?}", e)));
 
+	// drop the spec to free up genesis state.
+	drop(spec);
+
 	// forward panics from service
 	panic_handler.forward_from(&service);
 

--- a/parity/snapshot.rs
+++ b/parity/snapshot.rs
@@ -183,7 +183,6 @@ impl SnapshotCommand {
 
 		Ok((service, panic_handler))
 	}
-
 	/// restore from a snapshot
 	pub fn restore(self) -> Result<(), String> {
 		let file = self.file_path.clone();


### PR DESCRIPTION
Closes #3436 

Will save some memory when genesis state or engine params are particularly large (for stuff like custom chain premines)