### PR TITLE
Filter null transactions for display (not available on node)

### DIFF
--- a/js/src/ui/TxList/store.js
+++ b/js/src/ui/TxList/store.js
@@ -93,7 +93,7 @@ export default class Store {
     Promise
       .all(txhashes.map((txhash) => this._api.eth.getTransactionByHash(txhash)))
       .then((_transactions) => {
-        const transactions = _transactions.filter((tx) => tx) || [];
+        const transactions = _transactions.filter((tx) => tx);
 
         this.addTransactions(
           transactions.reduce((transactions, tx, index) => {

--- a/js/src/ui/TxList/store.js
+++ b/js/src/ui/TxList/store.js
@@ -92,7 +92,9 @@ export default class Store {
 
     Promise
       .all(txhashes.map((txhash) => this._api.eth.getTransactionByHash(txhash)))
-      .then((transactions) => {
+      .then((_transactions) => {
+        const transactions = _transactions.filter((tx) => tx);
+
         this.addTransactions(
           transactions.reduce((transactions, tx, index) => {
             transactions[txhashes[index]] = tx;

--- a/js/src/ui/TxList/store.js
+++ b/js/src/ui/TxList/store.js
@@ -93,7 +93,7 @@ export default class Store {
     Promise
       .all(txhashes.map((txhash) => this._api.eth.getTransactionByHash(txhash)))
       .then((_transactions) => {
-        const transactions = _transactions.filter((tx) => tx);
+        const transactions = _transactions.filter((tx) => tx) || [];
 
         this.addTransactions(
           transactions.reduce((transactions, tx, index) => {


### PR DESCRIPTION
When the node is syncing and we try to find a non-existent (though valid) hash, the transaction can be null. Filter null retrieved transactions before attempting to add it to the list.