### PR TITLE
Unify proptypes in util/proptypes.js

### DIFF
--- a/js/src/dapps/registry/Application/application.js
+++ b/js/src/dapps/registry/Application/application.js
@@ -21,14 +21,15 @@ const muiTheme = getMuiTheme(lightBaseTheme);
 
 import CircularProgress from 'material-ui/CircularProgress';
 import { Card, CardText } from 'material-ui/Card';
+
+import { nullableProptype } from '~/util/proptypes';
+
 import styles from './application.css';
 import Accounts from '../Accounts';
 import Events from '../Events';
 import Lookup from '../Lookup';
 import Names from '../Names';
 import Records from '../Records';
-
-const nullable = (type) => React.PropTypes.oneOfType([ React.PropTypes.oneOf([ null ]), type ]);
 
 export default class Application extends Component {
   static childContextTypes = {
@@ -44,8 +45,8 @@ export default class Application extends Component {
     actions: PropTypes.object.isRequired,
     accounts: PropTypes.object.isRequired,
     contacts: PropTypes.object.isRequired,
-    contract: nullable(PropTypes.object.isRequired),
-    fee: nullable(PropTypes.object.isRequired),
+    contract: nullableProptype(PropTypes.object.isRequired),
+    fee: nullableProptype(PropTypes.object.isRequired),
     lookup: PropTypes.object.isRequired,
     events: PropTypes.object.isRequired,
     names: PropTypes.object.isRequired,

--- a/js/src/dapps/registry/Container.js
+++ b/js/src/dapps/registry/Container.js
@@ -18,19 +18,19 @@ import React, { Component, PropTypes } from 'react';
 import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 
+import { nullableProptype } from '~/util/proptypes';
+
 import Application from './Application';
 import * as actions from './actions';
-
-const nullable = (type) => React.PropTypes.oneOfType([ React.PropTypes.oneOf([ null ]), type ]);
 
 class Container extends Component {
   static propTypes = {
     actions: PropTypes.object.isRequired,
     accounts: PropTypes.object.isRequired,
     contacts: PropTypes.object.isRequired,
-    contract: nullable(PropTypes.object.isRequired),
-    owner: nullable(PropTypes.string.isRequired),
-    fee: nullable(PropTypes.object.isRequired),
+    contract: nullableProptype(PropTypes.object.isRequired),
+    owner: nullableProptype(PropTypes.string.isRequired),
+    fee: nullableProptype(PropTypes.object.isRequired),
     lookup: PropTypes.object.isRequired,
     events: PropTypes.object.isRequired
   };

--- a/js/src/dapps/registry/Lookup/lookup.js
+++ b/js/src/dapps/registry/Lookup/lookup.js
@@ -19,13 +19,14 @@ import { Card, CardHeader, CardText } from 'material-ui/Card';
 import TextField from 'material-ui/TextField';
 import RaisedButton from 'material-ui/RaisedButton';
 import SearchIcon from 'material-ui/svg-icons/action/search';
+
+import { nullableProptype } from '~/util/proptypes';
+
 import renderAddress from '../ui/address.js';
 import renderImage from '../ui/image.js';
 
 import recordTypeSelect from '../ui/record-type-select.js';
 import styles from './lookup.css';
-
-const nullable = (type) => React.PropTypes.oneOfType([ React.PropTypes.oneOf([ null ]), type ]);
 
 export default class Lookup extends Component {
 
@@ -33,7 +34,7 @@ export default class Lookup extends Component {
     actions: PropTypes.object.isRequired,
     name: PropTypes.string.isRequired,
     type: PropTypes.string.isRequired,
-    result: nullable(PropTypes.string.isRequired),
+    result: nullableProptype(PropTypes.string.isRequired),
     accounts: PropTypes.object.isRequired,
     contacts: PropTypes.object.isRequired
   }

--- a/js/src/modals/SMSVerification/GatherData/gatherData.js
+++ b/js/src/modals/SMSVerification/GatherData/gatherData.js
@@ -15,7 +15,6 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 import React, { Component, PropTypes } from 'react';
-import nullable from '../../../util/nullable-proptype';
 import BigNumber from 'bignumber.js';
 import { Checkbox } from 'material-ui';
 import InfoIcon from 'material-ui/svg-icons/action/info-outline';
@@ -24,6 +23,7 @@ import ErrorIcon from 'material-ui/svg-icons/navigation/close';
 
 import { fromWei } from '~/api/util/wei';
 import { Form, Input } from '~/ui';
+import { nullableProptype } from '~/util/proptypes';
 
 import { termsOfService } from '../../../3rdparty/sms-verification';
 import styles from './gatherData.css';
@@ -32,8 +32,8 @@ export default class GatherData extends Component {
   static propTypes = {
     fee: React.PropTypes.instanceOf(BigNumber),
     isNumberValid: PropTypes.bool.isRequired,
-    isVerified: nullable(PropTypes.bool.isRequired),
-    hasRequested: nullable(PropTypes.bool.isRequired),
+    isVerified: nullableProptype(PropTypes.bool.isRequired),
+    hasRequested: nullableProptype(PropTypes.bool.isRequired),
     setNumber: PropTypes.func.isRequired,
     setConsentGiven: PropTypes.func.isRequired
   }

--- a/js/src/modals/SMSVerification/SendConfirmation/sendConfirmation.js
+++ b/js/src/modals/SMSVerification/SendConfirmation/sendConfirmation.js
@@ -15,8 +15,8 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 import React, { Component, PropTypes } from 'react';
-import nullable from '../../../util/nullable-proptype';
 
+import { nullableProptype } from '~/util/proptypes';
 import TxHash from '~/ui/TxHash';
 import {
   POSTING_CONFIRMATION, POSTED_CONFIRMATION
@@ -27,7 +27,7 @@ import styles from './sendConfirmation.css';
 export default class SendConfirmation extends Component {
   static propTypes = {
     step: PropTypes.any.isRequired,
-    tx: nullable(PropTypes.any.isRequired)
+    tx: nullableProptype(PropTypes.any.isRequired)
   }
 
   render () {

--- a/js/src/modals/SMSVerification/SendRequest/sendRequest.js
+++ b/js/src/modals/SMSVerification/SendRequest/sendRequest.js
@@ -15,8 +15,8 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 import React, { Component, PropTypes } from 'react';
-import nullable from '../../../util/nullable-proptype';
 
+import { nullableProptype } from '~/util/proptypes';
 import TxHash from '~/ui/TxHash';
 import {
   POSTING_REQUEST, POSTED_REQUEST, REQUESTING_SMS
@@ -27,7 +27,7 @@ import styles from './sendRequest.css';
 export default class SendRequest extends Component {
   static propTypes = {
     step: PropTypes.any.isRequired,
-    tx: nullable(PropTypes.any.isRequired)
+    tx: nullableProptype(PropTypes.any.isRequired)
   }
 
   render () {

--- a/js/src/modals/Transfer/Details/details.js
+++ b/js/src/modals/Transfer/Details/details.js
@@ -17,11 +17,10 @@
 import BigNumber from 'bignumber.js';
 import React, { Component, PropTypes } from 'react';
 import { Checkbox, MenuItem } from 'material-ui';
-
 import { isEqual } from 'lodash';
 
 import Form, { Input, InputAddressSelect, AddressSelect, Select } from '~/ui/Form';
-import nullableProptype from '~/util/nullable-proptype';
+import { nullableProptype } from '~/util/proptypes';
 
 import imageUnknown from '../../../../assets/images/contracts/unknown-64x64.png';
 import styles from '../transfer.css';

--- a/js/src/modals/Transfer/transfer.js
+++ b/js/src/modals/Transfer/transfer.js
@@ -26,7 +26,7 @@ import NavigationArrowForward from 'material-ui/svg-icons/navigation/arrow-forwa
 
 import { newError } from '~/ui/Errors/actions';
 import { BusyStep, CompletedStep, Button, IdentityIcon, Modal, TxHash } from '~/ui';
-import nullableProptype from '~/util/nullable-proptype';
+import { nullableProptype } from '~/util/proptypes';
 
 import Details from './Details';
 import Extras from './Extras';

--- a/js/src/ui/ConfirmDialog/confirmDialog.js
+++ b/js/src/ui/ConfirmDialog/confirmDialog.js
@@ -1,6 +1,24 @@
+// Copyright 2015, 2016 Ethcore (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
 import React, { Component, PropTypes } from 'react';
 import ActionDone from 'material-ui/svg-icons/action/done';
 import ContentClear from 'material-ui/svg-icons/content/clear';
+
+import { nodeOrStringProptype } from '~/util/proptypes';
 
 import Button from '../Button';
 import Modal from '../Modal';
@@ -15,9 +33,7 @@ export default class ConfirmDialog extends Component {
     iconDeny: PropTypes.node,
     labelConfirm: PropTypes.string,
     labelDeny: PropTypes.string,
-    title: PropTypes.oneOfType([
-      PropTypes.node, PropTypes.string
-    ]).isRequired,
+    title: nodeOrStringProptype.isRequired,
     visible: PropTypes.bool.isRequired,
     onConfirm: PropTypes.func.isRequired,
     onDeny: PropTypes.func.isRequired

--- a/js/src/ui/Container/Title/title.js
+++ b/js/src/ui/Container/Title/title.js
@@ -16,17 +16,15 @@
 
 import React, { Component, PropTypes } from 'react';
 
+import { nodeOrStringProptype } from '~/util/proptypes';
+
 import styles from './title.css';
 
 export default class Title extends Component {
   static propTypes = {
     className: PropTypes.string,
-    title: PropTypes.oneOfType([
-      PropTypes.string, PropTypes.node
-    ]),
-    byline: PropTypes.oneOfType([
-      PropTypes.string, PropTypes.node
-    ])
+    title: nodeOrStringProptype,
+    byline: nodeOrStringProptype
   }
 
   state = {

--- a/js/src/ui/Container/container.js
+++ b/js/src/ui/Container/container.js
@@ -17,6 +17,8 @@
 import React, { Component, PropTypes } from 'react';
 import { Card } from 'material-ui/Card';
 
+import { nodeOrStringProptype } from '~/util/proptypes';
+
 import Title from './Title';
 
 import styles from './container.css';
@@ -28,9 +30,7 @@ export default class Container extends Component {
     compact: PropTypes.bool,
     light: PropTypes.bool,
     style: PropTypes.object,
-    title: PropTypes.oneOfType([
-      PropTypes.string, PropTypes.node
-    ])
+    title: nodeOrStringProptype
   }
 
   render () {

--- a/js/src/ui/Form/InputInline/inputInline.js
+++ b/js/src/ui/Form/InputInline/inputInline.js
@@ -16,6 +16,8 @@
 
 import React, { Component, PropTypes } from 'react';
 
+import { nodeOrStringProptype } from '~/util/proptypes';
+
 import Input from '../Input';
 
 import styles from './inputInline.css';
@@ -33,9 +35,7 @@ export default class InputInline extends Component {
     value: PropTypes.oneOfType([
       PropTypes.number, PropTypes.string
     ]),
-    static: PropTypes.oneOfType([
-      PropTypes.node, PropTypes.string
-    ])
+    static: nodeOrStringProptype
   }
 
   state = {

--- a/js/src/ui/Modal/Title/title.js
+++ b/js/src/ui/Modal/Title/title.js
@@ -18,6 +18,8 @@ import React, { Component, PropTypes } from 'react';
 import { LinearProgress } from 'material-ui';
 import { Step, Stepper, StepLabel } from 'material-ui/Stepper';
 
+import { nodeOrStringProptype } from '~/util/proptypes';
+
 import styles from '../modal.css';
 
 export default class Title extends Component {
@@ -26,9 +28,7 @@ export default class Title extends Component {
     current: PropTypes.number,
     steps: PropTypes.array,
     waiting: PropTypes.array,
-    title: React.PropTypes.oneOfType([
-      PropTypes.node, PropTypes.string
-    ])
+    title: nodeOrStringProptype
   }
 
   render () {

--- a/js/src/ui/Modal/modal.js
+++ b/js/src/ui/Modal/modal.js
@@ -19,6 +19,8 @@ import { connect } from 'react-redux';
 import { bindActionCreators } from 'redux';
 import { Dialog } from 'material-ui';
 
+import { nodeOrStringProptype } from '~/util/proptypes';
+
 import Container from '../Container';
 import Title from './Title';
 
@@ -42,9 +44,7 @@ class Modal extends Component {
     current: PropTypes.number,
     waiting: PropTypes.array,
     steps: PropTypes.array,
-    title: PropTypes.oneOfType([
-      PropTypes.node, PropTypes.string
-    ]),
+    title: nodeOrStringProptype,
     visible: PropTypes.bool.isRequired,
     settings: PropTypes.object.isRequired
   }

--- a/js/src/util/proptypes.js
+++ b/js/src/util/proptypes.js
@@ -16,6 +16,16 @@
 
 import { PropTypes } from 'react';
 
-export default function nullableProptype (type) {
-  return PropTypes.oneOfType([ PropTypes.oneOf([ null ]), type ]);
+export function nullableProptype (type) {
+  return PropTypes.oneOfType([
+    PropTypes.oneOf([ null ]),
+    type
+  ]);
+}
+
+export function nodeOrStringProptype () {
+  return PropTypes.oneOfType([
+    PropTypes.node,
+    PropTypes.string
+  ]);
 }


### PR DESCRIPTION
- combine all defined proptypes in `util/proptypes.js`
- add new PropTypes as cherry-picked from WIP branches
- change all existing references
- make references consistent between `nullable` & `nullableProptype`