### PR TITLE
Blocktime format rounding

### DIFF
--- a/js/src/views/Status/components/Status/status.js
+++ b/js/src/views/Status/components/Status/status.js
@@ -52,7 +52,7 @@ export default class Status extends Component {
                   #{ nodeStatus.blockNumber.toFormat() }
                 </div>
                 <div className={ styles.blockByline }>
-                  { moment().calendar(nodeStatus.blockTimestamp) }
+                  { moment(nodeStatus.blockTimestamp).calendar() }
                 </div>
               </div>
               <div className={ `${styles.col12} ${styles.padBottom}` }>


### PR DESCRIPTION
Displays `13:57:47` as `15:37` as opposed to `15:38` (Reference now goes from `blockTime` -> `current` as opposed to the other way around)

May improve display for https://github.com/ethcore/parity/issues/3888