### PR TITLE
Splitting serialization of signTransaction and sendTransaction confirmation requests

### DIFF
--- a/js/src/api/format/output.js
+++ b/js/src/api/format/output.js
@@ -144,7 +144,8 @@ export function outSignerRequest (request) {
           break;
 
         case 'payload':
-          request[key].transaction = outTransaction(request[key].transaction);
+          request[key].signTransaction = outTransaction(request[key].signTransaction);
+          request[key].sendTransaction = outTransaction(request[key].sendTransaction);
           break;
       }
     });

--- a/js/src/redux/providers/signerMiddleware.js
+++ b/js/src/redux/providers/signerMiddleware.js
@@ -72,8 +72,8 @@ export default class SignerMiddleware {
     };
 
     // Sign request in-browser
-    if (wallet && payload.transaction) {
-      const { transaction } = payload;
+    if (wallet && (payload.sendTransaction || payload.signTransaction)) {
+      const transaction = payload.sendTransaction || payload.signTransaction;
 
       (transaction.nonce.isZero()
         ? this._api.parity.nextNonce(transaction.from)

--- a/js/src/redux/providers/signerMiddleware.js
+++ b/js/src/redux/providers/signerMiddleware.js
@@ -72,9 +72,8 @@ export default class SignerMiddleware {
     };
 
     // Sign request in-browser
-    if (wallet && (payload.sendTransaction || payload.signTransaction)) {
-      const transaction = payload.sendTransaction || payload.signTransaction;
-
+    const transaction = payload.sendTransaction || payload.signTransaction;
+    if (wallet && transaction) {
       (transaction.nonce.isZero()
         ? this._api.parity.nextNonce(transaction.from)
         : Promise.resolve(transaction.nonce)

--- a/js/src/views/Signer/components/RequestFinished/requestFinished.js
+++ b/js/src/views/Signer/components/RequestFinished/requestFinished.js
@@ -25,7 +25,8 @@ export default class RequestFinished extends Component {
     result: PropTypes.any.isRequired,
     date: PropTypes.instanceOf(Date).isRequired,
     payload: PropTypes.oneOfType([
-      PropTypes.shape({ transaction: PropTypes.object.isRequired }),
+      PropTypes.shape({ signTransaction: PropTypes.object.isRequired }),
+      PropTypes.shape({ sendTransaction: PropTypes.object.isRequired }),
       PropTypes.shape({ sign: PropTypes.object.isRequired })
     ]).isRequired,
     msg: PropTypes.string,
@@ -58,8 +59,8 @@ export default class RequestFinished extends Component {
       );
     }
 
-    if (payload.transaction) {
-      const { transaction } = payload;
+    if (payload.sendTransaction || payload.signTransaction) {
+      const transaction = payload.sendTransaction || payload.signTransaction;
 
       return (
         <TransactionFinished

--- a/js/src/views/Signer/components/RequestFinished/requestFinished.js
+++ b/js/src/views/Signer/components/RequestFinished/requestFinished.js
@@ -59,9 +59,8 @@ export default class RequestFinished extends Component {
       );
     }
 
-    if (payload.sendTransaction || payload.signTransaction) {
-      const transaction = payload.sendTransaction || payload.signTransaction;
-
+    const transaction = payload.sendTransaction || payload.signTransaction;
+    if (transaction) {
       return (
         <TransactionFinished
           className={ className }

--- a/js/src/views/Signer/components/RequestPending/requestPending.js
+++ b/js/src/views/Signer/components/RequestPending/requestPending.js
@@ -27,7 +27,8 @@ export default class RequestPending extends Component {
     isSending: PropTypes.bool.isRequired,
     date: PropTypes.instanceOf(Date).isRequired,
     payload: PropTypes.oneOfType([
-      PropTypes.shape({ transaction: PropTypes.object.isRequired }),
+      PropTypes.shape({ signTransaction: PropTypes.object.isRequired }),
+      PropTypes.shape({ sendTransaction: PropTypes.object.isRequired }),
       PropTypes.shape({ sign: PropTypes.object.isRequired })
     ]).isRequired,
     className: PropTypes.string,
@@ -64,8 +65,8 @@ export default class RequestPending extends Component {
       );
     }
 
-    if (payload.transaction) {
-      const { transaction } = payload;
+    if (payload.sendTransaction || payload.signTransaction) {
+      const transaction = payload.sendTransaction || payload.signTransaction;
 
       return (
         <TransactionPending

--- a/js/src/views/Signer/components/RequestPending/requestPending.js
+++ b/js/src/views/Signer/components/RequestPending/requestPending.js
@@ -65,9 +65,8 @@ export default class RequestPending extends Component {
       );
     }
 
-    if (payload.sendTransaction || payload.signTransaction) {
-      const transaction = payload.sendTransaction || payload.signTransaction;
-
+    const transaction = payload.sendTransaction || payload.signTransaction;
+    if (transaction) {
       return (
         <TransactionPending
           className={ className }

--- a/rpc/src/v1/tests/mocked/signer.rs
+++ b/rpc/src/v1/tests/mocked/signer.rs
@@ -89,7 +89,7 @@ fn should_return_list_of_items_to_confirm() {
 	let request = r#"{"jsonrpc":"2.0","method":"signer_requestsToConfirm","params":[],"id":1}"#;
 	let response = concat!(
 		r#"{"jsonrpc":"2.0","result":["#,
-		r#"{"id":"0x1","payload":{"transaction":{"data":"0x","from":"0x0000000000000000000000000000000000000001","gas":"0x989680","gasPrice":"0x2710","nonce":null,"to":"0xd46e8dd67c5d32be8058bb8eb970870f07244567","value":"0x1"}}},"#,
+		r#"{"id":"0x1","payload":{"sendTransaction":{"data":"0x","from":"0x0000000000000000000000000000000000000001","gas":"0x989680","gasPrice":"0x2710","nonce":null,"to":"0xd46e8dd67c5d32be8058bb8eb970870f07244567","value":"0x1"}}},"#,
 		r#"{"id":"0x2","payload":{"sign":{"address":"0x0000000000000000000000000000000000000001","hash":"0x0000000000000000000000000000000000000000000000000000000000000005"}}}"#,
 		r#"],"id":1}"#
 	);

--- a/rpc/src/v1/types/confirmations.rs
+++ b/rpc/src/v1/types/confirmations.rs
@@ -105,10 +105,10 @@ impl Serialize for ConfirmationResponse {
 #[derive(Debug, Clone, Eq, PartialEq, Hash, Serialize)]
 pub enum ConfirmationPayload {
 	/// Send Transaction
-	#[serde(rename="transaction")]
+	#[serde(rename="sendTransaction")]
 	SendTransaction(TransactionRequest),
 	/// Sign Transaction
-	#[serde(rename="transaction")]
+	#[serde(rename="signTransaction")]
 	SignTransaction(TransactionRequest),
 	/// Signature
 	#[serde(rename="sign")]
@@ -220,7 +220,49 @@ mod tests {
 
 		// when
 		let res = serde_json::to_string(&ConfirmationRequest::from(request));
-		let expected = r#"{"id":"0xf","payload":{"transaction":{"from":"0x0000000000000000000000000000000000000000","to":null,"gasPrice":"0x2710","gas":"0x3a98","value":"0x186a0","data":"0x010203","nonce":"0x1"}}}"#;
+		let expected = r#"{"id":"0xf","payload":{"sendTransaction":{"from":"0x0000000000000000000000000000000000000000","to":null,"gasPrice":"0x2710","gas":"0x3a98","value":"0x186a0","data":"0x010203","nonce":"0x1"}}}"#;
+
+		// then
+		assert_eq!(res.unwrap(), expected.to_owned());
+	}
+
+	#[test]
+	fn should_serialize_sign_transaction_confirmation() {
+		// given
+		let request = helpers::ConfirmationRequest {
+			id: 15.into(),
+			payload: helpers::ConfirmationPayload::SignTransaction(helpers::FilledTransactionRequest {
+				from: 0.into(),
+				to: None,
+				gas: 15_000.into(),
+				gas_price: 10_000.into(),
+				value: 100_000.into(),
+				data: vec![1, 2, 3],
+				nonce: Some(1.into()),
+			}),
+		};
+
+		// when
+		let res = serde_json::to_string(&ConfirmationRequest::from(request));
+		let expected = r#"{"id":"0xf","payload":{"signTransaction":{"from":"0x0000000000000000000000000000000000000000","to":null,"gasPrice":"0x2710","gas":"0x3a98","value":"0x186a0","data":"0x010203","nonce":"0x1"}}}"#;
+
+		// then
+		assert_eq!(res.unwrap(), expected.to_owned());
+	}
+
+	#[test]
+	fn should_serialize_decrypt_confirmation() {
+		// given
+		let request = helpers::ConfirmationRequest {
+			id: 15.into(),
+			payload: helpers::ConfirmationPayload::Decrypt(
+				10.into(), vec![1, 2, 3].into(),
+			),
+		};
+
+		// when
+		let res = serde_json::to_string(&ConfirmationRequest::from(request));
+		let expected = r#"{"id":"0xf","payload":{"decrypt":{"address":"0x000000000000000000000000000000000000000a","msg":"0x010203"}}}"#;
 
 		// then
 		assert_eq!(res.unwrap(), expected.to_owned());


### PR DESCRIPTION
Closes #3560
Breaks compatibility with Chrome Plugin (we should probably mention in Release notes that it's already deprecated)