### PR TITLE
Fix Wallet Settings Modal

### DIFF
--- a/js/src/modals/CreateWallet/WalletDetails/walletDetails.js
+++ b/js/src/modals/CreateWallet/WalletDetails/walletDetails.js
@@ -17,7 +17,6 @@
 import React, { Component, PropTypes } from 'react';
 
 import { Form, TypedInput, Input, AddressSelect, InputAddress } from '~/ui';
-import { parseAbiType } from '~/util/abi';
 
 import styles from '../createWallet.css';
 

--- a/js/src/modals/CreateWallet/WalletDetails/walletDetails.js
+++ b/js/src/modals/CreateWallet/WalletDetails/walletDetails.js
@@ -105,7 +105,7 @@ export default class WalletDetails extends Component {
           value={ wallet.owners.slice() }
           onChange={ this.onOwnersChange }
           accounts={ accounts }
-          param={ parseAbiType('address[]') }
+          param='address[]'
         />
 
         <div className={ styles.splitInput }>
@@ -115,7 +115,7 @@ export default class WalletDetails extends Component {
             value={ wallet.required }
             error={ errors.required }
             onChange={ this.onRequiredChange }
-            param={ parseAbiType('uint') }
+            param='uint'
             min={ 1 }
             max={ wallet.owners.length + 1 }
           />
@@ -126,7 +126,7 @@ export default class WalletDetails extends Component {
             value={ wallet.daylimit }
             error={ errors.daylimit }
             onChange={ this.onDaylimitChange }
-            param={ parseAbiType('uint') }
+            param='uint'
             isEth
           />
         </div>

--- a/js/src/modals/DeployContract/ParametersStep/parametersStep.js
+++ b/js/src/modals/DeployContract/ParametersStep/parametersStep.js
@@ -83,6 +83,7 @@ export default class ParametersStep extends Component {
             accounts={ accounts }
             onChange={ onChange }
             param={ param }
+            isEth={ false }
           />
         </div>
       );

--- a/js/src/modals/ExecuteContract/DetailsStep/detailsStep.js
+++ b/js/src/modals/ExecuteContract/DetailsStep/detailsStep.js
@@ -18,7 +18,6 @@ import React, { Component, PropTypes } from 'react';
 import { Checkbox, MenuItem } from 'material-ui';
 
 import { AddressSelect, Form, Input, Select, TypedInput } from '~/ui';
-import { parseAbiType } from '~/util/abi';
 
 import styles from '../executeContract.css';
 

--- a/js/src/modals/ExecuteContract/DetailsStep/detailsStep.js
+++ b/js/src/modals/ExecuteContract/DetailsStep/detailsStep.js
@@ -162,7 +162,8 @@ export default class DetailsStep extends Component {
             error={ valuesError[index] }
             onChange={ onChange }
             accounts={ accounts }
-            param={ parseAbiType(input.type) }
+            param={ input.type }
+            isEth={ false }
           />
         </div>
       );

--- a/js/src/modals/WalletSettings/walletSettings.js
+++ b/js/src/modals/WalletSettings/walletSettings.js
@@ -22,7 +22,6 @@ import { pick } from 'lodash';
 import ActionDone from 'material-ui/svg-icons/action/done';
 import ContentClear from 'material-ui/svg-icons/content/clear';
 import NavigationArrowForward from 'material-ui/svg-icons/navigation/arrow-forward';
-import { parseAbiType } from '~/util/abi';
 
 import { Button, Modal, TxHash, BusyStep, Form, TypedInput, InputAddress, AddressSelect } from '~/ui';
 import { fromWei } from '~/api/util/wei';

--- a/js/src/modals/WalletSettings/walletSettings.js
+++ b/js/src/modals/WalletSettings/walletSettings.js
@@ -107,10 +107,7 @@ class WalletSettings extends Component {
 
         return (
           <div>
-            <p>You are about to make the following modifications</p>
-            <div>
-              { this.renderChanges(changes) }
-            </div>
+            { this.renderChanges(changes) }
           </div>
         );
 
@@ -142,19 +139,19 @@ class WalletSettings extends Component {
               value={ wallet.owners.slice() }
               onChange={ this.store.onOwnersChange }
               accounts={ accounts }
-              param={ parseAbiType('address[]') }
+              param='address[]'
             />
 
             <div className={ styles.splitInput }>
               <TypedInput
                 label='required owners'
                 hint='number of required owners to accept a transaction'
-                value={ wallet.require }
                 error={ errors.require }
-                onChange={ this.store.onRequireChange }
-                param={ parseAbiType('uint') }
                 min={ 1 }
+                onChange={ this.store.onRequireChange }
                 max={ wallet.owners.length }
+                param='uint'
+                value={ wallet.require }
               />
 
               <TypedInput
@@ -163,7 +160,7 @@ class WalletSettings extends Component {
                 value={ wallet.dailylimit }
                 error={ errors.dailylimit }
                 onChange={ this.store.onDailylimitChange }
-                param={ parseAbiType('uint') }
+                param='uint'
                 isEth
               />
             </div>
@@ -173,11 +170,24 @@ class WalletSettings extends Component {
   }
 
   renderChanges (changes) {
-    return changes.map((change, index) => (
+    if (changes.length === 0) {
+      return (
+        <p>No modifications have been made to the Wallet settings.</p>
+      );
+    }
+
+    const modifications = changes.map((change, index) => (
       <div key={ `${change.type}_${index}` }>
         { this.renderChange(change) }
       </div>
     ));
+
+    return (
+      <div>
+        <p>You are about to make the following modifications</p>
+        { modifications }
+      </div>
+    );
   }
 
   renderChange (change) {
@@ -297,6 +307,12 @@ class WalletSettings extends Component {
         return done ? [ closeBtn ] : [ closeBtn, sendingBtn ];
 
       case 'CONFIRMATION':
+        const { changes } = this.store;
+
+        if (changes.length === 0) {
+          return [ closeBtn ];
+        }
+
         return [ cancelBtn, sendBtn ];
 
       default:

--- a/js/src/util/abi.js
+++ b/js/src/util/abi.js
@@ -143,4 +143,7 @@ export function parseAbiType (type) {
       signed: true
     };
   }
+
+  // If no matches, return null
+  return null;
 }


### PR DESCRIPTION
Fixes the wrong `require` field in Wallet Settings modal.
Also, stop defaulting Uint TypedInput with the `ETH` toggle. Only for contracts now.