### PR TITLE
Update Webpack

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -126,7 +126,7 @@
     "stylelint": "7.6.0",
     "stylelint-config-standard": "15.0.0",
     "url-loader": "0.5.7",
-    "webpack": "2.2.0-rc.1",
+    "webpack": "2.2.0-rc.2",
     "webpack-dev-middleware": "1.8.4",
     "webpack-error-notification": "0.1.6",
     "webpack-hot-middleware": "2.13.2",


### PR DESCRIPTION
Fixing https://github.com/webpack/webpack/issues/3498

(`"Cannot read property 'harmonyModule' of null" in watch mode`)