### PR TITLE
Target Babel to latest Chrome Versions in dev

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -59,6 +59,7 @@
     "babel-plugin-transform-runtime": "6.15.0",
     "babel-plugin-webpack-alias": "2.1.2",
     "babel-polyfill": "6.20.0",
+    "babel-preset-env": "1.0.2",
     "babel-preset-es2015": "6.18.0",
     "babel-preset-es2016": "6.16.0",
     "babel-preset-es2017": "6.16.0",

--- a/js/webpack/shared.js
+++ b/js/webpack/shared.js
@@ -41,7 +41,7 @@ function getBabelrc () {
   const npmStart = process.env.npm_lifecycle_event === 'start';
   const npmStartApp = process.env.npm_lifecycle_event === 'start:app';
 
-  if (BABEL_PRESET_ENV || npmStart || npmStartApp) {
+  if (BABEL_PRESET_ENV && (npmStart || npmStartApp)) {
     console.log('using babel-preset-env');
 
     babelrc.presets = [

--- a/js/webpack/shared.js
+++ b/js/webpack/shared.js
@@ -36,6 +36,29 @@ function getBabelrc () {
   // [ "es2015", { "modules": false } ]
   babelrc.presets[es2015Index] = [ 'es2015', { modules: false } ];
   babelrc['babelrc'] = false;
+
+  const BABEL_PRESET_ENV = process.env.BABEL_PRESET_ENV;
+  const npmStart = process.env.npm_lifecycle_event === 'start';
+  const npmStartApp = process.env.npm_lifecycle_event === 'start:app';
+
+  if (BABEL_PRESET_ENV || npmStart || npmStartApp) {
+    console.log('using babel-preset-env');
+
+    babelrc.presets = [
+      // 'es2017',
+      'stage-0', 'react',
+      [
+        'env',
+        {
+          targets: { browsers: ['last 2 Chrome versions'] },
+          modules: false,
+          loose: true,
+          useBuiltIns: true
+        }
+      ]
+    ];
+  }
+
   return babelrc;
 }
 


### PR DESCRIPTION
Use `babel-preset-env` to target Babel to latest Chrome Versions.

This increases re-build speeds by 25% (from ~4s to ~3s). It isn't much yet, but could eventually get better while Chrome is shipping new features.