### PR TITLE
Fix parity.js badly built

### DIFF
--- a/js/webpack.libraries.js
+++ b/js/webpack.libraries.js
@@ -26,7 +26,6 @@ const DEST = process.env.BUILD_DEST || '.build';
 
 module.exports = {
   context: path.join(__dirname, './src'),
-  target: 'node',
   entry: {
     // library
     'inject': ['./web3.js'],
@@ -39,14 +38,7 @@ module.exports = {
     library: '[name].js',
     libraryTarget: 'umd'
   },
-  externals: {
-    'node-fetch': 'node-fetch',
-    'vertx': 'vertx'
-  },
   module: {
-    noParse: [
-      /babel-polyfill/
-    ],
     loaders: [
       {
         test: /\.js$/,


### PR DESCRIPTION
The dApps wouldn't load, except for GitHub Hint because the `parity.js` file was not built correctly.