### PR TITLE
Fixes to the Wallet UI

### DIFF
--- a/js/src/views/Account/Header/header.js
+++ b/js/src/views/Account/Header/header.js
@@ -92,7 +92,7 @@ export default class Header extends Component {
   renderTxCount () {
     const { balance, isContract } = this.props;
 
-    if (!balance) {
+    if (!balance || isContract) {
       return null;
     }
 
@@ -102,12 +102,9 @@ export default class Header extends Component {
       return null;
     }
 
-    // Contracts always have one transaction, contract creation
-    const count = isContract && txCount.gt(0) ? txCount.minus(1) : txCount;
-
     return (
       <div className={ styles.infoline }>
-        { count.toFormat() } outgoing transactions
+        { txCount.toFormat() } outgoing transactions
       </div>
     );
   }

--- a/js/src/views/Account/Header/header.js
+++ b/js/src/views/Account/Header/header.js
@@ -31,12 +31,14 @@ export default class Header extends Component {
     account: PropTypes.object,
     balance: PropTypes.object,
     className: PropTypes.string,
-    children: PropTypes.node
+    children: PropTypes.node,
+    isContract: PropTypes.bool
   };
 
   static defaultProps = {
     className: '',
-    children: null
+    children: null,
+    isContract: false
   };
 
   render () {
@@ -88,7 +90,7 @@ export default class Header extends Component {
   }
 
   renderTxCount () {
-    const { balance } = this.props;
+    const { balance, isContract } = this.props;
 
     if (!balance) {
       return null;
@@ -100,9 +102,12 @@ export default class Header extends Component {
       return null;
     }
 
+    // Contracts always have one transaction, contract creation
+    const count = isContract && txCount.gt(0) ? txCount.minus(1) : txCount;
+
     return (
       <div className={ styles.infoline }>
-        { txCount.toFormat() } outgoing transactions
+        { count.toFormat() } outgoing transactions
       </div>
     );
   }

--- a/js/src/views/Contract/contract.js
+++ b/js/src/views/Contract/contract.js
@@ -133,6 +133,7 @@ class Contract extends Component {
           <Header
             account={ account }
             balance={ balance }
+            isContract
           />
           <Queries
             contract={ contract }

--- a/js/src/views/Wallet/wallet.js
+++ b/js/src/views/Wallet/wallet.js
@@ -153,7 +153,13 @@ class Wallet extends Component {
       return null;
     }
 
-    const limit = api.util.fromWei(dailylimit.limit).toFormat(3);
+    const _limit = api.util.fromWei(dailylimit.limit);
+
+    if (_limit.equals(0)) {
+      return null;
+    }
+
+    const limit = _limit.toFormat(3);
     const spent = api.util.fromWei(dailylimit.spent).toFormat(3);
     const date = moment(dailylimit.last.toNumber() * 24 * 3600 * 1000);
 

--- a/js/src/views/Wallet/wallet.js
+++ b/js/src/views/Wallet/wallet.js
@@ -127,6 +127,7 @@ class Wallet extends Component {
               className={ styles.header }
               account={ wallet }
               balance={ balance }
+              isContract
             >
               { this.renderInfos() }
             </Header>


### PR DESCRIPTION
```
gavofyork [12:05 AM]  
number of "outgoing transactions" (i.e. nonce) is incorrect for contracts
they start at one (rather than zero for basic accounts).

it's particularly misleading for wallet contracts, since the actual outgoing transactions can be numerous even with a nonce of 1.
(nonce only gets increased for a contract account when it makes a `CREATE` operation) (edited)

also, wallet day limit of 0 makes little sense - if the daily limit (and do note, this is for single-signing shortcut - multi-signing is never limited) is zero, then it should just be elided from the UI (edited)
```