### PR TITLE
remove light server capability temporarily

### DIFF
--- a/parity/cli/mod.rs
+++ b/parity/cli/mod.rs
@@ -141,8 +141,6 @@ usage! {
 		flag_reserved_only: bool = false,
 			or |c: &Config| otry!(c.network).reserved_only.clone(),
 		flag_no_ancient_blocks: bool = false, or |_| None,
-		flag_serve_light: bool = false,
-			or |c: &Config| otry!(c.network).serve_light.clone(),
 
 		// -- API and Console Options
 		// RPC
@@ -254,7 +252,7 @@ usage! {
 			or |c: &Config| otry!(c.footprint).fat_db.clone(),
 		flag_scale_verifiers: bool = false,
 			or |c: &Config| otry!(c.footprint).scale_verifiers.clone(),
-		flag_num_verifiers: Option<usize> = None, 
+		flag_num_verifiers: Option<usize> = None,
 			or |c: &Config| otry!(c.footprint).num_verifiers.clone().map(Some),
 
 		// -- Import/Export Options
@@ -348,7 +346,6 @@ struct Network {
 	node_key: Option<String>,
 	reserved_peers: Option<String>,
 	reserved_only: Option<bool>,
-	serve_light: Option<bool>,
 }
 
 #[derive(Default, Debug, PartialEq, RustcDecodable)]
@@ -566,7 +563,6 @@ mod tests {
 			flag_reserved_peers: Some("./path_to_file".into()),
 			flag_reserved_only: false,
 			flag_no_ancient_blocks: false,
-			flag_serve_light: true,
 
 			// -- API and Console Options
 			// RPC
@@ -740,7 +736,6 @@ mod tests {
 				node_key: None,
 				reserved_peers: Some("./path/to/reserved_peers".into()),
 				reserved_only: Some(true),
-				serve_light: None,
 			}),
 			rpc: Some(Rpc {
 				disable: Some(true),

--- a/parity/cli/usage.txt
+++ b/parity/cli/usage.txt
@@ -101,7 +101,6 @@ Networking Options:
   --max-pending-peers NUM  Allow up to NUM pending connections. (default: {flag_max_pending_peers})
   --no-ancient-blocks      Disable downloading old blocks after snapshot restoration
                            or warp sync. (default: {flag_no_ancient_blocks})
-  --serve-light            Experimental: Serve light client peers. (default: {flag_serve_light})
 
 API and Console Options:
   --no-jsonrpc             Disable the JSON-RPC API server. (default: {flag_no_jsonrpc})

--- a/parity/configuration.rs
+++ b/parity/configuration.rs
@@ -338,7 +338,6 @@ impl Configuration {
 				no_periodic_snapshot: self.args.flag_no_periodic_snapshot,
 				check_seal: !self.args.flag_no_seal_check,
 				download_old_blocks: !self.args.flag_no_ancient_blocks,
-				serve_light: self.args.flag_serve_light,
 				verifier_settings: verifier_settings,
 			};
 			Cmd::Run(run_cmd)
@@ -1003,7 +1002,6 @@ mod tests {
 			no_periodic_snapshot: false,
 			check_seal: true,
 			download_old_blocks: true,
-			serve_light: false,
 			verifier_settings: Default::default(),
 		}));
 	}

--- a/parity/run.rs
+++ b/parity/run.rs
@@ -94,7 +94,6 @@ pub struct RunCmd {
 	pub no_periodic_snapshot: bool,
 	pub check_seal: bool,
 	pub download_old_blocks: bool,
-	pub serve_light: bool,
 	pub verifier_settings: VerifierSettings,
 }
 
@@ -189,11 +188,6 @@ pub fn execute(cmd: RunCmd, logger: Arc<RotatingLogger>) -> Result<(), String> {
 	);
 	info!("Operating mode: {}", Colour::White.bold().paint(format!("{}", mode)));
 
-	if cmd.serve_light {
-		info!("Configured to serve light client peers. Please note this feature is {}.",
-			Colour::White.bold().paint("experimental".to_string()));
-	}
-
 	// display warning about using experimental journaldb alorithm
 	if !algorithm.is_stable() {
 		warn!("Your chosen strategy is {}! You can re-run with --pruning to change.", Colour::Red.bold().paint("unstable"));
@@ -213,7 +207,6 @@ pub fn execute(cmd: RunCmd, logger: Arc<RotatingLogger>) -> Result<(), String> {
 	sync_config.fork_block = spec.fork_block();
 	sync_config.warp_sync = cmd.warp_sync;
 	sync_config.download_old_blocks = cmd.download_old_blocks;
-	sync_config.serve_light = cmd.serve_light;
 
 	let passwords = try!(passwords_from_files(&cmd.acc_conf.password_files));
 
@@ -291,12 +284,12 @@ pub fn execute(cmd: RunCmd, logger: Arc<RotatingLogger>) -> Result<(), String> {
 
 	// create sync object
 	let (sync_provider, manage_network, chain_notify) = try!(modules::sync(
-		&mut hypervisor, 
-		sync_config, 
-		net_conf.into(), 
-		client.clone(), 
-		snapshot_service.clone(), 
-		client.clone(), 
+		&mut hypervisor,
+		sync_config,
+		net_conf.into(),
+		client.clone(),
+		snapshot_service.clone(),
+		client.clone(),
 		&cmd.logger_config,
 	).map_err(|e| format!("Sync error: {}", e)));
 


### PR DESCRIPTION
Will add it in again once light sync is ready, but this will probably be after the 1.5 release.