### PR TITLE
Basic account type

### DIFF
--- a/ethcore/src/snapshot/tests/helpers.rs
+++ b/ethcore/src/snapshot/tests/helpers.rs
@@ -17,9 +17,9 @@
 //! Snapshot test helpers. These are used to build blockchains and state tries
 //! which can be queried before and after a full snapshot/restore cycle.
 
+use basic_account::BasicAccount;
 use account_db::AccountDBMut;
 use rand::Rng;
-use snapshot::account::Account;
 
 use util::DBValue;
 use util::hash::{FixedHash, H256};
@@ -64,10 +64,10 @@ impl StateProducer {
 
 		// sweep once to alter storage tries.
 		for &mut (ref mut address_hash, ref mut account_data) in &mut accounts_to_modify {
-			let mut account = Account::from_thin_rlp(&*account_data);
+			let mut account: BasicAccount = ::rlp::decode(&*account_data);
 			let acct_db = AccountDBMut::from_hash(db, *address_hash);
-			fill_storage(acct_db, account.storage_root_mut(), &mut self.storage_seed);
-			*account_data = DBValue::from_vec(account.to_thin_rlp());
+			fill_storage(acct_db, &mut account.storage_root, &mut self.storage_seed);
+			*account_data = DBValue::from_vec(::rlp::encode(&account).to_vec());
 		}
 
 		// sweep again to alter account trie.

--- a/ethcore/src/state/account.rs
+++ b/ethcore/src/state/account.rs
@@ -20,45 +20,11 @@ use util::*;
 use pod_account::*;
 use rlp::*;
 use lru_cache::LruCache;
+use basic_account::BasicAccount;
 
 use std::cell::{RefCell, Cell};
 
 const STORAGE_CACHE_ITEMS: usize = 8192;
-
-/// Basic account type.
-#[derive(Debug, Clone, PartialEq, Eq)]
-pub struct BasicAccount {
-	/// Nonce of the account.
-	pub nonce: U256,
-	/// Balance of the account.
-	pub balance: U256,
-	/// Storage root of the account.
-	pub storage_root: H256,
-	/// Code hash of the account.
-	pub code_hash: H256,
-}
-
-impl Encodable for BasicAccount {
-	fn rlp_append(&self, s: &mut RlpStream) {
-		s.begin_list(4)
-			.append(&self.nonce)
-			.append(&self.balance)
-			.append(&self.storage_root)
-			.append(&self.code_hash);
-	}
-}
-
-impl Decodable for BasicAccount {
-	fn decode<D>(decoder: &D) -> Result<Self, DecoderError> where D: Decoder {
-		let rlp = decoder.as_rlp();
-		Ok(BasicAccount {
-			nonce: rlp.val_at(0)?,
-			balance: rlp.val_at(1)?,
-			storage_root: rlp.val_at(2)?,
-			code_hash: rlp.val_at(3)?,
-		})
-	}
-}
 
 /// Single account in the system.
 /// Keeps track of changes to the code and storage.

--- a/ethcore/src/state/mod.rs
+++ b/ethcore/src/state/mod.rs
@@ -37,7 +37,7 @@ use util::trie::recorder::{Recorder, BasicRecorder as TrieRecorder};
 mod account;
 mod substate;
 
-pub use self::account::{BasicAccount, Account};
+pub use self::account::Account;
 pub use self::substate::Substate;
 
 /// Used to return information about an `State::apply` operation.

--- a/ethcore/src/state/mod.rs
+++ b/ethcore/src/state/mod.rs
@@ -37,7 +37,7 @@ use util::trie::recorder::{Recorder, BasicRecorder as TrieRecorder};
 mod account;
 mod substate;
 
-pub use self::account::Account;
+pub use self::account::{BasicAccount, Account};
 pub use self::substate::Substate;
 
 /// Used to return information about an `State::apply` operation.

--- a/ethcore/src/types/basic_account.rs
+++ b/ethcore/src/types/basic_account.rs
@@ -1,0 +1,55 @@
+// Copyright 2015, 2016 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Basic account type -- the decoded RLP from the state trie.
+
+use rlp::*;
+use util::{U256, H256};
+
+/// Basic account type.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BasicAccount {
+	/// Nonce of the account.
+	pub nonce: U256,
+	/// Balance of the account.
+	pub balance: U256,
+	/// Storage root of the account.
+	pub storage_root: H256,
+	/// Code hash of the account.
+	pub code_hash: H256,
+}
+
+impl Encodable for BasicAccount {
+	fn rlp_append(&self, s: &mut RlpStream) {
+		s.begin_list(4)
+			.append(&self.nonce)
+			.append(&self.balance)
+			.append(&self.storage_root)
+			.append(&self.code_hash);
+	}
+}
+
+impl Decodable for BasicAccount {
+	fn decode<D>(decoder: &D) -> Result<Self, DecoderError> where D: Decoder {
+		let rlp = decoder.as_rlp();
+		Ok(BasicAccount {
+			nonce: rlp.val_at(0)?,
+			balance: rlp.val_at(1)?,
+			storage_root: rlp.val_at(2)?,
+			code_hash: rlp.val_at(3)?,
+		})
+	}
+}

--- a/ethcore/src/types/mod.rs.in
+++ b/ethcore/src/types/mod.rs.in
@@ -37,3 +37,4 @@ pub mod mode;
 pub mod pruning_info;
 pub mod security_level;
 pub mod encoded;
+pub mod basic_account;


### PR DESCRIPTION
Just the decoded RLP in a strongly-typed structure. I have another usecase for this which will be in an upcoming PR.

Differs from PodAccount as it doesn't store the storage/data inline; rather, this represents a leaf of the state trie.