### PR TITLE
Fix tags not working

### DIFF
--- a/js/src/ui/Actionbar/Search/search.js
+++ b/js/src/ui/Actionbar/Search/search.js
@@ -71,15 +71,15 @@ export default class ActionbarSearch extends Component {
         key='searchAccount'>
         <div className={ inputContainerClasses.join(' ') }>
           <InputChip
+            addOnBlur
             className={ styles.input }
             hint='Enter search input...'
+            ref='inputChip'
             tokens={ tokens }
 
             onBlur={ this.handleSearchBlur }
             onInputChange={ this.handleInputChange }
             onTokensChange={ this.handleTokensChange }
-
-            addOnBlur
           />
         </div>
 
@@ -117,6 +117,10 @@ export default class ActionbarSearch extends Component {
 
   handleSearchClick = () => {
     const { showSearch } = this.state;
+
+    if (!showSearch) {
+      this.refs.inputChip.focus();
+    }
 
     this.handleOpenSearch(!showSearch);
   }

--- a/js/src/ui/Actionbar/actionbar.css
+++ b/js/src/ui/Actionbar/actionbar.css
@@ -27,13 +27,14 @@
 }
 
 .toolbuttons {
-}
+  overflow: hidden;
 
-.toolbuttons button {
-  margin: 10px 0 10px 16px !important;
-  color: white !important;
-}
+  button {
+    margin: 10px 0 10px 16px !important;
+    color: white !important;
+  }
 
-.toolbuttons svg {
-  fill: white !important;
+  svg {
+    fill: white !important;
+  }
 }

--- a/js/src/ui/Form/InputChip/inputChip.js
+++ b/js/src/ui/Form/InputChip/inputChip.js
@@ -170,6 +170,10 @@ export default class InputChip extends Component {
       .filter(v => v !== value));
 
     this.handleTokensChange(newTokens);
+    this.focus();
+  }
+
+  focus = () => {
     this.refs.chipInput.focus();
   }
 

--- a/js/src/views/Accounts/List/list.js
+++ b/js/src/views/Accounts/List/list.js
@@ -220,8 +220,8 @@ class List extends Component {
         const tags = account.meta.tags || [];
         const name = account.name || '';
 
-        const values = []
-          .concat(tags, name)
+        const values = tags
+          .concat(name)
           .map(v => v.toLowerCase());
 
         return searchValues


### PR DESCRIPTION
Tags weren't properly working (from the Accounts view) after having visited a specific Account page ; meaning that clicking on a tag wouldn't filter accounts correctly.

This was because of MobX implementation of Arrays as Object (thus not concatenating properly).

Small UI glitches fixes too.