### PR TITLE
contract query: render false as false

### DIFF
--- a/js/src/views/Contract/Queries/inputQuery.js
+++ b/js/src/views/Contract/Queries/inputQuery.js
@@ -184,7 +184,7 @@ export default class InputQuery extends Component {
   }
 
   renderValue (value) {
-    if (!value) {
+    if (value === null || value === undefined) {
       return 'no data';
     }
 


### PR DESCRIPTION
Hopefully fixes #3909.

Please let me know if there are any cases in which `false` is not supposed to be rendered as `'false'`. The proper way to solve this would be to render according to the contract ABI.