### PR TITLE
Appending logs by default

### DIFF
--- a/logger/src/lib.rs
+++ b/logger/src/lib.rs
@@ -26,9 +26,8 @@ extern crate time;
 #[macro_use]
 extern crate lazy_static;
 
-use std::{env, thread};
+use std::{env, thread, fs};
 use std::sync::Arc;
-use std::fs::File;
 use std::io::Write;
 use isatty::{stderr_isatty, stdout_isatty};
 use env_logger::LogBuilder;
@@ -80,9 +79,13 @@ pub fn setup_log(config: &Config) -> Result<Arc<RotatingLogger>, String> {
 	let enable_color = config.color && isatty;
 	let logs = Arc::new(RotatingLogger::new(levels));
 	let logger = logs.clone();
+	let mut open_options = fs::OpenOptions::new();
 
 	let maybe_file = match config.file.as_ref() {
-		Some(f) => Some(try!(File::create(f).map_err(|_| format!("Cannot write to log file given: {}", f)))),
+		Some(f) => Some(try!(open_options
+			.append(true).create(true).open(f)
+			.map_err(|_| format!("Cannot write to log file given: {}", f))
+		)),
 		None => None,
 	};
 

--- a/parity/cli/usage.txt
+++ b/parity/cli/usage.txt
@@ -323,7 +323,7 @@ Miscellaneous Options:
   -l --logging LOGGING     Specify the logging level. Must conform to the same
                            format as RUST_LOG. (default: {flag_logging:?})
   --log-file FILENAME      Specify a filename into which logging should be
-                           directed. (default: {flag_log_file:?})
+                           appended. (default: {flag_log_file:?})
   --no-config              Don't load a configuration file.
   --no-color               Don't use terminal color codes in output. (default: {flag_no_color})
   -v --version             Show information about version.


### PR DESCRIPTION
I believe it's better for us to have the logger append by default (people will be able to provide logs after restart).
Old behaviour is simple to replicate: 
```
$ echo "" > $LOG_FILE
$ parity --log-file $LOG_FILE
```
so I don't see a reason to have separate CLI option to choose the behavior.

Closes #3596