### PR TITLE
fix plural in TxHash

### DIFF
--- a/js/src/ui/TxHash/txHash.js
+++ b/js/src/ui/TxHash/txHash.js
@@ -111,7 +111,8 @@ class TxHash extends Component {
     } else {
       count = confirmations.toFormat(0) + `/${maxConfirmations}`;
     }
-    const unit = value === 1 ? 'confirmation' : 'confirmations';
+    const unit = Math.max(confirmations.toNumber(), maxConfirmations) === 1
+      ? 'confirmation' : 'confirmations';
 
     return (
       <div className={ styles.confirm }>


### PR DESCRIPTION
before: "0/1 confirmations", "1/1 confirmation", "2 confirmations"

after: "0/1 confirmation", "1/1 confirmation", "2 confirmations"