### PR TITLE
Starting on homestead showed reload snackbar

### DIFF
--- a/js/src/redux/providers/chainMiddleware.js
+++ b/js/src/redux/providers/chainMiddleware.js
@@ -15,6 +15,7 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 import { showSnackbar } from './snackbarActions';
+import { DEFAULT_NETCHAIN } from './statusReducer';
 
 export default class ChainMiddleware {
   toMiddleware () {
@@ -23,11 +24,11 @@ export default class ChainMiddleware {
         const { collection } = action;
 
         if (collection && collection.netChain) {
-          const chain = collection.netChain;
+          const newChain = collection.netChain;
           const { nodeStatus } = store.getState();
 
-          if (chain !== nodeStatus.netChain) {
-            store.dispatch(showSnackbar(`Switched to ${chain}. Please reload the page.`, 5000));
+          if (newChain !== nodeStatus.netChain && nodeStatus.netChain !== DEFAULT_NETCHAIN) {
+            store.dispatch(showSnackbar(`Switched to ${newChain}. Please reload the page.`, 5000));
           }
         }
       }

--- a/js/src/redux/providers/chainMiddleware.spec.js
+++ b/js/src/redux/providers/chainMiddleware.spec.js
@@ -1,0 +1,86 @@
+// Copyright 2015, 2016 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+import sinon from 'sinon';
+
+import { initialState as defaultNodeStatusState } from './statusReducer';
+import ChainMiddleware from './chainMiddleware';
+
+let middleware;
+let next;
+let store;
+
+function createMiddleware (collection = {}) {
+  middleware = new ChainMiddleware().toMiddleware();
+  next = sinon.stub();
+  store = {
+    dispatch: sinon.stub(),
+    getState: () => {
+      return {
+        nodeStatus: Object.assign({}, defaultNodeStatusState, collection)
+      };
+    }
+  };
+
+  return middleware;
+}
+
+function callMiddleware (action) {
+  return middleware(store)(next)(action);
+}
+
+describe('reduxs/providers/ChainMiddleware', () => {
+  describe('next action', () => {
+    beforeEach(() => {
+      createMiddleware();
+    });
+
+    it('calls next with matching actiontypes', () => {
+      callMiddleware({ type: 'statusCollection' });
+
+      expect(next).to.have.been.calledWithMatch({ type: 'statusCollection' });
+    });
+
+    it('calls next with non-matching actiontypes', () => {
+      callMiddleware({ type: 'nonMatchingType' });
+
+      expect(next).to.have.been.calledWithMatch({ type: 'nonMatchingType' });
+    });
+  });
+
+  describe('chain switching', () => {
+    it('does not dispatch when moving from the initial/unknown chain', () => {
+      createMiddleware();
+      callMiddleware({ type: 'statusCollection', collection: { netChain: 'homestead' } });
+
+      expect(store.dispatch).not.to.have.been.called;
+    });
+
+    it('does not dispatch when moving to the same chain', () => {
+      createMiddleware({ netChain: 'homestead' });
+      callMiddleware({ type: 'statusCollection', collection: { netChain: 'homestead' } });
+
+      expect(store.dispatch).not.to.have.been.called;
+    });
+
+    it('does dispatch when moving between chains', () => {
+      createMiddleware({ netChain: 'homestead' });
+      callMiddleware({ type: 'statusCollection', collection: { netChain: 'ropsten' } });
+
+      expect(store.dispatch).to.have.been.called;
+    });
+  });
+});

--- a/js/src/redux/providers/statusReducer.js
+++ b/js/src/redux/providers/statusReducer.js
@@ -17,6 +17,7 @@
 import BigNumber from 'bignumber.js';
 import { handleActions } from 'redux-actions';
 
+const DEFAULT_NETCHAIN = '(unknown)';
 const initialState = {
   blockNumber: new BigNumber(0),
   blockTimestamp: new Date(),
@@ -32,7 +33,7 @@ const initialState = {
   gasLimit: new BigNumber(0),
   hashrate: new BigNumber(0),
   minGasPrice: new BigNumber(0),
-  netChain: 'ropsten',
+  netChain: DEFAULT_NETCHAIN,
   netPeers: {
     active: new BigNumber(0),
     connected: new BigNumber(0),
@@ -82,3 +83,8 @@ export default handleActions({
     return Object.assign({}, state, { refreshStatus });
   }
 }, initialState);
+
+export {
+  DEFAULT_NETCHAIN,
+  initialState
+};


### PR DESCRIPTION
Starting on homestead immediately showed the "reload this page" snackbar.

- start from "(unknown)" chain
- don't show message when previous state indicated "(unknown)"
- test middleware & fix conditions

There is an additional issue - the long polling causes the new chain to only show up after some time (alon with the message), needs an additional issue/PR.