### PR TITLE
Allow contract constructors in chain spec

### DIFF
--- a/ethcore/res/constructor.json
+++ b/ethcore/res/constructor.json
@@ -1,0 +1,30 @@
+{
+	"name": "GenesisConstructor",
+	"engine": {
+		"null": null
+	},
+	"params": {
+		"accountStartNonce": "0x0",
+		"maximumExtraDataSize": "0x20",
+		"minGasLimit": "0x1388",
+		"networkID" : "0x2"
+	},
+	"genesis": {
+		"seal": {
+			"generic": "0x"
+		},
+		"difficulty": "0x20000",
+		"author": "0x0000000000000000000000000000000000000000",
+		"timestamp": "0x00",
+		"parentHash": "0x0000000000000000000000000000000000000000000000000000000000000000",
+		"extraData": "0x",
+		"gasLimit": "0x2fefd8"
+	},
+	"accounts": {
+		"0000000000000000000000000000000000000001": { "balance": "1", "builtin": { "name": "ecrecover", "pricing": { "linear": { "base": 3000, "word": 0 } } } },
+		"0000000000000000000000000000000000000002": { "balance": "1", "builtin": { "name": "sha256", "pricing": { "linear": { "base": 60, "word": 12 } } } },
+		"0000000000000000000000000000000000000003": { "balance": "1", "builtin": { "name": "ripemd160", "pricing": { "linear": { "base": 600, "word": 120 } } } },
+		"0000000000000000000000000000000000000004": { "balance": "1", "builtin": { "name": "identity", "pricing": { "linear": { "base": 15, "word": 3 } } } },
+		"0000000000000000000000000000000000000005": { "balance": "1", "constructor": "60606040526000805460ff19166001179055346000575b6075806100246000396000f300606060405263ffffffff60e060020a60003504166394b91deb81146022575b6000565b34600057602c6040565b604080519115158252519081900360200190f35b60005460ff16815600a165627a7a723058207882eb60ebce23178b3fa06d4cd8e5adc17711937ccddacb18a04abca2a2c9ee0029" }
+	}
+}

--- a/ethcore/src/block.rs
+++ b/ethcore/src/block.rs
@@ -595,9 +595,8 @@ mod tests {
 	use factory::Factories;
 	use state_db::StateDB;
 	use views::BlockView;
-	use util::{Address, TrieFactory};
+	use util::Address;
 	use util::hash::FixedHash;
-	use util::trie::TrieSpec;
 	use std::sync::Arc;
 
 	/// Enact the block given by `block_bytes` using `engine` on the database `db` with given `parent` block header
@@ -637,8 +636,7 @@ mod tests {
 		let spec = Spec::new_test();
 		let genesis_header = spec.genesis_header();
 		let mut db_result = get_temp_state_db();
-		let mut db = db_result.take();
-		spec.ensure_db_good(&mut db, &TrieFactory::new(TrieSpec::Secure)).unwrap();
+		let db = spec.ensure_db_good(db_result.take(), &Default::default()).unwrap();
 		let last_hashes = Arc::new(vec![genesis_header.hash()]);
 		let b = OpenBlock::new(&*spec.engine, Default::default(), false, db, &genesis_header, last_hashes, Address::zero(), (3141562.into(), 31415620.into()), vec![]).unwrap();
 		let b = b.close_and_lock();
@@ -653,8 +651,7 @@ mod tests {
 		let genesis_header = spec.genesis_header();
 
 		let mut db_result = get_temp_state_db();
-		let mut db = db_result.take();
-		spec.ensure_db_good(&mut db, &TrieFactory::new(TrieSpec::Secure)).unwrap();
+		let db = spec.ensure_db_good(db_result.take(), &Default::default()).unwrap();
 		let last_hashes = Arc::new(vec![genesis_header.hash()]);
 		let b = OpenBlock::new(engine, Default::default(), false, db, &genesis_header, last_hashes.clone(), Address::zero(), (3141562.into(), 31415620.into()), vec![]).unwrap()
 			.close_and_lock().seal(engine, vec![]).unwrap();
@@ -662,8 +659,7 @@ mod tests {
 		let orig_db = b.drain();
 
 		let mut db_result = get_temp_state_db();
-		let mut db = db_result.take();
-		spec.ensure_db_good(&mut db, &TrieFactory::new(TrieSpec::Secure)).unwrap();
+		let db = spec.ensure_db_good(db_result.take(), &Default::default()).unwrap();
 		let e = enact_and_seal(&orig_bytes, engine, false, db, &genesis_header, last_hashes, Default::default()).unwrap();
 
 		assert_eq!(e.rlp_bytes(), orig_bytes);
@@ -681,8 +677,7 @@ mod tests {
 		let genesis_header = spec.genesis_header();
 
 		let mut db_result = get_temp_state_db();
-		let mut db = db_result.take();
-		spec.ensure_db_good(&mut db, &TrieFactory::new(TrieSpec::Secure)).unwrap();
+		let db = spec.ensure_db_good(db_result.take(), &Default::default()).unwrap();
 		let last_hashes = Arc::new(vec![genesis_header.hash()]);
 		let mut open_block = OpenBlock::new(engine, Default::default(), false, db, &genesis_header, last_hashes.clone(), Address::zero(), (3141562.into(), 31415620.into()), vec![]).unwrap();
 		let mut uncle1_header = Header::new();
@@ -697,8 +692,7 @@ mod tests {
 		let orig_db = b.drain();
 
 		let mut db_result = get_temp_state_db();
-		let mut db = db_result.take();
-		spec.ensure_db_good(&mut db, &TrieFactory::new(TrieSpec::Secure)).unwrap();
+		let db = spec.ensure_db_good(db_result.take(), &Default::default()).unwrap();
 		let e = enact_and_seal(&orig_bytes, engine, false, db, &genesis_header, last_hashes, Default::default()).unwrap();
 
 		let bytes = e.rlp_bytes();

--- a/ethcore/src/client/test_client.rs
+++ b/ethcore/src/client/test_client.rs
@@ -336,8 +336,7 @@ impl MiningBlockChainClient for TestBlockChainClient {
 		let engine = &*self.spec.engine;
 		let genesis_header = self.spec.genesis_header();
 		let mut db_result = get_temp_state_db();
-		let mut db = db_result.take();
-		self.spec.ensure_db_good(&mut db, &TrieFactory::default()).unwrap();
+		let db = self.spec.ensure_db_good(db_result.take(), &Default::default()).unwrap();
 
 		let last_hashes = vec![genesis_header.hash()];
 		let mut open_block = OpenBlock::new(

--- a/ethcore/src/engines/authority_round.rs
+++ b/ethcore/src/engines/authority_round.rs
@@ -339,7 +339,6 @@ impl Engine for AuthorityRound {
 #[cfg(test)]
 mod tests {
 	use util::*;
-	use util::trie::TrieSpec;
 	use env_info::EnvInfo;
 	use header::Header;
 	use error::{Error, BlockError};
@@ -407,10 +406,8 @@ mod tests {
 		let engine = &*spec.engine;
 		engine.register_account_provider(Arc::new(tap));
 		let genesis_header = spec.genesis_header();
-		let mut db1 = get_temp_state_db().take();
-		spec.ensure_db_good(&mut db1, &TrieFactory::new(TrieSpec::Secure)).unwrap();
-		let mut db2 = get_temp_state_db().take();
-		spec.ensure_db_good(&mut db2, &TrieFactory::new(TrieSpec::Secure)).unwrap();
+		let db1 = spec.ensure_db_good(get_temp_state_db().take(), &Default::default()).unwrap();
+		let db2 = spec.ensure_db_good(get_temp_state_db().take(), &Default::default()).unwrap();
 		let last_hashes = Arc::new(vec![genesis_header.hash()]);
 		let b1 = OpenBlock::new(engine, Default::default(), false, db1, &genesis_header, last_hashes.clone(), addr1, (3141562.into(), 31415620.into()), vec![]).unwrap();
 		let b1 = b1.close_and_lock();

--- a/ethcore/src/engines/basic_authority.rs
+++ b/ethcore/src/engines/basic_authority.rs
@@ -191,7 +191,6 @@ impl Engine for BasicAuthority {
 #[cfg(test)]
 mod tests {
 	use util::*;
-	use util::trie::TrieSpec;
 	use block::*;
 	use env_info::EnvInfo;
 	use error::{BlockError, Error};
@@ -265,8 +264,7 @@ mod tests {
 		engine.register_account_provider(Arc::new(tap));
 		let genesis_header = spec.genesis_header();
 		let mut db_result = get_temp_state_db();
-		let mut db = db_result.take();
-		spec.ensure_db_good(&mut db, &TrieFactory::new(TrieSpec::Secure)).unwrap();
+		let db = spec.ensure_db_good(db_result.take(), &Default::default()).unwrap();
 		let last_hashes = Arc::new(vec![genesis_header.hash()]);
 		let b = OpenBlock::new(engine, Default::default(), false, db, &genesis_header, last_hashes, addr, (3141562.into(), 31415620.into()), vec![]).unwrap();
 		let b = b.close_and_lock();

--- a/ethcore/src/engines/instant_seal.rs
+++ b/ethcore/src/engines/instant_seal.rs
@@ -66,7 +66,6 @@ impl Engine for InstantSeal {
 #[cfg(test)]
 mod tests {
 	use util::*;
-	use util::trie::TrieSpec;
 	use tests::helpers::*;
 	use spec::Spec;
 	use header::Header;
@@ -79,8 +78,7 @@ mod tests {
 		let engine = &*spec.engine;
 		let genesis_header = spec.genesis_header();
 		let mut db_result = get_temp_state_db();
-		let mut db = db_result.take();
-		spec.ensure_db_good(&mut db, &TrieFactory::new(TrieSpec::Secure)).unwrap();
+		let db = spec.ensure_db_good(db_result.take(), &Default::default()).unwrap();
 		let last_hashes = Arc::new(vec![genesis_header.hash()]);
 		let b = OpenBlock::new(engine, Default::default(), false, db, &genesis_header, last_hashes, Address::default(), (3141562.into(), 31415620.into()), vec![]).unwrap();
 		let b = b.close_and_lock();

--- a/ethcore/src/engines/tendermint/mod.rs
+++ b/ethcore/src/engines/tendermint/mod.rs
@@ -656,7 +656,6 @@ impl Engine for Tendermint {
 #[cfg(test)]
 mod tests {
 	use util::*;
-	use util::trie::TrieSpec;
 	use io::{IoContext, IoHandler};
 	use block::*;
 	use error::{Error, BlockError};
@@ -681,8 +680,7 @@ mod tests {
 
 	fn propose_default(spec: &Spec, proposer: Address) -> (LockedBlock, Vec<Bytes>) {
 		let mut db_result = get_temp_state_db();
-		let mut db = db_result.take();
-		spec.ensure_db_good(&mut db, &TrieFactory::new(TrieSpec::Secure)).unwrap();
+		let db = spec.ensure_db_good(db_result.take(), &Default::default()).unwrap();
 		let genesis_header = spec.genesis_header();
 		let last_hashes = Arc::new(vec![genesis_header.hash()]);
 		let b = OpenBlock::new(spec.engine.as_ref(), Default::default(), false, db.boxed_clone(), &genesis_header, last_hashes, proposer, (3141562.into(), 31415620.into()), vec![]).unwrap();
@@ -889,9 +887,6 @@ mod tests {
 	fn relays_messages() {
 		let (spec, tap) = setup();
 		let engine = spec.engine.clone();
-		let mut db_result = get_temp_state_db();
-		let mut db = db_result.take();
-		spec.ensure_db_good(&mut db, &TrieFactory::new(TrieSpec::Secure)).unwrap();
 		
 		let v0 = insert_and_register(&tap, &engine, "0");
 		let v1 = insert_and_register(&tap, &engine, "1");
@@ -925,9 +920,6 @@ mod tests {
 	fn seal_submission() {
 		let (spec, tap) = setup();
 		let engine = spec.engine.clone();
-		let mut db_result = get_temp_state_db();
-		let mut db = db_result.take();
-		spec.ensure_db_good(&mut db, &TrieFactory::new(TrieSpec::Secure)).unwrap();
 		
 		let v0 = insert_and_register(&tap, &engine, "0");
 		let v1 = insert_and_register(&tap, &engine, "1");

--- a/ethcore/src/ethereum/ethash.rs
+++ b/ethcore/src/ethereum/ethash.rs
@@ -433,7 +433,6 @@ impl Header {
 #[cfg(test)]
 mod tests {
 	use util::*;
-	use util::trie::TrieSpec;
 	use block::*;
 	use tests::helpers::*;
 	use env_info::EnvInfo;
@@ -449,8 +448,7 @@ mod tests {
 		let engine = &*spec.engine;
 		let genesis_header = spec.genesis_header();
 		let mut db_result = get_temp_state_db();
-		let mut db = db_result.take();
-		spec.ensure_db_good(&mut db, &TrieFactory::new(TrieSpec::Secure)).unwrap();
+		let db = spec.ensure_db_good(db_result.take(), &Default::default()).unwrap();
 		let last_hashes = Arc::new(vec![genesis_header.hash()]);
 		let b = OpenBlock::new(engine, Default::default(), false, db, &genesis_header, last_hashes, Address::zero(), (3141562.into(), 31415620.into()), vec![]).unwrap();
 		let b = b.close();
@@ -463,8 +461,7 @@ mod tests {
 		let engine = &*spec.engine;
 		let genesis_header = spec.genesis_header();
 		let mut db_result = get_temp_state_db();
-		let mut db = db_result.take();
-		spec.ensure_db_good(&mut db, &TrieFactory::new(TrieSpec::Secure)).unwrap();
+		let db = spec.ensure_db_good(db_result.take(), &Default::default()).unwrap();
 		let last_hashes = Arc::new(vec![genesis_header.hash()]);
 		let mut b = OpenBlock::new(engine, Default::default(), false, db, &genesis_header, last_hashes, Address::zero(), (3141562.into(), 31415620.into()), vec![]).unwrap();
 		let mut uncle = Header::new();

--- a/ethcore/src/ethereum/mod.rs
+++ b/ethcore/src/ethereum/mod.rs
@@ -78,7 +78,6 @@ pub fn new_morden() -> Spec { load(include_bytes!("../../res/ethereum/morden.jso
 #[cfg(test)]
 mod tests {
 	use util::*;
-	use util::trie::TrieSpec;
 	use state::*;
 	use super::*;
 	use tests::helpers::*;
@@ -90,8 +89,7 @@ mod tests {
 		let engine = &spec.engine;
 		let genesis_header = spec.genesis_header();
 		let mut db_result = get_temp_state_db();
-		let mut db = db_result.take();
-		spec.ensure_db_good(&mut db, &TrieFactory::new(TrieSpec::Secure)).unwrap();
+		let db = spec.ensure_db_good(db_result.take(), &Default::default()).unwrap();
 		let s = State::from_existing(db, genesis_header.state_root().clone(), engine.account_start_nonce(), Default::default()).unwrap();
 		assert_eq!(s.balance(&"0000000000000000000000000000000000000001".into()), 1u64.into());
 		assert_eq!(s.balance(&"0000000000000000000000000000000000000002".into()), 1u64.into());

--- a/ethcore/src/spec/spec.rs
+++ b/ethcore/src/spec/spec.rs
@@ -367,7 +367,6 @@ mod tests {
 
 	#[test]
 	fn genesis_constructor() {
-		::env_logger::init().unwrap();
 		let spec = Spec::new_test_constructor();
 		let mut db_result = get_temp_state_db();
 		let db = spec.ensure_db_good(db_result.take(), &Default::default()).unwrap();

--- a/ethcore/src/state/mod.rs
+++ b/ethcore/src/state/mod.rs
@@ -46,6 +46,8 @@ pub struct ApplyOutcome {
 	pub receipt: Receipt,
 	/// The trace for the applied transaction, if None if tracing is disabled.
 	pub trace: Vec<FlatTrace>,
+	/// Contracts created.
+	pub contracts_created: Vec<Address>,
 }
 
 /// Result type for the execution ("application") of a transaction.
@@ -522,7 +524,7 @@ impl State {
 		try!(self.commit());
 		let receipt = Receipt::new(self.root().clone(), e.cumulative_gas_used, e.logs);
 		trace!(target: "state", "Transaction receipt: {:?}", receipt);
-		Ok(ApplyOutcome{receipt: receipt, trace: e.trace})
+		Ok(ApplyOutcome{receipt: receipt, trace: e.trace, contracts_created: e.contracts_created})
 	}
 
 	/// Commit accounts to SecTrieDBMut. This is similar to cpp-ethereum's dev::eth::commit.

--- a/ethcore/src/state/mod.rs
+++ b/ethcore/src/state/mod.rs
@@ -522,7 +522,7 @@ impl State {
 		try!(self.commit());
 		let receipt = Receipt::new(self.root().clone(), e.cumulative_gas_used, e.logs);
 		trace!(target: "state", "Transaction receipt: {:?}", receipt);
-		Ok(ApplyOutcome{receipt: receipt, trace: e.trace })
+		Ok(ApplyOutcome{receipt: receipt, trace: e.trace})
 	}
 
 	/// Commit accounts to SecTrieDBMut. This is similar to cpp-ethereum's dev::eth::commit.

--- a/ethcore/src/state/mod.rs
+++ b/ethcore/src/state/mod.rs
@@ -46,8 +46,6 @@ pub struct ApplyOutcome {
 	pub receipt: Receipt,
 	/// The trace for the applied transaction, if None if tracing is disabled.
 	pub trace: Vec<FlatTrace>,
-	/// Contracts created.
-	pub contracts_created: Vec<Address>,
 }
 
 /// Result type for the execution ("application") of a transaction.
@@ -524,7 +522,7 @@ impl State {
 		try!(self.commit());
 		let receipt = Receipt::new(self.root().clone(), e.cumulative_gas_used, e.logs);
 		trace!(target: "state", "Transaction receipt: {:?}", receipt);
-		Ok(ApplyOutcome{receipt: receipt, trace: e.trace, contracts_created: e.contracts_created})
+		Ok(ApplyOutcome{receipt: receipt, trace: e.trace })
 	}
 
 	/// Commit accounts to SecTrieDBMut. This is similar to cpp-ethereum's dev::eth::commit.

--- a/ethcore/src/tests/helpers.rs
+++ b/ethcore/src/tests/helpers.rs
@@ -18,7 +18,6 @@ use ethkey::KeyPair;
 use io::*;
 use client::{BlockChainClient, Client, ClientConfig};
 use util::*;
-use util::trie::TrieSpec;
 use spec::*;
 use state_db::StateDB;
 use block::{OpenBlock, Drain};
@@ -157,8 +156,7 @@ pub fn generate_dummy_client_with_spec_and_data<F>(get_test_spec: F, block_numbe
 	let test_engine = &*test_spec.engine;
 
 	let mut db_result = get_temp_state_db();
-	let mut db = db_result.take();
-	test_spec.ensure_db_good(&mut db, &TrieFactory::new(TrieSpec::Secure)).unwrap();
+	let mut db = test_spec.ensure_db_good(db_result.take(), &Default::default()).unwrap();
 	let genesis_header = test_spec.genesis_header();
 
 	let mut rolling_timestamp = 40;

--- a/json/src/spec/account.rs
+++ b/json/src/spec/account.rs
@@ -32,8 +32,10 @@ pub struct Account {
 	pub nonce: Option<Uint>,
 	/// Code.
 	pub code: Option<Bytes>,
-	/// Storage
+	/// Storage.
 	pub storage: Option<BTreeMap<Uint, Uint>>,
+	/// Constructor.
+	pub constructor: Option<Bytes>,
 }
 
 impl Account {

--- a/json/src/spec/state.rs
+++ b/json/src/spec/state.rs
@@ -18,6 +18,7 @@
 
 use std::collections::BTreeMap;
 use hash::Address;
+use bytes::Bytes;
 use spec::{Account, Builtin};
 
 /// Blockchain test state deserializer.
@@ -29,7 +30,15 @@ impl State {
 	pub fn builtins(&self) -> BTreeMap<Address, Builtin> {
 		self.0
 			.iter()
-			.filter_map(|ref pair| pair.1.builtin.clone().map(|b| (pair.0.clone(), b.clone())))
+			.filter_map(|(add, ref acc)| acc.builtin.clone().map(|b| (add.clone(), b)))
+			.collect()
+	}
+
+	/// Returns all constructors.
+	pub fn constructors(&self) -> BTreeMap<Address, Bytes> {
+		self.0
+			.iter()
+			.filter_map(|(add, ref acc)| acc.constructor.clone().map(|b| (add.clone(), b)))
 			.collect()
 	}
 }


### PR DESCRIPTION
Execute them on the genesis state. No need to manually specify the "storage" fields now.