### PR TITLE
Fix wrong transaction input for contract deployments

### DIFF
--- a/js/src/api/contract/contract.js
+++ b/js/src/api/contract/contract.js
@@ -218,14 +218,19 @@ export default class Contract {
   }
 
   _encodeOptions (func, options, values) {
-    options.data = this.getCallData(func, options, values);
-    return options;
+    const data = this.getCallData(func, options, values);
+
+    return {
+      ...options,
+      data
+    };
   }
 
   _addOptionsTo (options = {}) {
-    return Object.assign({
-      to: this._address
-    }, options);
+    return {
+      to: this._address,
+      ...options
+    };
   }
 
   _bindFunction = (func) => {

--- a/js/src/api/contract/contract.spec.js
+++ b/js/src/api/contract/contract.spec.js
@@ -41,12 +41,25 @@ describe('api/contract/Contract', () => {
       type: 'function', name: 'test2',
       outputs: [{ type: 'uint' }, { type: 'uint' }]
     },
-    { type: 'constructor' },
+    {
+      type: 'constructor',
+      inputs: [{ name: 'boolin', type: 'bool' }, { name: 'stringin', type: 'string' }]
+    },
     { type: 'event', name: 'baz' },
     { type: 'event', name: 'foo' }
   ];
-  const VALUES = [true, 'jacogr'];
-  const ENCODED = '0x023562050000000000000000000000000000000000000000000000000000000000000001000000000000000000000000000000000000000000000000000000000000004000000000000000000000000000000000000000000000000000000000000000066a61636f67720000000000000000000000000000000000000000000000000000';
+
+  const VALUES = [ true, 'jacogr' ];
+  const CALLDATA = `
+    0000000000000000000000000000000000000000000000000000000000000001
+    0000000000000000000000000000000000000000000000000000000000000040
+    0000000000000000000000000000000000000000000000000000000000000006
+    6a61636f67720000000000000000000000000000000000000000000000000000
+  `.replace(/\s/g, '');
+  const SIGNATURE = '02356205';
+
+  const ENCODED = `0x${SIGNATURE}${CALLDATA}`;
+
   const RETURN1 = '0000000000000000000000000000000000000000000000000000000000123456';
   const RETURN2 = '0000000000000000000000000000000000000000000000000000000000456789';
   let scope;
@@ -252,7 +265,7 @@ describe('api/contract/Contract', () => {
           { method: 'eth_getCode', reply: { result: '0x456' } }
         ]);
 
-        return contract.deploy({ data: '0x123' }, []);
+        return contract.deploy({ data: '0x123' }, VALUES);
       });
 
       it('calls estimateGas, postTransaction, checkRequest, getTransactionReceipt & getCode in order', () => {
@@ -261,7 +274,7 @@ describe('api/contract/Contract', () => {
 
       it('passes the options through to postTransaction (incl. gas calculation)', () => {
         expect(scope.body.parity_postTransaction.params).to.deep.equal([
-          { data: '0x123', gas: '0x4b0' }
+          { data: `0x123${CALLDATA}`, gas: '0x4b0' }
         ]);
       });
 
@@ -280,7 +293,7 @@ describe('api/contract/Contract', () => {
         ]);
 
         return contract
-          .deploy({ data: '0x123' }, [])
+          .deploy({ data: '0x123' }, VALUES)
           .catch((error) => {
             expect(error.message).to.match(/not deployed, gasUsed/);
           });
@@ -296,7 +309,7 @@ describe('api/contract/Contract', () => {
         ]);
 
         return contract
-          .deploy({ data: '0x123' }, [])
+          .deploy({ data: '0x123' }, VALUES)
           .catch((error) => {
             expect(error.message).to.match(/not deployed, getCode/);
           });

--- a/js/src/views/WriteContract/writeContract.js
+++ b/js/src/views/WriteContract/writeContract.js
@@ -458,20 +458,62 @@ class WriteContract extends Component {
     const { bytecode } = contract;
     const abi = contract.interface;
 
+    const metadata = contract.metadata
+      ? (
+        <Input
+          allowCopy
+          label='Metadata'
+          readOnly
+          value={ contract.metadata }
+        />
+      )
+      : null;
+
     return (
       <div>
         <Input
+          allowCopy
+          label='ABI Interface'
           readOnly
           value={ abi }
-          label='ABI Interface'
         />
 
         <Input
+          allowCopy
+          label='Bytecode'
           readOnly
           value={ `0x${bytecode}` }
-          label='Bytecode'
         />
+
+        { metadata }
+        { this.renderSwarmHash(contract) }
       </div>
+    );
+  }
+
+  renderSwarmHash (contract) {
+    if (!contract || !contract.metadata) {
+      return null;
+    }
+
+    const { bytecode } = contract;
+
+    // @see https://solidity.readthedocs.io/en/develop/miscellaneous.html#encoding-of-the-metadata-hash-in-the-bytecode
+    const hashRegex = /a165627a7a72305820([a-f0-9]{64})0029$/;
+
+    if (!hashRegex.test(bytecode)) {
+      return null;
+    }
+
+    const hash = hashRegex.exec(bytecode)[1];
+
+    return (
+      <Input
+        allowCopy
+        label='Swarm Metadata Hash'
+        readOnly
+        value={ `${hash}` }
+      />
     );
   }
 


### PR DESCRIPTION
The input contained twice the constructor arguments.
Also show the contract metadata and SWARM hash if available (would be great to be able to use it).