### PR TITLE
[Registry] Clear input and working buttons

### DIFF
--- a/js/src/dapps/registry/Lookup/lookup.js
+++ b/js/src/dapps/registry/Lookup/lookup.js
@@ -77,7 +77,7 @@ export default class Lookup extends Component {
             label='Lookup'
             primary
             icon={ <SearchIcon /> }
-            onClick={ this.onLookupClick }
+            onTouchTap={ this.onLookupClick }
           />
         </div>
         <CardText>{ output }</CardText>

--- a/js/src/dapps/registry/Names/names.js
+++ b/js/src/dapps/registry/Names/names.js
@@ -120,7 +120,7 @@ export default class Names extends Component {
             label={ action === 'reserve' ? 'Reserve' : 'Drop' }
             primary
             icon={ <CheckIcon /> }
-            onClick={ this.onSubmitClick }
+            onTouchTap={ this.onSubmitClick }
           />
           { queue.length > 0
             ? (<div>{ useSignerText }{ renderQueue(queue) }</div>)

--- a/js/src/dapps/registry/Names/names.js
+++ b/js/src/dapps/registry/Names/names.js
@@ -86,6 +86,22 @@ export default class Names extends Component {
     name: ''
   };
 
+  componentWillReceiveProps (nextProps) {
+    const nextQueue = nextProps.queue;
+    const prevQueue = this.props.queue;
+
+    if (nextQueue.length > prevQueue.length) {
+      const newQueued = nextQueue[nextQueue.length - 1];
+      const newName = newQueued.name;
+
+      if (newName !== this.state.name) {
+        return;
+      }
+
+      this.setState({ name: '' });
+    }
+  }
+
   render () {
     const { action, name } = this.state;
     const { fee, pending, queue } = this.props;

--- a/js/src/dapps/registry/Records/records.js
+++ b/js/src/dapps/registry/Records/records.js
@@ -52,7 +52,7 @@ export default class Records extends Component {
             label='Save'
             primary
             icon={ <SaveIcon /> }
-            onClick={ this.onSaveClick }
+            onTouchTap={ this.onSaveClick }
           />
         </CardText>
       </Card>

--- a/js/src/modals/LoadContract/loadContract.js
+++ b/js/src/modals/LoadContract/loadContract.js
@@ -174,7 +174,7 @@ export default class LoadContract extends Component {
         const secondaryText = description || `Saved ${moment(timestamp).fromNow()}`;
         const remove = removable
           ? (
-          <IconButton onClick={ onDelete }>
+          <IconButton onTouchTap={ onDelete }>
             <DeleteIcon />
           </IconButton>
           )

--- a/js/src/ui/Form/TypedInput/typedInput.js
+++ b/js/src/ui/Form/TypedInput/typedInput.js
@@ -96,7 +96,7 @@ export default class TypedInput extends Component {
         <IconButton
           iconStyle={ iconStyle }
           style={ style }
-          onClick={ this.onAddField }
+          onTouchTap={ this.onAddField }
         >
           <AddIcon />
         </IconButton>
@@ -104,7 +104,7 @@ export default class TypedInput extends Component {
         <IconButton
           iconStyle={ iconStyle }
           style={ style }
-          onClick={ this.onRemoveField }
+          onTouchTap={ this.onRemoveField }
         >
           <RemoveIcon />
         </IconButton>

--- a/js/src/views/Dapps/dapps.js
+++ b/js/src/views/Dapps/dapps.js
@@ -67,7 +67,7 @@ export default class Dapps extends Component {
               label='edit'
               key='edit'
               icon={ <EyeIcon /> }
-              onClick={ this.store.openModal }
+              onTouchTap={ this.store.openModal }
             />
           ] }
         />

--- a/js/src/views/Signer/components/TransactionPendingForm/TransactionPendingFormConfirm/TransactionPendingFormConfirm.js
+++ b/js/src/views/Signer/components/TransactionPendingForm/TransactionPendingFormConfirm/TransactionPendingFormConfirm.js
@@ -74,7 +74,7 @@ class TransactionPendingFormConfirm extends Component {
             data-effect='solid'
           >
             <RaisedButton
-              onClick={ this.onConfirm }
+              onTouchTap={ this.onConfirm }
               className={ styles.confirmButton }
               fullWidth
               primary

--- a/js/src/views/Signer/components/TransactionPendingForm/TransactionPendingFormReject/TransactionPendingFormReject.js
+++ b/js/src/views/Signer/components/TransactionPendingForm/TransactionPendingFormReject/TransactionPendingFormReject.js
@@ -37,7 +37,7 @@ export default class TransactionPendingFormReject extends Component {
           <strong>This cannot be undone</strong>
         </div>
         <RaisedButton
-          onClick={ onReject }
+          onTouchTap={ onReject }
           className={ styles.rejectButton }
           fullWidth
           label={ 'Reject Transaction' }

--- a/js/src/views/Status/components/CallsToolbar/CallsToolbar.js
+++ b/js/src/views/Status/components/CallsToolbar/CallsToolbar.js
@@ -57,7 +57,7 @@ export default class CallsToolbar extends Component {
         <div className={ styles.callActions } { ...this._test('button-container') }>
           <IconButton
             className={ styles.callAction }
-            onClick={ this.setCall }
+            onTouchTap={ this.setCall }
             tooltip='Set'
             tooltipPosition='top-left'
             { ...this._test('button-setCall') }
@@ -66,7 +66,7 @@ export default class CallsToolbar extends Component {
           </IconButton>
           <IconButton
             className={ styles.callAction }
-            onClick={ this.makeCall }
+            onTouchTap={ this.makeCall }
             tooltip='Fire again'
             tooltipPosition='top-left'
             { ...this._test('button-makeCall') }

--- a/js/src/views/Status/components/ScrollTopButton/ScrollTopButton.js
+++ b/js/src/views/Status/components/ScrollTopButton/ScrollTopButton.js
@@ -45,7 +45,7 @@ export default class ScrollTopButton extends Component {
     return (
       <IconButton
         className={ `${styles.scrollButton} ${hiddenClass}` }
-        onClick={ this._scrollToTop }>
+        onTouchTap={ this._scrollToTop }>
         <ArrowUpwardIcon />
       </IconButton>
     );


### PR DESCRIPTION
Fixes #3557 
Fixes #3556 

Use `onTouchTap` for every MaterialUI button in the UI.
Check the signer in the Registry dApp for rejected transactions. Clear input if accepted.