### PR TITLE
Move decoding for contract deployment logic earlier

### DIFF
--- a/js/src/ui/MethodDecoding/methodDecoding.js
+++ b/js/src/ui/MethodDecoding/methodDecoding.js
@@ -461,7 +461,7 @@ class MethodDecoding extends Component {
     this.setState({ methodSignature: signature, methodParams: paramdata });
 
     if (!signature || signature === CONTRACT_CREATE || transaction.creates) {
-      this.setState({ icContract: true, isDeploy: true });
+      this.setState({ isDeploy: true });
       return;
     }
 

--- a/js/src/ui/MethodDecoding/methodDecoding.js
+++ b/js/src/ui/MethodDecoding/methodDecoding.js
@@ -457,6 +457,14 @@ class MethodDecoding extends Component {
       return;
     }
 
+    const { signature, paramdata } = api.util.decodeCallData(input);
+    this.setState({ methodSignature: signature, methodParams: paramdata });
+
+    if (!signature || signature === CONTRACT_CREATE || transaction.creates) {
+      this.setState({ icContract: true, isDeploy: true });
+      return;
+    }
+
     if (contractAddress === '0x') {
       return;
     }
@@ -469,14 +477,6 @@ class MethodDecoding extends Component {
         this.setState({ isContract });
 
         if (!isContract) {
-          return;
-        }
-
-        const { signature, paramdata } = api.util.decodeCallData(input);
-        this.setState({ methodSignature: signature, methodParams: paramdata });
-
-        if (!signature || signature === CONTRACT_CREATE || transaction.creates) {
-          this.setState({ isDeploy: true });
           return;
         }
 


### PR DESCRIPTION
Fixes the case where a contract is to be deployed and the signer shows the actual input data instead of the contract deployment state

![parity 2016-12-05 12-22-54](https://cloud.githubusercontent.com/assets/1424473/20883889/b27437ac-bae8-11e6-8b02-a720cf527f40.png)