### PR TITLE
Keep track of block gasLimit

### DIFF
--- a/js/src/redux/providers/status.js
+++ b/js/src/redux/providers/status.js
@@ -51,6 +51,15 @@ export default class Status {
         }
 
         this._store.dispatch(statusBlockNumber(blockNumber));
+
+        this._api.eth
+          .getBlockByNumber(blockNumber)
+          .then((block) => {
+            this._store.dispatch(statusCollection({ gasLimit: block.gasLimit }));
+          })
+          .catch((error) => {
+            console.warn('status._subscribeBlockNumber', 'getBlockByNumber', error);
+          });
       })
       .then((subscriptionId) => {
         console.log('status._subscribeBlockNumber', 'subscriptionId', subscriptionId);

--- a/js/src/redux/providers/statusReducer.js
+++ b/js/src/redux/providers/statusReducer.js
@@ -28,6 +28,7 @@ const initialState = {
   enode: '',
   extraData: '',
   gasFloorTarget: new BigNumber(0),
+  gasLimit: new BigNumber(0),
   hashrate: new BigNumber(0),
   minGasPrice: new BigNumber(0),
   netChain: 'morden',


### PR DESCRIPTION
- Retrieve gasLimit on new block subscription
- To be used in contract execute/transactions to determine too high costs (to warn user)

@ngotchac Please take a look, this should fit in with the optimisation approach you are taking, if not need to tweak this PR