### PR TITLE
[beta] Avoid re-broadcasting transactions on each block

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -737,7 +737,7 @@ dependencies = [
 [[package]]
 name = "hyper"
 version = "0.9.4"
-source = "git+https://github.com/ethcore/hyper#9e346c1d4bc30cd4142dea9d8a0b117d30858ca4"
+source = "git+https://github.com/ethcore/hyper#4379a3629abc10e42e6d3fbcb21ecef5c1c86a77"
 dependencies = [
  "cookie 0.2.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/ethcore/src/blockchain/blockchain.rs
+++ b/ethcore/src/blockchain/blockchain.rs
@@ -140,7 +140,7 @@ pub trait BlockProvider {
 	fn blocks_with_bloom(&self, bloom: &H2048, from_block: BlockNumber, to_block: BlockNumber) -> Vec<BlockNumber>;
 
 	/// Returns logs matching given filter.
-	fn logs<F>(&self, mut blocks: Vec<BlockNumber>, matches: F, limit: Option<usize>) -> Vec<LocalizedLogEntry>
+	fn logs<F>(&self, blocks: Vec<BlockNumber>, matches: F, limit: Option<usize>) -> Vec<LocalizedLogEntry>
 		where F: Fn(&LogEntry) -> bool, Self: Sized;
 }
 

--- a/sync/src/chain.rs
+++ b/sync/src/chain.rs
@@ -2344,7 +2344,7 @@ mod tests {
 		// Try to propagate same transactions for the second time
 		let peer_count2 = sync.propagate_new_transactions(&mut io);
 
-		// 2 message should be send
+		// 1 message should be send
 		assert_eq!(1, io.queue.len());
 		// 1 peer should be updated only for the first time
 		assert_eq!(1, peer_count);

--- a/sync/src/chain.rs
+++ b/sync/src/chain.rs
@@ -2331,7 +2331,7 @@ mod tests {
 	}
 
 	#[test]
-	fn propagates_transactions_again_after_new_block() {
+	fn should_not_propagate_transactions_again_after_new_block() {
 		let mut client = TestBlockChainClient::new();
 		client.add_blocks(100, EachBlockWith::Uncle);
 		client.insert_transaction_to_queue();
@@ -2345,13 +2345,12 @@ mod tests {
 		let peer_count2 = sync.propagate_new_transactions(&mut io);
 
 		// 2 message should be send
-		assert_eq!(2, io.queue.len());
-		// 1 peer should be updated twice
+		assert_eq!(1, io.queue.len());
+		// 1 peer should be updated only for the first time
 		assert_eq!(1, peer_count);
-		assert_eq!(1, peer_count2);
+		assert_eq!(0, peer_count2);
 		// TRANSACTIONS_PACKET
 		assert_eq!(0x02, io.queue[0].packet_id);
-		assert_eq!(0x02, io.queue[1].packet_id);
 	}
 
 	#[test]

--- a/sync/src/chain.rs
+++ b/sync/src/chain.rs
@@ -1995,9 +1995,6 @@ impl ChainSync {
 			trace!(target: "sync", "Bad blocks in the queue, restarting");
 			self.restart(io);
 		}
-		for peer_info in self.peers.values_mut() {
-			peer_info.last_sent_transactions.clear();
-		}
 	}
 }
 


### PR DESCRIPTION
Currently 1.4.x is re-broadcasting all transactions after each block is imported.
That's not nice to other peers and may cause excessive traffic.

Related: #4007, #3996, #3358