### PR TITLE
Fix method decoding

### DIFF
--- a/js/src/ui/Form/InputAddress/inputAddress.js
+++ b/js/src/ui/Form/InputAddress/inputAddress.js
@@ -63,7 +63,7 @@ class InputAddress extends Component {
     classes.push(!icon ? styles.inputEmpty : styles.input);
 
     const containerClasses = [ styles.container ];
-    const nullName = new BigNumber(value || 0).eq(0) ? 'null' : null;
+    const nullName = new BigNumber(value).eq(0) ? 'null' : null;
 
     if (small) {
       containerClasses.push(styles.small);

--- a/js/src/ui/Form/InputAddress/inputAddress.js
+++ b/js/src/ui/Form/InputAddress/inputAddress.js
@@ -63,7 +63,7 @@ class InputAddress extends Component {
     classes.push(!icon ? styles.inputEmpty : styles.input);
 
     const containerClasses = [ styles.container ];
-    const nullName = new BigNumber(value).eq(0) ? 'null' : null;
+    const nullName = new BigNumber(value || 0).eq(0) ? 'null' : null;
 
     if (small) {
       containerClasses.push(styles.small);

--- a/js/src/ui/MethodDecoding/methodDecodingStore.js
+++ b/js/src/ui/MethodDecoding/methodDecodingStore.js
@@ -118,15 +118,6 @@ export default class MethodDecodingStore {
       return Promise.resolve(result);
     }
 
-    const { signature, paramdata } = this.api.util.decodeCallData(input);
-    result.signature = signature;
-    result.params = paramdata;
-
-    // Contract deployment
-    if (!signature || signature === CONTRACT_CREATE || transaction.creates) {
-      return Promise.resolve({ ...result, deploy: true });
-    }
-
     return this
       .isContract(contractAddress || transaction.creates)
       .then((isContract) => {
@@ -134,6 +125,15 @@ export default class MethodDecodingStore {
 
         if (!isContract) {
           return result;
+        }
+
+        const { signature, paramdata } = this.api.util.decodeCallData(input);
+        result.signature = signature;
+        result.params = paramdata;
+
+        // Contract deployment
+        if (!signature || signature === CONTRACT_CREATE || transaction.creates) {
+          return Promise.resolve({ ...result, deploy: true });
         }
 
         return this


### PR DESCRIPTION
It used to break when transaction input was < 8 chars (eg. Zero Account on Testnet).