### PR TITLE
Give accounts precedence over address_book entries

### DIFF
--- a/js/src/redux/providers/personalActions.js
+++ b/js/src/redux/providers/personalActions.js
@@ -27,18 +27,17 @@ export function personalAccountsInfo (accountsInfo) {
 
   Object.keys(accountsInfo || {})
     .map((address) => Object.assign({}, accountsInfo[address], { address }))
+    .filter((account) => account.uuid || !account.meta.deleted)
     .forEach((account) => {
       if (account.uuid) {
         accounts[account.address] = account;
-      } else if (!account.meta.deleted) {
-        if (account.meta.wallet) {
-          account.wallet = true;
-          wallets[account.address] = account;
-        } else if (account.meta.contract) {
-          contracts[account.address] = account;
-        } else {
-          contacts[account.address] = account;
-        }
+      } else if (account.meta.wallet) {
+        account.wallet = true;
+        wallets[account.address] = account;
+      } else if (account.meta.contract) {
+        contracts[account.address] = account;
+      } else {
+        contacts[account.address] = account;
       }
     });
 

--- a/js/src/redux/providers/personalActions.js
+++ b/js/src/redux/providers/personalActions.js
@@ -27,17 +27,18 @@ export function personalAccountsInfo (accountsInfo) {
 
   Object.keys(accountsInfo || {})
     .map((address) => Object.assign({}, accountsInfo[address], { address }))
-    .filter((account) => !account.meta.deleted)
     .forEach((account) => {
       if (account.uuid) {
         accounts[account.address] = account;
-      } else if (account.meta.wallet) {
-        account.wallet = true;
-        wallets[account.address] = account;
-      } else if (account.meta.contract) {
-        contracts[account.address] = account;
-      } else {
-        contacts[account.address] = account;
+      } else if (!account.meta.deleted) {
+        if (account.meta.wallet) {
+          account.wallet = true;
+          wallets[account.address] = account;
+        } else if (account.meta.contract) {
+          contracts[account.address] = account;
+        } else {
+          contacts[account.address] = account;
+        }
       }
     });
 

--- a/js/src/ui/IdentityName/identityName.js
+++ b/js/src/ui/IdentityName/identityName.js
@@ -37,7 +37,7 @@ class IdentityName extends Component {
   render () {
     const { address, accountsInfo, tokens, empty, name, shorten, unknown, className } = this.props;
     const account = accountsInfo[address] || tokens[address];
-    const hasAccount = account && (!account.meta || !account.meta.deleted);
+    const hasAccount = account && (account.uuid || !account.meta || !account.meta.deleted);
 
     if (!hasAccount && empty) {
       return null;

--- a/rpc/src/v1/impls/parity_accounts.rs
+++ b/rpc/src/v1/impls/parity_accounts.rs
@@ -57,7 +57,7 @@ impl<C: 'static> ParityAccounts for ParityAccountsClient<C> where C: MiningBlock
 		let info = try!(store.accounts_info().map_err(|e| errors::account("Could not fetch account info.", e)));
 		let other = store.addresses_info().expect("addresses_info always returns Ok; qed");
 
-		Ok(info.into_iter().chain(other.into_iter()).map(|(a, v)| {
+		Ok(other.into_iter().chain(info.into_iter()).map(|(a, v)| {
 			let m = map![
 				"name".to_owned() => to_value(&v.name),
 				"meta".to_owned() => to_value(&v.meta),


### PR DESCRIPTION
- Allow `parity_accountsInfo` to return entries where accounts have a higher/overriding priority over address_book.json entries
- Clean UI to ignore meta.delete for accounts (real delete in-place)
- Fixes https://github.com/ethcore/parity/issues/3721 & Fixes https://github.com/ethcore/parity/issues/3722