### PR TITLE
Add TxQueue visibility specifier (not added between merges)

### DIFF
--- a/js/src/views/Dapps/builtin.json
+++ b/js/src/views/Dapps/builtin.json
@@ -52,6 +52,7 @@
     "description": "Have a peak on internals of transaction queue of your node.",
     "author": "Parity Team <admin@ethcore.io>",
     "version": "1.0.0",
+    "visible": true,
     "secure": true
   }
 ]


### PR DESCRIPTION
Was not added between the changes I made to the dapps list and the PR for adding this dapp. (Adding so the dapp shows by default, as intended)