### PR TITLE
Add trace_{call, rawTransaction, replayTransaction}

### DIFF
--- a/js/src/api/format/input.js
+++ b/js/src/api/format/input.js
@@ -166,3 +166,11 @@ export function inTraceFilter (filterObject) {
 
   return filterObject;
 }
+
+export function inTraceType (whatTrace) {
+  if (isString(whatTrace)) {
+    return [whatTrace];
+  }
+
+  return whatTrace;
+}

--- a/js/src/api/format/input.spec.js
+++ b/js/src/api/format/input.spec.js
@@ -16,7 +16,7 @@
 
 import BigNumber from 'bignumber.js';
 
-import { inAddress, inBlockNumber, inData, inFilter, inHex, inNumber10, inNumber16, inOptions } from './input';
+import { inAddress, inBlockNumber, inData, inFilter, inHex, inNumber10, inNumber16, inOptions, inTraceType } from './input';
 import { isAddress } from '../../../test/types';
 
 describe('api/format/input', () => {
@@ -240,6 +240,18 @@ describe('api/format/input', () => {
         data: '0x0123456789',
         extraData: 'someExtraStuffInHere'
       });
+    });
+  });
+
+  describe('inTraceType', () => {
+    it('returns array of types as is', () => {
+      const types = ['vmTrace', 'trace', 'stateDiff'];
+      expect(inTraceType(types)).to.deep.equal(types);
+    });
+
+    it('formats single string type into array', () => {
+      const type = 'vmTrace';
+      expect(inTraceType(type)).to.deep.equal([type]);
     });
   });
 });

--- a/js/src/api/format/output.js
+++ b/js/src/api/format/output.js
@@ -254,3 +254,25 @@ export function outTrace (trace) {
 
   return trace;
 }
+
+export function outTraces (traces) {
+  if (traces) {
+    return traces.map(outTrace);
+  }
+
+  return traces;
+}
+
+export function outTraceReplay (trace) {
+  if (trace) {
+    Object.keys(trace).forEach((key) => {
+      switch (key) {
+        case 'trace':
+          trace[key] = outTraces(trace[key]);
+          break;
+      }
+    });
+  }
+
+  return trace;
+}

--- a/js/src/api/rpc/trace/trace.e2e.js
+++ b/js/src/api/rpc/trace/trace.e2e.js
@@ -16,19 +16,29 @@
 
 import { createHttpApi } from '../../../../test/e2e/ethapi';
 
-describe('ethapi.trace', () => {
+describe.only('ethapi.trace', () => {
   const ethapi = createHttpApi();
 
   describe('block', () => {
-    it('returns the latest block', () => {
-      return ethapi.trace.block().then((block) => {
-        expect(block).to.be.ok;
+    it('returns the latest block traces', () => {
+      return ethapi.trace.block().then((traces) => {
+        expect(traces).to.be.ok;
       });
     });
 
-    it('returns a specified block', () => {
-      return ethapi.trace.block('0x65432').then((block) => {
-        expect(block).to.be.ok;
+    it('returns traces for a specified block', () => {
+      return ethapi.trace.block('0x65432').then((traces) => {
+        expect(traces).to.be.ok;
+      });
+    });
+  });
+
+  describe('replayTransaction', () => {
+    it('returns traces for a specific transaction', () => {
+      return ethapi.eth.getBlockByNumber().then((latestBlock) => {
+        return ethapi.trace.replayTransaction(latestBlock.transactions[0]).then((traces) => {
+          expect(traces).to.be.ok;
+        });
       });
     });
   });

--- a/js/src/api/rpc/trace/trace.e2e.js
+++ b/js/src/api/rpc/trace/trace.e2e.js
@@ -16,7 +16,7 @@
 
 import { createHttpApi } from '../../../../test/e2e/ethapi';
 
-describe.only('ethapi.trace', () => {
+describe('ethapi.trace', () => {
   const ethapi = createHttpApi();
 
   describe('block', () => {

--- a/js/src/api/rpc/trace/trace.js
+++ b/js/src/api/rpc/trace/trace.js
@@ -14,35 +14,53 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-import { inBlockNumber, inHex, inNumber16, inTraceFilter } from '../../format/input';
-import { outTrace } from '../../format/output';
+import { inBlockNumber, inData, inHex, inNumber16, inOptions, inTraceFilter, inTraceType } from '../../format/input';
+import { outTraces, outTraceReplay } from '../../format/output';
 
 export default class Trace {
   constructor (transport) {
     this._transport = transport;
   }
 
+  block (blockNumber = 'latest') {
+    return this._transport
+      .execute('trace_block', inBlockNumber(blockNumber))
+      .then(outTraces);
+  }
+
+  call (options, blockNumber = 'latest', whatTrace = ['trace']) {
+    return this._transport
+      .execute('trace_call', inOptions(options), inBlockNumber(blockNumber), inTraceType(whatTrace))
+      .then(outTraceReplay);
+  }
+
   filter (filterObj) {
     return this._transport
       .execute('trace_filter', inTraceFilter(filterObj))
-      .then(traces => traces.map(trace => outTrace(trace)));
+      .then(outTraces);
   }
 
   get (txHash, position) {
     return this._transport
       .execute('trace_get', inHex(txHash), inNumber16(position))
-      .then(trace => outTrace(trace));
+      .then(outTraces);
+  }
+
+  rawTransaction (data, whatTrace = ['trace']) {
+    return this._transport
+      .execute('trace_rawTransaction', inData(data), inTraceType(whatTrace))
+      .then(outTraceReplay);
+  }
+
+  replayTransaction (txHash, whatTrace = ['trace']) {
+    return this._transport
+      .execute('trace_replayTransaction', txHash, inTraceType(whatTrace))
+      .then(outTraceReplay);
   }
 
   transaction (txHash) {
     return this._transport
       .execute('trace_transaction', inHex(txHash))
-      .then(traces => traces.map(trace => outTrace(trace)));
-  }
-
-  block (blockNumber = 'latest') {
-    return this._transport
-      .execute('trace_block', inBlockNumber(blockNumber))
-      .then(traces => traces.map(trace => outTrace(trace)));
+      .then(outTraces);
   }
 }

--- a/js/src/jsonrpc/interfaces/trace.js
+++ b/js/src/jsonrpc/interfaces/trace.js
@@ -14,9 +14,45 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-import { BlockNumber, Hash, Integer } from '../types';
+import { BlockNumber, Data, Hash, Integer } from '../types';
 
 export default {
+  block: {
+    desc: 'Returns traces created at given block',
+    params: [
+      {
+        type: BlockNumber,
+        desc: 'Integer block number, or \'latest\' for the last mined block or \'pending\', \'earliest\' for not yet mined transactions'
+      }
+    ],
+    returns: {
+      type: Array,
+      desc: 'Block traces'
+    }
+  },
+
+  call: {
+    desc: 'Returns traces for a specific call',
+    params: [
+      {
+        type: Object,
+        desc: 'Call options'
+      },
+      {
+        type: BlockNumber,
+        desc: 'The blockNumber'
+      },
+      {
+        type: Array,
+        desc: 'Type of trace, one or more of \'vmTrace\', \'trace\' and/or \'stateDiff\''
+      }
+    ],
+    returns: {
+      type: Array,
+      desc: 'Block traces'
+    }
+  },
+
   filter: {
     desc: 'Returns traces matching given filter',
     params: [
@@ -49,6 +85,42 @@ export default {
     }
   },
 
+  rawTransaction: {
+    desc: 'Traces a call to eth_sendRawTransaction without making the call, returning the traces',
+    params: [
+      {
+        type: Data,
+        desc: 'Transaction data'
+      },
+      {
+        type: Array,
+        desc: 'Type of trace, one or more of \'vmTrace\', \'trace\' and/or \'stateDiff\''
+      }
+    ],
+    returns: {
+      type: Array,
+      desc: 'Block traces'
+    }
+  },
+
+  replayTransaction: {
+    desc: 'Replays a transaction, returning the traces',
+    params: [
+      {
+        type: Hash,
+        desc: 'Transaction hash'
+      },
+      {
+        type: Array,
+        desc: 'Type of trace, one or more of \'vmTrace\', \'trace\' and/or \'stateDiff\''
+      }
+    ],
+    returns: {
+      type: Array,
+      desc: 'Block traces'
+    }
+  },
+
   transaction: {
     desc: 'Returns all traces of given transaction',
     params: [
@@ -60,20 +132,6 @@ export default {
     returns: {
       type: Array,
       desc: 'Traces of given transaction'
-    }
-  },
-
-  block: {
-    desc: 'Returns traces created at given block',
-    params: [
-      {
-        type: BlockNumber,
-        desc: 'Integer block number, or \'latest\' for the last mined block or \'pending\', \'earliest\' for not yet mined transactions'
-      }
-    ],
-    returns: {
-      type: Array,
-      desc: 'Block traces'
     }
   }
 };


### PR DESCRIPTION
Closes #3487

TODO: Only outputs from `trace` gets properly formatted along the lines of the rest of the API, formatting is currently not applies to `vmTrace` & `stateDiff` (i.e. it just returns what comes back from RPC)