### PR TITLE
Add support for wallets without getOwner() interface

### DIFF
--- a/js/src/contracts/registry.js
+++ b/js/src/contracts/registry.js
@@ -97,7 +97,7 @@ export default class Registry {
       return instance.getAddress.call({}, [sha3, 'A']);
     })
     .then((address) => {
-      console.log('[lookupAddress]', `(${sha3.slice(0, 5)}...${sha3.slice(-3)}) ${name}: ${address}`);
+      console.log('[lookupAddress]', `(${sha3}) ${name}: ${address}`);
       return address;
     });
   }

--- a/js/src/contracts/registry.js
+++ b/js/src/contracts/registry.js
@@ -97,7 +97,7 @@ export default class Registry {
       return instance.getAddress.call({}, [sha3, 'A']);
     })
     .then((address) => {
-      console.log('lookupAddress', name, sha3, address);
+      console.log('[lookupAddress]', `(${sha3.slice(0, 5)}...${sha3.slice(-3)}) ${name}: ${address}`);
       return address;
     });
   }

--- a/js/src/contracts/registry.js
+++ b/js/src/contracts/registry.js
@@ -19,7 +19,10 @@ import * as abis from './abi';
 export default class Registry {
   constructor (api) {
     this._api = api;
-    this._contracts = [];
+
+    this._contracts = {};
+    this._pendingContracts = {};
+
     this._instance = null;
     this._fetching = false;
     this._queue = [];
@@ -59,20 +62,25 @@ export default class Registry {
   getContract (_name) {
     const name = _name.toLowerCase();
 
-    return new Promise((resolve, reject) => {
-      if (this._contracts[name]) {
-        resolve(this._contracts[name]);
-        return;
-      }
+    if (this._contracts[name]) {
+      return Promise.resolve(this._contracts[name]);
+    }
 
-      this
-        .lookupAddress(name)
-        .then((address) => {
-          this._contracts[name] = this._api.newContract(abis[name], address);
-          resolve(this._contracts[name]);
-        })
-        .catch(reject);
-    });
+    if (this._pendingContracts[name]) {
+      return this._pendingContracts[name];
+    }
+
+    const promise = this
+      .lookupAddress(name)
+      .then((address) => {
+        this._contracts[name] = this._api.newContract(abis[name], address);
+        delete this._pendingContracts[name];
+        return this._contracts[name];
+      });
+
+    this._pendingContracts[name] = promise;
+
+    return promise;
   }
 
   getContractInstance (_name) {

--- a/js/src/modals/CreateWallet/createWalletStore.js
+++ b/js/src/modals/CreateWallet/createWalletStore.js
@@ -22,6 +22,7 @@ import { wallet as walletAbi } from '~/contracts/abi';
 import { wallet as walletCode } from '~/contracts/code';
 
 import { validateUint, validateAddress, validateName } from '~/util/validation';
+import { toWei } from '~/api/util/wei';
 import WalletsUtils from '~/util/wallets';
 
 const STEPS = {
@@ -46,7 +47,7 @@ export default class CreateWalletStore {
     address: '',
     owners: [],
     required: 1,
-    daylimit: 0,
+    daylimit: toWei(1),
 
     name: '',
     description: ''

--- a/js/src/redux/providers/personal.js
+++ b/js/src/redux/providers/personal.js
@@ -36,9 +36,6 @@ export default class Personal {
         }
 
         this._store.dispatch(personalAccountsInfo(accountsInfo));
-      })
-      .then((subscriptionId) => {
-        console.log('personal._subscribeAccountsInfo', 'subscriptionId', subscriptionId);
       });
   }
 

--- a/js/src/redux/providers/signer.js
+++ b/js/src/redux/providers/signer.js
@@ -34,9 +34,6 @@ export default class Signer {
         }
 
         this._store.dispatch(signerRequestsToConfirm(pending || []));
-      })
-      .then((subscriptionId) => {
-        console.log('signer._subscribeRequestsToConfirm', 'subscriptionId', subscriptionId);
       });
   }
 }

--- a/js/src/redux/providers/status.js
+++ b/js/src/redux/providers/status.js
@@ -59,9 +59,6 @@ export default class Status {
           .catch((error) => {
             console.warn('status._subscribeBlockNumber', 'getBlockByNumber', error);
           });
-      })
-      .then((subscriptionId) => {
-        console.log('status._subscribeBlockNumber', 'subscriptionId', subscriptionId);
       });
   }
 

--- a/js/src/ui/Form/Input/input.js
+++ b/js/src/ui/Form/Input/input.js
@@ -112,31 +112,36 @@ export default class Input extends Component {
         { this.renderCopyButton() }
         <TextField
           autoComplete='off'
-          className={ className }
-          style={ textFieldStyle }
-
-          readOnly={ readOnly }
-
-          errorText={ error }
-          floatingLabelFixed
-          floatingLabelText={ label }
-          fullWidth
-          hintText={ hint }
-          multiLine={ multiLine }
           name={ NAME_ID }
           id={ NAME_ID }
+
+          className={ className }
+          style={ textFieldStyle }
+          inputStyle={ inputStyle }
+          fullWidth
+
+          readOnly={ readOnly }
+          value={ value }
+
+          multiLine={ multiLine }
           rows={ rows }
           type={ type || 'text' }
+
+          errorText={ error }
+          hintText={ hint }
+          floatingLabelFixed
+          floatingLabelText={ label }
+
           underlineDisabledStyle={ UNDERLINE_DISABLED }
           underlineStyle={ readOnly ? UNDERLINE_READONLY : UNDERLINE_NORMAL }
           underlineFocusStyle={ readOnly ? { display: 'none' } : null }
           underlineShow={ !hideUnderline }
-          value={ value }
+
           onBlur={ this.onBlur }
           onChange={ this.onChange }
           onKeyDown={ this.onKeyDown }
           onPaste={ this.onPaste }
-          inputStyle={ inputStyle }
+
           min={ min }
           max={ max }
         >

--- a/js/src/ui/Form/Input/input.js
+++ b/js/src/ui/Form/Input/input.js
@@ -112,38 +112,39 @@ export default class Input extends Component {
         { this.renderCopyButton() }
         <TextField
           autoComplete='off'
-          name={ NAME_ID }
-          id={ NAME_ID }
-
           className={ className }
-          style={ textFieldStyle }
-          inputStyle={ inputStyle }
-          fullWidth
-
-          readOnly={ readOnly }
-          value={ value }
-
-          multiLine={ multiLine }
-          rows={ rows }
-          type={ type || 'text' }
-
           errorText={ error }
-          hintText={ hint }
+
           floatingLabelFixed
           floatingLabelText={ label }
 
-          underlineDisabledStyle={ UNDERLINE_DISABLED }
-          underlineStyle={ readOnly ? UNDERLINE_READONLY : UNDERLINE_NORMAL }
-          underlineFocusStyle={ readOnly ? { display: 'none' } : null }
-          underlineShow={ !hideUnderline }
+          hintText={ hint }
+          id={ NAME_ID }
+          inputStyle={ inputStyle }
+          fullWidth
+
+          max={ max }
+          min={ min }
+
+          multiLine={ multiLine }
+          name={ NAME_ID }
 
           onBlur={ this.onBlur }
           onChange={ this.onChange }
           onKeyDown={ this.onKeyDown }
           onPaste={ this.onPaste }
 
-          min={ min }
-          max={ max }
+          readOnly={ readOnly }
+          rows={ rows }
+          style={ textFieldStyle }
+          type={ type || 'text' }
+
+          underlineDisabledStyle={ UNDERLINE_DISABLED }
+          underlineStyle={ readOnly ? UNDERLINE_READONLY : UNDERLINE_NORMAL }
+          underlineFocusStyle={ readOnly ? { display: 'none' } : null }
+          underlineShow={ !hideUnderline }
+
+          value={ value }
         >
           { children }
         </TextField>

--- a/js/src/ui/Form/TypedInput/typedInput.js
+++ b/js/src/ui/Form/TypedInput/typedInput.js
@@ -53,13 +53,13 @@ export default class TypedInput extends Component {
   };
 
   state = {
-    isEth: true,
+    isEth: false,
     ethValue: 0
   };
 
-  componentDidMount () {
+  componentWillMount () {
     if (this.props.isEth && this.props.value) {
-      this.setState({ ethValue: fromWei(this.props.value) });
+      this.setState({ isEth: true, ethValue: fromWei(this.props.value) });
     }
   }
 
@@ -164,28 +164,32 @@ export default class TypedInput extends Component {
     }
 
     if (type === ABI_TYPES.INT) {
-      return this.renderNumber();
+      return this.renderEth();
     }
 
     if (type === ABI_TYPES.FIXED) {
-      return this.renderNumber();
+      return this.renderFloat();
     }
 
     return this.renderDefault();
   }
 
   renderEth () {
-    const { ethValue } = this.state;
+    const { ethValue, isEth } = this.state;
 
     const value = ethValue && typeof ethValue.toNumber === 'function'
       ? ethValue.toNumber()
       : ethValue;
 
+    const input = isEth
+      ? this.renderFloat(value, this.onEthValueChange)
+      : this.renderInteger(value, this.onEthValueChange);
+
     return (
       <div className={ styles.ethInput }>
         <div className={ styles.input }>
-          { this.renderNumber(value, this.onEthValueChange) }
-          { this.state.isEth ? (<div className={ styles.label }>ETH</div>) : null }
+          { input }
+          { isEth ? (<div className={ styles.label }>ETH</div>) : null }
         </div>
         <div className={ styles.toggle }>
           <Toggle
@@ -198,8 +202,9 @@ export default class TypedInput extends Component {
     );
   }
 
-  renderNumber (value = this.props.value, onChange = this.onChange) {
+  renderInteger (value = this.props.value, onChange = this.onChange) {
     const { label, error, param, hint, min, max } = this.props;
+
     const realValue = value && typeof value.toNumber === 'function'
       ? value.toNumber()
       : value;
@@ -212,6 +217,35 @@ export default class TypedInput extends Component {
         error={ error }
         onChange={ onChange }
         type='number'
+        step={ 1 }
+        min={ min !== null ? min : (param.signed ? null : 0) }
+        max={ max !== null ? max : null }
+      />
+    );
+  }
+
+  /**
+   * Decimal numbers have to be input via text field
+   * because of some react issues with input number fields.
+   * Once the issue is fixed, this could be a number again.
+   *
+   * @see https://github.com/facebook/react/issues/1549
+   */
+  renderFloat (value = this.props.value, onChange = this.onChange) {
+    const { label, error, param, hint, min, max } = this.props;
+
+    const realValue = value && typeof value.toNumber === 'function'
+      ? value.toNumber()
+      : value;
+
+    return (
+      <Input
+        label={ label }
+        hint={ hint }
+        value={ realValue }
+        error={ error }
+        onChange={ onChange }
+        type='text'
         min={ min !== null ? min : (param.signed ? null : 0) }
         max={ max !== null ? max : null }
       />

--- a/js/src/ui/Page/page.css
+++ b/js/src/ui/Page/page.css
@@ -17,8 +17,8 @@
 
 .layout {
   padding: 0.25em 0.25em 1em 0.25em;
-}
 
-.layout>div {
-  padding-bottom: 0.75em;
+  > * {
+    margin-bottom: 0.75em;
+  }
 }

--- a/js/src/views/Accounts/Summary/summary.js
+++ b/js/src/views/Accounts/Summary/summary.js
@@ -75,6 +75,13 @@ export default class Summary extends Component {
       return true;
     }
 
+    const prevOwners = this.props.owners;
+    const nextOwners = nextProps.owners;
+
+    if (!isEqual(prevOwners, nextOwners)) {
+      return true;
+    }
+
     return false;
   }
 
@@ -123,8 +130,8 @@ export default class Summary extends Component {
     return (
       <div className={ styles.owners }>
         {
-          ownersValid.map((owner) => (
-            <div key={ owner.address }>
+          ownersValid.map((owner, index) => (
+            <div key={ `${index}_${owner.address}` }>
               <div
                 data-tip
                 data-for={ `owner_${owner.address}` }

--- a/js/src/views/Application/TabBar/tabBar.js
+++ b/js/src/views/Application/TabBar/tabBar.js
@@ -188,7 +188,7 @@ class TabBar extends Component {
     return (
       <ToolbarGroup>
         <div className={ styles.logo }>
-          <img src={ imagesEthcoreBlock } />
+          <img src={ imagesEthcoreBlock } height={ 28 } />
         </div>
       </ToolbarGroup>
     );

--- a/js/src/views/Contract/Events/events.js
+++ b/js/src/views/Contract/Events/events.js
@@ -45,9 +45,7 @@ export default class Events extends Component {
       return (
         <Container title='events'>
           <div>
-            <Loading
-              size={ 2 }
-            />
+            <Loading size={ 2 } />
           </div>
         </Container>
       );

--- a/js/src/views/Contract/Events/events.js
+++ b/js/src/views/Contract/Events/events.js
@@ -17,7 +17,7 @@
 import React, { Component, PropTypes } from 'react';
 import { uniq } from 'lodash';
 
-import { Container } from '~/ui';
+import { Container, Loading } from '~/ui';
 
 import Event from './Event';
 import styles from '../contract.css';
@@ -25,18 +25,40 @@ import styles from '../contract.css';
 export default class Events extends Component {
   static contextTypes = {
     api: PropTypes.object
-  }
+  };
 
   static propTypes = {
-    events: PropTypes.array,
-    isTest: PropTypes.bool.isRequired
-  }
+    isTest: PropTypes.bool.isRequired,
+    isLoading: PropTypes.bool,
+    events: PropTypes.array
+  };
+
+  static defaultProps = {
+    isLoading: false,
+    events: []
+  };
 
   render () {
-    const { events, isTest } = this.props;
+    const { events, isTest, isLoading } = this.props;
+
+    if (isLoading) {
+      return (
+        <Container title='events'>
+          <div>
+            <Loading
+              size={ 2 }
+            />
+          </div>
+        </Container>
+      );
+    }
 
     if (!events || !events.length) {
-      return null;
+      return (
+        <Container title='events'>
+          <p>No events has been sent from this contract.</p>
+        </Container>
+      );
     }
 
     const eventsKey = uniq(events.map((e) => e.key));

--- a/js/src/views/Contract/Queries/queries.js
+++ b/js/src/views/Contract/Queries/queries.js
@@ -54,6 +54,10 @@ export default class Queries extends Component {
       .filter((fn) => fn.inputs.length > 0)
       .map((fn) => this.renderInputQuery(fn));
 
+    if (queries.length + noInputQueries.length + withInputQueries.length === 0) {
+      return null;
+    }
+
     return (
       <Container title='queries'>
         <div className={ styles.methods }>

--- a/js/src/views/Contract/contract.js
+++ b/js/src/views/Contract/contract.js
@@ -40,7 +40,7 @@ import styles from './contract.css';
 class Contract extends Component {
   static contextTypes = {
     api: React.PropTypes.object.isRequired
-  }
+  };
 
   static propTypes = {
     setVisibleAccounts: PropTypes.func.isRequired,
@@ -50,7 +50,7 @@ class Contract extends Component {
     contracts: PropTypes.object,
     isTest: PropTypes.bool,
     params: PropTypes.object
-  }
+  };
 
   state = {
     contract: null,
@@ -64,8 +64,9 @@ class Contract extends Component {
     allEvents: [],
     minedEvents: [],
     pendingEvents: [],
-    queryValues: {}
-  }
+    queryValues: {},
+    loadingEvents: true
+  };
 
   componentDidMount () {
     const { api } = this.context;
@@ -115,7 +116,7 @@ class Contract extends Component {
 
   render () {
     const { balances, contracts, params, isTest } = this.props;
-    const { allEvents, contract, queryValues } = this.state;
+    const { allEvents, contract, queryValues, loadingEvents } = this.state;
     const account = contracts[params.address];
     const balance = balances[params.address];
 
@@ -134,12 +135,21 @@ class Contract extends Component {
             account={ account }
             balance={ balance }
           />
-          <Queries
-            contract={ contract }
-            values={ queryValues } />
-          <Events
-            isTest={ isTest }
-            events={ allEvents } />
+
+          <div>
+            <Queries
+              contract={ contract }
+              values={ queryValues }
+            />
+          </div>
+
+          <div>
+            <Events
+              isTest={ isTest }
+              isLoading={ loadingEvents }
+              events={ allEvents }
+            />
+          </div>
 
           { this.renderDetails(account) }
         </Page>
@@ -358,6 +368,10 @@ class Contract extends Component {
   }
 
   _receiveEvents = (error, logs) => {
+    if (this.state.loadingEvents) {
+      this.setState({ loadingEvents: false });
+    }
+
     if (error) {
       console.error('_receiveEvents', error);
       return;

--- a/js/src/views/Contract/contract.js
+++ b/js/src/views/Contract/contract.js
@@ -136,20 +136,16 @@ class Contract extends Component {
             balance={ balance }
           />
 
-          <div>
-            <Queries
-              contract={ contract }
-              values={ queryValues }
-            />
-          </div>
+          <Queries
+            contract={ contract }
+            values={ queryValues }
+          />
 
-          <div>
-            <Events
-              isTest={ isTest }
-              isLoading={ loadingEvents }
-              events={ allEvents }
-            />
-          </div>
+          <Events
+            isTest={ isTest }
+            isLoading={ loadingEvents }
+            events={ allEvents }
+          />
 
           { this.renderDetails(account) }
         </Page>

--- a/js/src/views/Wallet/Details/details.js
+++ b/js/src/views/Wallet/Details/details.js
@@ -55,9 +55,9 @@ export default class WalletDetails extends Component {
       return null;
     }
 
-    const ownersList = owners.map((address) => (
+    const ownersList = owners.map((address, idx) => (
       <InputAddress
-        key={ address }
+        key={ `${idx}_${address}` }
         value={ address }
         disabled
         text


### PR DESCRIPTION
This adds Mist Wallet support (which doesn't have the `getOwner` method).

Plus small fixes here and there (React errors from same keys for elements, stop fetching addresses from the registry twice if it is loading...)