### PR TITLE
remove -Zorbit=off from rustflags on windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,7 +6,7 @@ environment:
   certpass:
     secure: 0BgXJqxq9Ei34/hZ7121FQ==
   keyfile: C:\users\appveyor\Certificates.p12
-  RUSTFLAGS: -Zorbit=off -D warnings
+  RUSTFLAGS: -D warnings
 
 branches:
   only:


### PR DESCRIPTION
It was added to fix windows compilation for a broken rustc 1.12.0 release. No longer relevant as of 1.12.1/1.13.0. The flag has since been removed.