### PR TITLE
block: enforce gas limit falls within engine bounds

### DIFF
--- a/ethcore/src/block.rs
+++ b/ethcore/src/block.rs
@@ -266,7 +266,8 @@ impl<'x> OpenBlock<'x> {
 		r.block.base.header.set_extra_data(extra_data);
 		r.block.base.header.note_dirty();
 
-		engine.populate_from_parent(&mut r.block.base.header, parent, gas_range_target.0, gas_range_target.1);
+		let gas_floor_target = ::std::cmp::max(gas_range_target.0, engine.params().min_gas_limit);
+		engine.populate_from_parent(&mut r.block.base.header, parent, gas_floor_target, gas_range_target.1);
 		engine.on_new_block(&mut r.block);
 		Ok(r)
 	}

--- a/ethcore/src/engines/mod.rs
+++ b/ethcore/src/engines/mod.rs
@@ -125,8 +125,9 @@ pub trait Engine : Sync + Send {
 		self.verify_block_basic(header, None).and_then(|_| self.verify_block_unordered(header, None))
 	}
 
-	/// Don't forget to call Super::populate_from_parent when subclassing & overriding.
-	// TODO: consider including State in the params.
+	/// Populate a header's fields based on its parent's header.
+	/// Takes gas floor and ceiling targets.
+	/// The gas floor target must not be lower than the engine's minimum gas limit.
 	fn populate_from_parent(&self, header: &mut Header, parent: &Header, _gas_floor_target: U256, _gas_ceil_target: U256) {
 		header.set_difficulty(parent.difficulty().clone());
 		header.set_gas_limit(parent.gas_limit().clone());


### PR DESCRIPTION
Fixes #3760

Ideally I think the best thing to do would be to no longer expose `CommonParams` and allow engines to internally manage the ranges while exposing nothing more than a simple validation/creation interface as a black box.