### PR TITLE
Properly delete addresses/contracts in addressbook

### DIFF
--- a/js/src/api/subscriptions/personal.js
+++ b/js/src/api/subscriptions/personal.js
@@ -68,6 +68,7 @@ export default class Personal {
           this._accountsInfo();
           return;
 
+        case 'parity_removeAddress':
         case 'parity_setAccountName':
         case 'parity_setAccountMeta':
           this._accountsInfo();

--- a/js/src/dapps/basiccoin/Application/application.js
+++ b/js/src/dapps/basiccoin/Application/application.js
@@ -94,7 +94,6 @@ export default class Application extends Component {
           tokenregInstance,
           accounts: Object
             .keys(accountsInfo)
-            .filter((address) => !accountsInfo[address].meta.deleted)
             .sort((a, b) => {
               return (accountsInfo[b].uuid || '').localeCompare(accountsInfo[a].uuid || '');
             })

--- a/js/src/dapps/registry/addresses/actions.js
+++ b/js/src/dapps/registry/addresses/actions.js
@@ -24,7 +24,6 @@ export const fetch = () => (dispatch) => {
     .then((accountsInfo) => {
       const addresses = Object
         .keys(accountsInfo)
-        .filter((address) => accountsInfo[address] && !accountsInfo[address].meta.deleted)
         .map((address) => ({
           ...accountsInfo[address],
           address,

--- a/js/src/modals/AddAddress/addAddress.js
+++ b/js/src/modals/AddAddress/addAddress.js
@@ -102,7 +102,7 @@ export default class AddAddress extends Component {
     if (!addressError) {
       const contact = contacts[address];
 
-      if (contact && !contact.meta.deleted) {
+      if (contact) {
         addressError = ERRORS.duplicateAddress;
       }
     }

--- a/js/src/modals/AddContract/addContract.js
+++ b/js/src/modals/AddContract/addContract.js
@@ -231,7 +231,7 @@ export default class AddContract extends Component {
     if (!addressError) {
       const contract = contracts[address];
 
-      if (contract && !contract.meta.deleted) {
+      if (contract) {
         addressError = ERRORS.duplicateAddress;
       }
     }

--- a/js/src/redux/providers/personal.js
+++ b/js/src/redux/providers/personal.js
@@ -64,7 +64,6 @@ export default class Personal {
       })
       .catch((error) => {
         console.warn('removeDeleted', error);
-        return [];
       });
   }
 }

--- a/js/src/redux/providers/personal.js
+++ b/js/src/redux/providers/personal.js
@@ -23,6 +23,7 @@ export default class Personal {
   }
 
   start () {
+    this._removeDeleted();
     this._subscribeAccountsInfo();
   }
 
@@ -38,6 +39,32 @@ export default class Personal {
       })
       .then((subscriptionId) => {
         console.log('personal._subscribeAccountsInfo', 'subscriptionId', subscriptionId);
+      });
+  }
+
+  _removeDeleted () {
+    this._api.parity
+      .accountsInfo()
+      .then((accountsInfo) => {
+        return Promise.all(
+          Object
+            .keys(accountsInfo)
+            .filter((address) => {
+              const account = accountsInfo[address];
+
+              return !account.uuid && account.meta.deleted;
+            })
+            .map((address) => this._api.parity.removeAddress(address))
+        );
+      })
+      .then((results) => {
+        if (results.length) {
+          console.log(`Removed ${results.length} previously marked addresses`);
+        }
+      })
+      .catch((error) => {
+        console.warn('removeDeleted', error);
+        return [];
       });
   }
 }

--- a/js/src/ui/Form/InputAddress/inputAddress.js
+++ b/js/src/ui/Form/InputAddress/inputAddress.js
@@ -53,7 +53,6 @@ class InputAddress extends Component {
     const { small, allowCopy, hideUnderline, onSubmit, accountsInfo, tokens } = this.props;
 
     const account = accountsInfo[value] || tokens[value];
-    const hasAccount = account && !(account.meta && account.meta.deleted);
 
     const icon = this.renderIcon();
 
@@ -74,7 +73,7 @@ class InputAddress extends Component {
           label={ label }
           hint={ hint }
           error={ error }
-          value={ text && hasAccount ? account.name : value }
+          value={ text && account ? account.name : value }
           onChange={ this.handleInputChange }
           onSubmit={ onSubmit }
           allowCopy={ allowCopy && (disabled ? value : false) }

--- a/js/src/ui/IdentityName/identityName.js
+++ b/js/src/ui/IdentityName/identityName.js
@@ -37,17 +37,16 @@ class IdentityName extends Component {
   render () {
     const { address, accountsInfo, tokens, empty, name, shorten, unknown, className } = this.props;
     const account = accountsInfo[address] || tokens[address];
-    const hasAccount = account && (!account.meta || !account.meta.deleted);
 
-    if (!hasAccount && empty) {
+    if (!account && empty) {
       return null;
     }
 
     const addressFallback = shorten ? (<ShortenedHash data={ address } />) : address;
     const fallback = unknown ? defaultName : addressFallback;
-    const isUuid = hasAccount && account.name === account.uuid;
+    const isUuid = account && account.name === account.uuid;
     const displayName = (name && name.toUpperCase().trim()) ||
-      (hasAccount && !isUuid
+      (account && !isUuid
       ? account.name.toUpperCase().trim()
       : fallback);
 

--- a/js/src/views/Address/Delete/delete.js
+++ b/js/src/views/Address/Delete/delete.js
@@ -80,10 +80,8 @@ class Delete extends Component {
     const { api, router } = this.context;
     const { account, route, newError } = this.props;
 
-    account.meta.deleted = true;
-
     api.parity
-      .setAccountMeta(account.address, account.meta)
+      .removeAddress(account.address)
       .then(() => {
         router.push(route);
         this.closeDeleteDialog();

--- a/js/src/views/Address/address.js
+++ b/js/src/views/Address/address.js
@@ -121,7 +121,7 @@ class Address extends Component {
     return (
       <Actionbar
         title='Address Information'
-        buttons={ !contact || contact.meta.deleted ? [] : buttons } />
+        buttons={ !contact ? [] : buttons } />
     );
   }
 

--- a/js/src/views/Contract/contract.js
+++ b/js/src/views/Contract/contract.js
@@ -229,7 +229,7 @@ class Contract extends Component {
     return (
       <Actionbar
         title='Contract Information'
-        buttons={ !account || account.meta.deleted ? [] : buttons } />
+        buttons={ !account ? [] : buttons } />
     );
   }
 


### PR DESCRIPTION
- Convert previously marked meta.deleted entries into deleted
- Use parity_removeAddress to delete addresses (instead of marking)
- Remove now unneeded meta.deleted checks