### PR TITLE
Add Email and Registry lookups to Address Selector

### DIFF
--- a/js/src/modals/ExecuteContract/DetailsStep/detailsStep.spec.js
+++ b/js/src/modals/ExecuteContract/DetailsStep/detailsStep.spec.js
@@ -22,7 +22,7 @@ import { ContextProvider, muiTheme } from '~/ui';
 
 import DetailsStep from './';
 
-import { STORE, CONTRACT } from '../executeContract.test.js';
+import { createApi, STORE, CONTRACT } from '../executeContract.test.js';
 
 let component;
 let onAmountChange;
@@ -41,7 +41,7 @@ function render (props) {
   onValueChange = sinon.stub();
 
   component = mount(
-    <ContextProvider api={ {} } muiTheme={ muiTheme } store={ STORE }>
+    <ContextProvider api={ createApi() } muiTheme={ muiTheme } store={ STORE }>
       <DetailsStep
         { ...props }
         contract={ CONTRACT }

--- a/js/src/modals/ExecuteContract/executeContract.spec.js
+++ b/js/src/modals/ExecuteContract/executeContract.spec.js
@@ -20,7 +20,7 @@ import sinon from 'sinon';
 
 import ExecuteContract from './';
 
-import { CONTRACT, STORE } from './executeContract.test.js';
+import { createApi, CONTRACT, STORE } from './executeContract.test.js';
 
 let component;
 let onClose;
@@ -36,7 +36,7 @@ function render (props) {
       contract={ CONTRACT }
       onClose={ onClose }
       onFromAddressChange={ onFromAddressChange } />,
-      { context: { api: {}, store: STORE } }
+      { context: { api: createApi(), store: STORE } }
   ).find('ExecuteContract').shallow();
 
   return component;

--- a/js/src/modals/ExecuteContract/executeContract.test.js
+++ b/js/src/modals/ExecuteContract/executeContract.test.js
@@ -64,7 +64,19 @@ const STORE = {
   }
 };
 
+function createApi (result = true) {
+  return {
+    parity: {
+      registryAddress: sinon.stub().resolves('0x0000000000000000000000000000000000000000')
+    },
+    util: {
+      sha3: sinon.stub().resolves('0x0000000000000000000000000000000000000000')
+    }
+  };
+}
+
 export {
+  createApi,
   CONTRACT,
   STORE
 };

--- a/js/src/ui/AccountCard/accountCard.css
+++ b/js/src/ui/AccountCard/accountCard.css
@@ -54,7 +54,7 @@
 
 .description {
   font-size: 0.75em;
-  color: rgba(255, 255, 255, 0.498039);
+  color: rgba(255, 255, 255, 0.5);
 }
 
 .accountInfo {

--- a/js/src/ui/AccountCard/accountCard.css
+++ b/js/src/ui/AccountCard/accountCard.css
@@ -52,6 +52,11 @@
   }
 }
 
+.description {
+  font-size: 0.75em;
+  color: rgba(255, 255, 255, 0.498039);
+}
+
 .accountInfo {
   flex: 1;
 

--- a/js/src/ui/AccountCard/accountCard.js
+++ b/js/src/ui/AccountCard/accountCard.js
@@ -43,7 +43,7 @@ export default class AccountCard extends Component {
     const { account } = this.props;
     const { copied } = this.state;
 
-    const { address, name, meta = {} } = account;
+    const { address, name, description, meta = {} } = account;
 
     const displayName = (name && name.toUpperCase()) || address;
     const { tags = [] } = meta;
@@ -70,9 +70,22 @@ export default class AccountCard extends Component {
           </div>
 
           { this.renderTags(tags, address) }
+          { this.renderDescription(description) }
           { this.renderAddress(displayName, address) }
           { this.renderBalance(address) }
         </div>
+      </div>
+    );
+  }
+
+  renderDescription (description) {
+    if (!description) {
+      return null;
+    }
+
+    return (
+      <div className={ styles.description }>
+        <span>{ description }</span>
       </div>
     );
   }

--- a/js/src/ui/Form/AddressSelect/addressSelect.js
+++ b/js/src/ui/Form/AddressSelect/addressSelect.js
@@ -191,6 +191,7 @@ class AddressSelect extends Component {
         </div>
 
         { this.renderCurrentInput() }
+        { this.renderRegsitryValues() }
         { this.renderAccounts() }
       </Portal>
     );
@@ -212,6 +213,28 @@ class AddressSelect extends Component {
     return (
       <div>
         { this.renderAccountCard({ address }) }
+      </div>
+    );
+  }
+
+  renderRegsitryValues () {
+    const { regsitryValues } = this.store;
+
+    if (regsitryValues.length === 0) {
+      return null;
+    }
+
+    const accounts = regsitryValues
+      .map((regsitryValue) => {
+        const { address, value } = regsitryValue;
+        const account = { address, name: value, index: address };
+
+        return this.renderAccountCard(account);
+      });
+
+    return (
+      <div>
+        { accounts }
       </div>
     );
   }
@@ -303,7 +326,7 @@ class AddressSelect extends Component {
   validateCustomInput = () => {
     const { allowInput } = this.props;
     const { inputValue } = this.store;
-    const { values } = this.state;
+    const { values } = this.store;
 
     // If input is HEX and allowInput === true, send it
     if (allowInput && inputValue && /^(0x)?([0-9a-f])+$/i.test(inputValue)) {
@@ -311,8 +334,8 @@ class AddressSelect extends Component {
     }
 
     // If only one value, select it
-    if (values.length === 1 && values[0].values.length === 1) {
-      const value = values[0].values[0];
+    if (values.reduce((cur, cat) => cur + cat.values.length, 0) === 1) {
+      const value = values.find((cat) => cat.values.length > 0).values[0];
       return this.handleClick(value.address);
     }
   }
@@ -388,7 +411,7 @@ class AddressSelect extends Component {
     const { values } = this.store;
 
     // Don't do anything if no values
-    if (values.length === 0) {
+    if (values.reduce((cur, cat) => cur + cat.values.length, 0) === 0) {
       return event;
     }
 

--- a/js/src/ui/Form/AddressSelect/addressSelect.js
+++ b/js/src/ui/Form/AddressSelect/addressSelect.js
@@ -191,7 +191,7 @@ class AddressSelect extends Component {
         </div>
 
         { this.renderCurrentInput() }
-        { this.renderRegsitryValues() }
+        { this.renderRegistryValues() }
         { this.renderAccounts() }
       </Portal>
     );
@@ -217,16 +217,16 @@ class AddressSelect extends Component {
     );
   }
 
-  renderRegsitryValues () {
-    const { regsitryValues } = this.store;
+  renderRegistryValues () {
+    const { registryValues } = this.store;
 
-    if (regsitryValues.length === 0) {
+    if (registryValues.length === 0) {
       return null;
     }
 
-    const accounts = regsitryValues
-      .map((regsitryValue, index) => {
-        const account = { ...regsitryValue, index: `${regsitryValue.address}_${index}` };
+    const accounts = registryValues
+      .map((registryValue, index) => {
+        const account = { ...registryValue, index: `${registryValue.address}_${index}` };
         return this.renderAccountCard(account);
       });
 
@@ -253,8 +253,8 @@ class AddressSelect extends Component {
       );
     }
 
-    const categories = values.map((category) => {
-      return this.renderCategory(category.label, category.values);
+    const categories = values.map((category, index) => {
+      return this.renderCategory(category, index);
     });
 
     return (
@@ -264,7 +264,8 @@ class AddressSelect extends Component {
     );
   }
 
-  renderCategory (name, values = []) {
+  renderCategory (category, index) {
+    const { label, key, values = [] } = category;
     let content;
 
     if (values.length === 0) {
@@ -288,8 +289,8 @@ class AddressSelect extends Component {
     }
 
     return (
-      <div className={ styles.category } key={ name }>
-        <div className={ styles.title }>{ name }</div>
+      <div className={ styles.category } key={ `${key}_${index}` }>
+        <div className={ styles.title }>{ label }</div>
         { content }
       </div>
     );

--- a/js/src/ui/Form/AddressSelect/addressSelect.js
+++ b/js/src/ui/Form/AddressSelect/addressSelect.js
@@ -225,10 +225,8 @@ class AddressSelect extends Component {
     }
 
     const accounts = regsitryValues
-      .map((regsitryValue) => {
-        const { address, value } = regsitryValue;
-        const account = { address, name: value, index: address };
-
+      .map((regsitryValue, index) => {
+        const account = { ...regsitryValue, index: `${regsitryValue.address}_${index}` };
         return this.renderAccountCard(account);
       });
 
@@ -423,7 +421,12 @@ class AddressSelect extends Component {
 
       event.preventDefault();
 
-      const nextValues = values[focusedCat || 0];
+      const firstCat = values.findIndex((cat) => cat.values.length > 0);
+      const nextCat = focusedCat && values[focusedCat].values.length > 0
+        ? focusedCat
+        : firstCat;
+
+      const nextValues = values[nextCat];
       const nextFocus = nextValues ? nextValues.values[0] : null;
       return this.focusItem(nextFocus && nextFocus.index || 1);
     }
@@ -457,12 +460,21 @@ class AddressSelect extends Component {
 
     // If right: next category
     if (direction === 'right') {
-      nextCategory = Math.min(prevCategoryIndex + 1, values.length - 1);
+      const categoryShift = values
+        .slice(prevCategoryIndex + 1, values.length)
+        .findIndex((cat) => cat.values.length > 0) + 1;
+
+      nextCategory = Math.min(prevCategoryIndex + categoryShift, values.length - 1);
     }
 
     // If right: previous category
     if (direction === 'left') {
-      nextCategory = Math.max(prevCategoryIndex - 1, 0);
+      const categoryShift = values
+        .slice(0, prevCategoryIndex)
+        .reverse()
+        .findIndex((cat) => cat.values.length > 0) + 1;
+
+      nextCategory =  Math.max(prevCategoryIndex - categoryShift, 0);
     }
 
     // If left or right: try to keep the horizontal index

--- a/js/src/ui/Form/AddressSelect/addressSelect.js
+++ b/js/src/ui/Form/AddressSelect/addressSelect.js
@@ -474,7 +474,7 @@ class AddressSelect extends Component {
         .reverse()
         .findIndex((cat) => cat.values.length > 0) + 1;
 
-      nextCategory =  Math.max(prevCategoryIndex - categoryShift, 0);
+      nextCategory = Math.max(prevCategoryIndex - categoryShift, 0);
     }
 
     // If left or right: try to keep the horizontal index

--- a/js/src/ui/Form/AddressSelect/addressSelect.js
+++ b/js/src/ui/Form/AddressSelect/addressSelect.js
@@ -27,6 +27,7 @@ import AccountCard from '~/ui/AccountCard';
 import InputAddress from '~/ui/Form/InputAddress';
 import Portal from '~/ui/Portal';
 import { validateAddress } from '~/util/validation';
+import { nodeOrStringProptype } from '~/util/proptypes';
 
 import AddressSelectStore from './addressSelectStore';
 import styles from './addressSelect.css';
@@ -39,6 +40,7 @@ let currentId = 1;
 @observer
 class AddressSelect extends Component {
   static contextTypes = {
+    api: PropTypes.object.isRequired,
     muiTheme: PropTypes.object.isRequired
   };
 
@@ -58,10 +60,10 @@ class AddressSelect extends Component {
     // Optional props
     allowInput: PropTypes.bool,
     disabled: PropTypes.bool,
-    error: PropTypes.string,
-    hint: PropTypes.string,
-    label: PropTypes.string,
-    value: PropTypes.string
+    error: nodeOrStringProptype(),
+    hint: nodeOrStringProptype(),
+    label: nodeOrStringProptype(),
+    value: nodeOrStringProptype()
   };
 
   static defaultProps = {

--- a/js/src/ui/Form/AddressSelect/addressSelectStore.js
+++ b/js/src/ui/Form/AddressSelect/addressSelectStore.js
@@ -14,8 +14,10 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
+import React from 'react';
 import { observable, action } from 'mobx';
 import { flatMap } from 'lodash';
+import { FormattedMessage } from 'react-intl';
 
 import Contracts from '~/contracts';
 import { sha3 } from '~/api/util/sha3';
@@ -23,7 +25,7 @@ import { sha3 } from '~/api/util/sha3';
 export default class AddressSelectStore {
 
   @observable values = [];
-  @observable regsitryValues = [];
+  @observable registryValues = [];
 
   initValues = [];
   regLookups = [];
@@ -42,7 +44,15 @@ export default class AddressSelectStore {
               .instance
               .reverse.call({}, [ sha3(value) ]);
           },
-          describe: (value) => `${value} (from email verification)`
+          describe: (value) => (
+            <FormattedMessage
+              id='addressSelect.fromEmail'
+              defaultMessage='Verified using email {value}'
+              values={ {
+                value
+              } }
+            />
+          )
         });
       });
 
@@ -54,7 +64,15 @@ export default class AddressSelectStore {
             return registryInstance
               .getAddress.call({}, [ sha3(value), 'A' ]);
           },
-          describe: (value) => `${value} (from registry)`
+          describe: (value) => (
+            <FormattedMessage
+              id='addressSelect.fromRegistry'
+              defaultMessage='{value} (from registry)'
+              values={ {
+                value
+              } }
+            />
+          )
         });
       });
   }
@@ -73,18 +91,36 @@ export default class AddressSelectStore {
 
     this.initValues = [
       {
-        label: 'accounts',
+        key: 'accounts',
+        label: (
+          <FormattedMessage
+            id='addressSelect.labels.accounts'
+            defaultMessage='accounts'
+          />
+        ),
         values: [].concat(
           Object.values(wallets),
           Object.values(accounts)
         )
       },
       {
-        label: 'contacts',
+        key: 'contacts',
+        label: (
+          <FormattedMessage
+            id='addressSelect.labels.contacts'
+            defaultMessage='contacts'
+          />
+        ),
         values: Object.values(contacts)
       },
       {
-        label: 'contracts',
+        key: 'contracts',
+        label: (
+          <FormattedMessage
+            id='addressSelect.labels.contracts'
+            defaultMessage='contracts'
+          />
+        ),
         values: Object.values(contracts)
       }
     ].filter((cat) => cat.values.length > 0);
@@ -101,7 +137,11 @@ export default class AddressSelectStore {
           .filterValues(category.values, value)
           .map((value) => {
             index++;
-            return { ...value, index: parseInt(index) };
+
+            return {
+              index: parseInt(index),
+              ...value
+            };
           });
 
         return {
@@ -111,7 +151,7 @@ export default class AddressSelectStore {
       });
 
     // Registries Lookup
-    this.regsitryValues = [];
+    this.registryValues = [];
 
     const lookups = this.regLookups.map((regLookup) => regLookup.lookup(value));
 
@@ -124,8 +164,10 @@ export default class AddressSelectStore {
               return;
             }
 
+            const lowercaseResult = result.toLowerCase();
+
             const account = flatMap(this.initValues, (cat) => cat.values)
-              .find((account) => account.address.toLowerCase() === result.toLowerCase());
+              .find((account) => account.address.toLowerCase() === lowercaseResult);
 
             return {
               description: this.regLookups[index].describe(value),
@@ -135,8 +177,8 @@ export default class AddressSelectStore {
           })
           .filter((data) => data);
       })
-      .then((regsitryValues) => {
-        this.regsitryValues = regsitryValues;
+      .then((registryValues) => {
+        this.registryValues = registryValues;
       });
   }
 

--- a/js/src/ui/Form/AddressSelect/addressSelectStore.js
+++ b/js/src/ui/Form/AddressSelect/addressSelectStore.js
@@ -33,7 +33,7 @@ export default class AddressSelectStore {
   constructor (api) {
     this.api = api;
 
-    const { registry } = Contracts.get();
+    const { registry } = Contracts.create(api);
 
     registry
       .getContract('emailverification')

--- a/js/src/ui/Form/AddressSelect/addressSelectStore.js
+++ b/js/src/ui/Form/AddressSelect/addressSelectStore.js
@@ -1,0 +1,152 @@
+// Copyright 2015, 2016 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+import { observable, action } from 'mobx';
+
+import Contracts from '~/contracts';
+import { sha3 } from '~/api/util/sha3';
+
+export default class AddressSelectStore {
+
+  @observable values = [];
+  @observable regsitryValues = [];
+
+  initValues = [];
+
+  constructor (api) {
+    this.api = api;
+
+    Contracts
+      .get()
+      .registry
+      .getContract('emailverification')
+      .then((emailVerification) => {
+        this.emailVerification = emailVerification;
+      });
+  }
+
+  @action setValues (props) {
+    const { accounts = {}, contracts = {}, contacts = {}, wallets = {} } = props;
+
+    const accountsN = Object.keys(accounts).length;
+    const contractsN = Object.keys(contracts).length;
+    const contactsN = Object.keys(contacts).length;
+    const walletsN = Object.keys(wallets).length;
+
+    if (accountsN + contractsN + contactsN + walletsN === 0) {
+      return;
+    }
+
+    this.initValues = [
+      {
+        label: 'accounts',
+        values: [].concat(
+          Object.values(wallets),
+          Object.values(accounts)
+        )
+      },
+      {
+        label: 'contacts',
+        values: Object.values(contacts)
+      },
+      {
+        label: 'contracts',
+        values: Object.values(contracts)
+      }
+    ].filter((cat) => cat.values.length > 0);
+
+    this.handleChange();
+  }
+
+  @action handleChange = (value = '') => {
+    let index = 0;
+
+    this.values = this.initValues
+      .map((category) => {
+        const filteredValues = this
+          .filterValues(category.values, value)
+          .map((value) => {
+            index++;
+            return { ...value, index: parseInt(index) };
+          });
+
+        return {
+          label: category.label,
+          values: filteredValues
+        };
+      });
+
+    // Registries Lookup
+    this.regsitryValues = [];
+
+    if (this.emailVerification) {
+      this
+        .emailVerification
+        .instance
+        .reverse
+        .call({}, [ sha3(value) ])
+        .then((result) => {
+          if (/^(0x)?0*$/.test(result)) {
+            return;
+          }
+
+          this.regsitryValues.push({
+            type: 'email',
+            address: result,
+            value
+          });
+        });
+    }
+  }
+
+  /**
+   * Filter the given values based on the given
+   * filter
+   */
+  filterValues = (values = [], _filter = '') => {
+    const filter = _filter.toLowerCase();
+
+    return values
+      // Remove empty accounts
+      .filter((a) => a)
+      .filter((account) => {
+        const address = account.address.toLowerCase();
+        const inAddress = address.includes(filter);
+
+        if (!account.name || inAddress) {
+          return inAddress;
+        }
+
+        const name = account.name.toLowerCase();
+        const inName = name.includes(filter);
+        const { meta = {} } = account;
+
+        if (!meta.tags || inName) {
+          return inName;
+        }
+
+        const tags = (meta.tags || []).join('');
+        return tags.includes(filter);
+      })
+      .sort((accA, accB) => {
+        const nameA = accA.name || accA.address;
+        const nameB = accB.name || accB.address;
+
+        return nameA.localeCompare(nameB);
+      });
+  }
+
+}


### PR DESCRIPTION
Closes #3871 

Adds to the new Address Selector lookups capabilities from the Registry and the Email Verification contract.

The result is shown right under the input.

![mail address selector](https://cloud.githubusercontent.com/assets/2864519/21529307/bbb0daa2-cd38-11e6-8842-777edc052a55.png)

It also fixes some issues in the component.
