### PR TITLE
Signer layouts to flexbox

### DIFF
--- a/js/src/views/ParityBar/parityBar.css
+++ b/js/src/views/ParityBar/parityBar.css
@@ -43,7 +43,7 @@
 
 .expanded {
   right: 16px;
-  height: 300px;
+  max-height: 300px;
   border-radius: 4px 4px 0 0;
   overflow-y: auto;
   display: flex;

--- a/js/src/views/ParityBar/parityBar.css
+++ b/js/src/views/ParityBar/parityBar.css
@@ -14,6 +14,7 @@
 /* You should have received a copy of the GNU General Public License
 /* along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 .bar, .expanded {
   position: fixed;
   bottom: 0;
@@ -42,7 +43,6 @@
 
 .expanded {
   right: 16px;
-  width: 964px;
   height: 300px;
   border-radius: 4px 4px 0 0;
   overflow-y: auto;

--- a/js/src/views/Signer/_layout.css
+++ b/js/src/views/Signer/_layout.css
@@ -15,5 +15,10 @@
 /* along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-$statusWidth: 240px;
-$statusMargin: 280px;
+$pendingHeight: 190px;
+$finishedHeight: 120px;
+
+$embedWidth: 920px;
+$statusWidth: 260px;
+
+$accountPadding: 75px;

--- a/js/src/views/Signer/_layout.css
+++ b/js/src/views/Signer/_layout.css
@@ -15,35 +15,5 @@
 /* along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-@import '../../_layout.css';
-
-.container {
-  padding: 25px 0 15px;
-}
-
-.transactionDetails {
-  padding-right: $statusMargin;
-  width: 100%;
-  box-sizing: border-box;
-}
-
-.mainContainer {
-  position: relative;
-}
-
-.mainContainer:after {
-  clear: both;
-}
-
-.mainContainer > * {
-  vertical-align: middle;
-  min-height: 190px;
-}
-
-.inputs {
-  margin-right: 30px;
-  margin-left: 30px;
-  width: 180px;
-  position: relative;
-  top: -15px; /* due to material ui weird styling */
-}
+$statusWidth: 240px;
+$statusMargin: 280px;

--- a/js/src/views/Signer/components/SignRequest/SignRequest.css
+++ b/js/src/views/Signer/components/SignRequest/SignRequest.css
@@ -14,31 +14,35 @@
 /* You should have received a copy of the GNU General Public License
 /* along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+@import '../../_layout.css';
+
 .container {
-  position: relative;
-  padding: 25px 0 15px;
+  display: flex;
+  padding: 1.5em 0 1em;
 }
 
 .actions, .signDetails {
-  display: inline-block;
   vertical-align: middle;
-  min-height: 120px;
+  min-height: $pendingHeight;
 }
 
 .signDetails {
-  border-right: 1px solid #eee;
-  margin-right: 2rem;
-  /* TODO [todr] mess - just to align with transaction */
-  width:  430px;
+  flex: 1;
 }
 
 .address, .info {
+  box-sizing: border-box;
   display: inline-block;
+  width: 50%;
+}
+
+.address {
+  padding-right: $accountPadding;
 }
 
 .info {
   padding: 0 30px;
-  width: 250px;
   color: #E53935;
   vertical-align: top;
 }
@@ -63,7 +67,7 @@
 
 .actions {
   display: inline-block;
-  min-height: 120px;
+  min-height: $finishedHeight;
 }
 
 .signDetails img {

--- a/js/src/views/Signer/components/TransactionFinished/TransactionFinished.css
+++ b/js/src/views/Signer/components/TransactionFinished/TransactionFinished.css
@@ -18,29 +18,23 @@
 @import '../../_layout.css';
 
 .container {
-  padding: 25px 0 15px;
-}
+  display: flex;
+  padding: 1.5em 0 1em;
 
-.mainContainer {
-  position: relative;
-}
-
-.mainContainer > * {
-  vertical-align: middle;
-  min-height: 120px;
+  & > * {
+    vertical-align: middle;
+    min-height: $finishedHeight;
+  }
 }
 
 .statusContainer {
-  width: $statusWidth;
-  padding: 0;
-  position: absolute;
-  top: 0;
-  right: 0;
-  box-sizing: content-box;
+  box-sizing: border-box;
+  float: right;
+  padding: 0 1em;
+  flex: 0 0 $statusWidth;
 }
 
 .transactionDetails {
-  padding-right: $statusMargin;
   width: 100%;
   box-sizing: border-box;
 }

--- a/js/src/views/Signer/components/TransactionFinished/TransactionFinished.css
+++ b/js/src/views/Signer/components/TransactionFinished/TransactionFinished.css
@@ -14,6 +14,9 @@
 /* You should have received a copy of the GNU General Public License
 /* along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+@import '../../_layout.css';
+
 .container {
   padding: 25px 0 15px;
 }
@@ -28,9 +31,8 @@
 }
 
 .statusContainer {
-  width: 220px;
-  padding: 0 40px 0 40px;
-  /*border-left: 1px solid #aaa;*/
+  width: $statusWidth;
+  padding: 0;
   position: absolute;
   top: 0;
   right: 0;
@@ -38,7 +40,7 @@
 }
 
 .transactionDetails {
-  padding-right: 321px;
+  padding-right: $statusMargin;
   width: 100%;
   box-sizing: border-box;
 }

--- a/js/src/views/Signer/components/TransactionFinished/TransactionFinished.js
+++ b/js/src/views/Signer/components/TransactionFinished/TransactionFinished.js
@@ -63,22 +63,20 @@ export default class TransactionFinished extends Component {
 
     return (
       <div className={ `${styles.container} ${className || ''}` }>
-        <div className={ styles.mainContainer }>
-          <TransactionMainDetails
-            { ...this.props }
-            { ...this.state }
-            fromBalance={ fromBalance }
-            toBalance={ toBalance }
-            className={ styles.transactionDetails }
-          >
-            <TransactionSecondaryDetails
-              id={ id }
-              date={ date }
-            />
-          </TransactionMainDetails>
-          <div className={ styles.statusContainer }>
-            { this.renderStatus() }
-          </div>
+        <TransactionMainDetails
+          { ...this.props }
+          { ...this.state }
+          fromBalance={ fromBalance }
+          toBalance={ toBalance }
+          className={ styles.transactionDetails }
+        >
+          <TransactionSecondaryDetails
+            id={ id }
+            date={ date }
+          />
+        </TransactionMainDetails>
+        <div className={ styles.statusContainer }>
+          { this.renderStatus() }
         </div>
       </div>
     );

--- a/js/src/views/Signer/components/TransactionMainDetails/TransactionMainDetails.css
+++ b/js/src/views/Signer/components/TransactionMainDetails/TransactionMainDetails.css
@@ -14,7 +14,11 @@
 /* You should have received a copy of the GNU General Public License
 /* along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+@import '../../_layout.css';
+
 .transaction {
+  flex: 1;
 }
 
 .transaction > * {
@@ -30,11 +34,11 @@
 }
 
 .from .account {
-  padding-right: 75px;
+  padding-right: $accountPadding;
 }
 
 .to .account {
-  padding-left: 75px;
+  padding-left: $accountPadding;
 }
 
 .from img, .to img {

--- a/js/src/views/Signer/components/TransactionMainDetails/TransactionMainDetails.js
+++ b/js/src/views/Signer/components/TransactionMainDetails/TransactionMainDetails.js
@@ -33,7 +33,6 @@ export default class TransactionMainDetails extends Component {
     isTest: PropTypes.bool.isRequired,
     to: PropTypes.string, // undefined if it's a contract
     toBalance: PropTypes.object, // eth BigNumber - undefined if it's a contract or until it's fetched
-    className: PropTypes.string,
     children: PropTypes.node
   };
 
@@ -60,23 +59,15 @@ export default class TransactionMainDetails extends Component {
   }
 
   render () {
-    const { className, children } = this.props;
+    const { to } = this.props;
 
-    return (
-      <div className={ className }>
-        { this.renderTransfer() }
-        { this.renderContract() }
-        { children }
-      </div>
-    );
+    return to
+      ? this.renderTransfer()
+      : this.renderContract();
   }
 
   renderTransfer () {
-    const { from, fromBalance, to, toBalance, isTest } = this.props;
-
-    if (!to) {
-      return;
-    }
+    const { children, from, fromBalance, to, toBalance, isTest } = this.props;
 
     return (
       <div className={ styles.transaction }>
@@ -101,16 +92,13 @@ export default class TransactionMainDetails extends Component {
               isTest={ isTest } />
           </div>
         </div>
+        { children }
       </div>
     );
   }
 
   renderContract () {
-    const { from, fromBalance, to, isTest } = this.props;
-
-    if (to) {
-      return;
-    }
+    const { children, from, fromBalance, isTest } = this.props;
 
     return (
       <div className={ styles.transaction }>
@@ -134,6 +122,7 @@ export default class TransactionMainDetails extends Component {
             Contract
           </div>
         </div>
+        { children }
       </div>
     );
   }

--- a/js/src/views/Signer/components/TransactionPending/TransactionPending.css
+++ b/js/src/views/Signer/components/TransactionPending/TransactionPending.css
@@ -18,32 +18,11 @@
 @import '../../_layout.css';
 
 .container {
-  padding: 25px 0 15px;
-}
+  display: flex;
+  padding: 1.5em 0 1em;
 
-.transactionDetails {
-  padding-right: $statusMargin;
-  width: 100%;
-  box-sizing: border-box;
-}
-
-.mainContainer {
-  position: relative;
-}
-
-.mainContainer:after {
-  clear: both;
-}
-
-.mainContainer > * {
-  vertical-align: middle;
-  min-height: 190px;
-}
-
-.inputs {
-  margin-right: 30px;
-  margin-left: 30px;
-  width: 180px;
-  position: relative;
-  top: -15px; /* due to material ui weird styling */
+  & > * {
+    vertical-align: middle;
+    min-height: $pendingHeight;
+  }
 }

--- a/js/src/views/Signer/components/TransactionPending/TransactionPending.css
+++ b/js/src/views/Signer/components/TransactionPending/TransactionPending.css
@@ -23,6 +23,5 @@
 
   & > * {
     vertical-align: middle;
-    min-height: $pendingHeight;
   }
 }

--- a/js/src/views/Signer/components/TransactionPending/TransactionPending.js
+++ b/js/src/views/Signer/components/TransactionPending/TransactionPending.js
@@ -70,29 +70,27 @@ export default class TransactionPending extends Component {
 
     return (
       <div className={ `${styles.container} ${className || ''}` }>
-        <div className={ styles.mainContainer }>
-          <TransactionMainDetails
-            { ...this.props }
-            { ...this.state }
-            fromBalance={ fromBalance }
-            toBalance={ toBalance }
-            className={ styles.transactionDetails }
-            totalValue={ totalValue }>
-            <TransactionSecondaryDetails
-              id={ id }
-              date={ date }
-              data={ data }
-              gasPriceEthmDisplay={ gasPriceEthmDisplay }
-              gasToDisplay={ gasToDisplay }
-            />
-          </TransactionMainDetails>
-          <TransactionPendingForm
-            address={ from }
-            isSending={ this.props.isSending }
-            onConfirm={ this.onConfirm }
-            onReject={ this.onReject }
+        <TransactionMainDetails
+          { ...this.props }
+          { ...this.state }
+          fromBalance={ fromBalance }
+          toBalance={ toBalance }
+          className={ styles.transactionDetails }
+          totalValue={ totalValue }>
+          <TransactionSecondaryDetails
+            id={ id }
+            date={ date }
+            data={ data }
+            gasPriceEthmDisplay={ gasPriceEthmDisplay }
+            gasToDisplay={ gasToDisplay }
           />
-        </div>
+        </TransactionMainDetails>
+        <TransactionPendingForm
+          address={ from }
+          isSending={ this.props.isSending }
+          onConfirm={ this.onConfirm }
+          onReject={ this.onReject }
+        />
       </div>
     );
   }

--- a/js/src/views/Signer/components/TransactionPendingForm/TransactionPendingForm.css
+++ b/js/src/views/Signer/components/TransactionPendingForm/TransactionPendingForm.css
@@ -14,10 +14,12 @@
 /* You should have received a copy of the GNU General Public License
 /* along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+@import '../../_layout.css';
+
 .container {
-  width: 220px;
-  padding: 20px 40px 0 40px;
-  /*border-left: 1px solid #aaa;*/
+  width: $statusWidth;
+  padding: 20px 0 0 0;
   position: absolute;
   top: 0;
   right: 0;

--- a/js/src/views/Signer/components/TransactionPendingForm/TransactionPendingForm.css
+++ b/js/src/views/Signer/components/TransactionPendingForm/TransactionPendingForm.css
@@ -18,12 +18,9 @@
 @import '../../_layout.css';
 
 .container {
-  width: $statusWidth;
-  padding: 20px 0 0 0;
-  position: absolute;
-  top: 0;
-  right: 0;
-  box-sizing: content-box;
+  box-sizing: border-box;
+  padding: 1em 1em 0 1em;
+  flex: 0 0 $statusWidth;
 }
 
 .rejectToggle {

--- a/js/src/views/Signer/components/TransactionPendingForm/TransactionPendingFormConfirm/TransactionPendingFormConfirm.css
+++ b/js/src/views/Signer/components/TransactionPendingForm/TransactionPendingFormConfirm/TransactionPendingFormConfirm.css
@@ -15,7 +15,7 @@
 /* along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 */
 .confirmForm {
-  margin-top: -45px;
+  margin-top: -2em;
 }
 
 .confirmButton {

--- a/js/src/views/Signer/components/TransactionPendingForm/TransactionPendingFormReject/TransactionPendingFormReject.css
+++ b/js/src/views/Signer/components/TransactionPendingForm/TransactionPendingFormReject/TransactionPendingFormReject.css
@@ -14,6 +14,7 @@
 /* You should have received a copy of the GNU General Public License
 /* along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 /* the rejection button itself, once .reject has been pressed */
 .rejectButton {
   display: block !important;

--- a/js/src/views/Signer/components/TransactionSecondaryDetails/TransactionSecondaryDetails.css
+++ b/js/src/views/Signer/components/TransactionSecondaryDetails/TransactionSecondaryDetails.css
@@ -1,3 +1,24 @@
+/* Copyright 2015, 2016 Ethcore (UK) Ltd.
+/* This file is part of Parity.
+/*
+/* Parity is free software: you can redistribute it and/or modify
+/* it under the terms of the GNU General Public License as published by
+/* the Free Software Foundation, either version 3 of the License, or
+/* (at your option) any later version.
+/*
+/* Parity is distributed in the hope that it will be useful,
+/* but WITHOUT ANY WARRANTY; without even the implied warranty of
+/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+/* GNU General Public License for more details.
+/*
+/* You should have received a copy of the GNU General Public License
+/* along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+.container {
+  display: block;
+}
+
 .iconsContainer {
   display: block;
   text-align: center;
@@ -67,4 +88,3 @@
 .expandedContainer:empty {
   padding: 0;
 }
-

--- a/js/src/views/Signer/components/TransactionSecondaryDetails/TransactionSecondaryDetails.js
+++ b/js/src/views/Signer/components/TransactionSecondaryDetails/TransactionSecondaryDetails.js
@@ -27,7 +27,6 @@ import styles from './TransactionSecondaryDetails.css';
 import * as tUtil from '../util/transaction';
 
 export default class TransactionSecondaryDetails extends Component {
-
   static propTypes = {
     id: PropTypes.object.isRequired,
     date: PropTypes.instanceOf(Date),
@@ -45,7 +44,7 @@ export default class TransactionSecondaryDetails extends Component {
     const className = this.props.className || '';
 
     return (
-      <div className={ className }>
+      <div className={ `${styles.container} ${className}` }>
         <div className={ styles.iconsContainer }>
           { this.renderGasPrice() }
           { this.renderData() }

--- a/js/src/views/Signer/containers/Embedded/embedded.css
+++ b/js/src/views/Signer/containers/Embedded/embedded.css
@@ -14,8 +14,13 @@
 /* You should have received a copy of the GNU General Public License
 /* along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 */
+
+@import '../../_layout.css';
+
 .signer {
-  width: 916px;
+  box-sizing: border-box;
+  padding: 0;
+  width: $embedWidth;
 }
 
 .pending {

--- a/js/src/views/Signer/containers/RequestsPage/RequestsPage.css
+++ b/js/src/views/Signer/containers/RequestsPage/RequestsPage.css
@@ -14,6 +14,7 @@
 /* You should have received a copy of the GNU General Public License
 /* along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 */
+
 .request {
 }
 


### PR DESCRIPTION
Simplifies the Signer layouts by moving the column display to flexbox, while also removing visual glitches between components.

Before -

![parity 2016-11-24 14-48-12](https://cloud.githubusercontent.com/assets/1424473/20600983/8daa612a-b256-11e6-9261-e509a5c3f695.png)
![parity 2016-11-24 14-42-41](https://cloud.githubusercontent.com/assets/1424473/20600984/8dadef16-b256-11e6-92b1-660573cf4ea6.png)

With this -

https://www.youtube.com/watch?v=YbNmOQTlCrk

(Not 100% where it should be yet since there is still duplication in classes between components, however allows us to move ahead with the adaptions with the signer info that is in the queue.)