### PR TITLE
Fix CPU usage when idle

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -385,7 +385,7 @@ version = "1.5.0"
 dependencies = [
  "crossbeam 0.2.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.1 (git+https://github.com/carllerche/mio)",
+ "mio 0.6.1 (git+https://github.com/ethcore/mio)",
  "parking_lot 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "slab 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -475,7 +475,7 @@ dependencies = [
  "igd 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
- "mio 0.6.1 (git+https://github.com/carllerche/mio)",
+ "mio 0.6.1 (git+https://github.com/ethcore/mio)",
  "parking_lot 0.3.5 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlp 0.1.0",
@@ -1026,7 +1026,7 @@ dependencies = [
 [[package]]
 name = "mio"
 version = "0.6.1"
-source = "git+https://github.com/carllerche/mio#56f8663510196fdca04bdf7c5f4d60b24297826f"
+source = "git+https://github.com/ethcore/mio#ef182bae193a9c7457cd2cf661fcaffb226e3eef"
 dependencies = [
  "kernel32-sys 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "lazycell 0.4.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2053,7 +2053,7 @@ dependencies = [
 "checksum mio 0.5.1 (git+https://github.com/ethcore/mio?branch=v0.5.x)" = "<none>"
 "checksum mio 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)" = "a637d1ca14eacae06296a008fa7ad955347e34efcb5891cfd8ba05491a37907e"
 "checksum mio 0.6.0-dev (git+https://github.com/ethcore/mio?branch=timer-fix)" = "<none>"
-"checksum mio 0.6.1 (git+https://github.com/carllerche/mio)" = "<none>"
+"checksum mio 0.6.1 (git+https://github.com/ethcore/mio)" = "<none>"
 "checksum miow 0.1.3 (registry+https://github.com/rust-lang/crates.io-index)" = "d5bfc6782530ac8ace97af10a540054a37126b63b0702ddaaa243b73b5745b9a"
 "checksum msdos_time 0.1.4 (registry+https://github.com/rust-lang/crates.io-index)" = "c04b68cc63a8480fb2550343695f7be72effdec953a9d4508161c3e69041c7d8"
 "checksum nanomsg 0.5.1 (git+https://github.com/ethcore/nanomsg.rs.git)" = "<none>"

--- a/util/io/Cargo.toml
+++ b/util/io/Cargo.toml
@@ -7,7 +7,7 @@ version = "1.5.0"
 authors = ["Ethcore <admin@ethcore.io>"]
 
 [dependencies]
-mio = { git = "https://github.com/carllerche/mio" }
+mio = { git = "https://github.com/ethcore/mio" }
 crossbeam = "0.2"
 parking_lot = "0.3"
 log = "0.3"

--- a/util/network/Cargo.toml
+++ b/util/network/Cargo.toml
@@ -8,7 +8,7 @@ authors = ["Ethcore <admin@ethcore.io>"]
 
 [dependencies]
 log = "0.3"
-mio = { git = "https://github.com/carllerche/mio" }
+mio = { git = "https://github.com/ethcore/mio" }
 bytes = "0.3.0"
 rand = "0.3.12"
 time = "0.1.34"


### PR DESCRIPTION
mio sometimes enter some weird state where it keeps hammering the timer loop with the following trace (Note that `target_tick` < `current_tick`):

```
2016-11-23 18:34:28   TRACE mio::timer  wakeup thread: sleep_until_tick=425; now_tick=426
2016-11-23 18:34:28   TRACE mio::timer  setting readiness from wakeup thread
2016-11-23 18:34:28   TRACE mio::poll  set_readiness event Ready {Readable} Token(18446744073709551613)
2016-11-23 18:34:28   TRACE mio::poll  returning readiness event Ready {Readable} Token(18446744073709551614)
2016-11-23 18:34:28   TRACE mio::timer  wakeup thread: sleep_until_tick=18446744073709551615; now_tick=426
2016-11-23 18:34:28   TRACE mio::deprecated::event_loop  io_process(..); cnt=1; len=1
2016-11-23 18:34:28   TRACE mio::timer  sleeping; tick_ms=100; now_tick=426; blocking sleep
2016-11-23 18:34:28   TRACE mio::deprecated::event_loop  event=Event { kind: Ready {Readable}, token: Token(18446744073709551614) }; idx=0
2016-11-23 18:34:28   TRACE mio::poll  registering with poller
2016-11-23 18:34:28   TRACE mio::sys::unix::kqueue  registering; token=Token(1); interests=Ready {Readable | Writable | Hup}
2016-11-23 18:34:28   TRACE mio::poll  set_readiness event Ready {} Token(18446744073709551614)
2016-11-23 18:34:28   TRACE mio::poll  registering with poller
2016-11-23 18:34:28   TRACE mio::deprecated::event_loop  event loop tick
2016-11-23 18:34:28   TRACE mio::poll  custom readiness queue has pending events
2016-11-23 18:34:28   TRACE mio::poll  returning readiness event Ready {Readable} Token(18446744073709551613)
2016-11-23 18:34:28   TRACE mio::deprecated::event_loop  io_process(..); cnt=1; len=1
2016-11-23 18:34:28   TRACE mio::deprecated::event_loop  event=Event { kind: Ready {Readable}, token: Token(18446744073709551613) }; idx=0
2016-11-23 18:34:28   TRACE mio::timer  tick_to; target_tick=426; current_tick=427
2016-11-23 18:34:28   TRACE mio::timer  unsetting readiness
2016-11-23 18:34:28   TRACE mio::poll  set_readiness event Ready {} Token(18446744073709551613)
2016-11-23 18:34:28   TRACE mio::timer  advancing the wakeup time; target=425; curr=18446744073709551615
2016-11-23 18:34:28   TRACE mio::timer  unparking wakeup thread
2016-11-23 18:34:28   TRACE mio::deprecated::event_loop  event loop tick
2016-11-23 18:34:28   TRACE mio::timer  wakeup thread: sleep_until_tick=425; now_tick=426
2016-11-23 18:34:28   TRACE mio::timer  setting readiness from wakeup thread
2016-11-23 18:34:28   TRACE mio::poll  set_readiness event Ready {Readable} Token(18446744073709551613)
2016-11-23 18:34:28   TRACE mio::timer  wakeup thread: sleep_until_tick=18446744073709551615; now_tick=426
2016-11-23 18:34:28   TRACE mio::timer  sleeping; tick_ms=100; now_tick=426; blocking sleep
2016-11-23 18:34:28   TRACE mio::poll  returning readiness event Ready {Readable} Token(18446744073709551613)
2016-11-23 18:34:28   TRACE mio::deprecated::event_loop  io_process(..); cnt=1; len=1
2016-11-23 18:34:28   TRACE mio::deprecated::event_loop  event=Event { kind: Ready {Readable}, token: Token(18446744073709551613) }; idx=0
2016-11-23 18:34:28   TRACE mio::timer  tick_to; target_tick=426; current_tick=427
2016-11-23 18:34:28   TRACE mio::timer  unsetting readiness
2016-11-23 18:34:28   TRACE mio::poll  set_readiness event Ready {} Token(18446744073709551613)
2016-11-23 18:34:28   TRACE mio::timer  advancing the wakeup time; target=425; curr=18446744073709551615
2016-11-23 18:34:28   TRACE mio::timer  unparking wakeup thread
2016-11-23 18:34:28   TRACE mio::deprecated::event_loop  event loop tick
2016-11-23 18:34:28   TRACE mio::timer  wakeup thread: sleep_until_tick=425; now_tick=426
2016-11-23 18:34:28   TRACE mio::timer  setting readiness from wakeup thread
```

My patch for this:
https://github.com/ethcore/mio/commit/ef182bae193a9c7457cd2cf661fcaffb226e3eef