### PR TITLE
Fix balances update

### DIFF
--- a/js/src/redux/providers/balances.js
+++ b/js/src/redux/providers/balances.js
@@ -86,7 +86,7 @@ export default class Balances {
         // If syncing, only retrieve balances once every
         // few seconds
         if (syncing) {
-          this.shortThrottledFetch();
+          this.shortThrottledFetch.cancel();
           return this.longThrottledFetch();
         }
 

--- a/js/src/redux/providers/balancesActions.js
+++ b/js/src/redux/providers/balancesActions.js
@@ -173,18 +173,15 @@ export function fetchTokens (_tokenIds) {
 export function fetchBalances (_addresses) {
   return (dispatch, getState) => {
     const { api, personal } = getState();
-    const { visibleAccounts, accountsInfo } = personal;
+    const { visibleAccounts, accounts } = personal;
 
-    const addresses = uniq((_addresses || visibleAccounts || []).concat(Object.keys(accountsInfo)));
-
-    if (addresses.length === 0) {
-      return Promise.resolve();
-    }
+    const addresses = uniq(_addresses || visibleAccounts || []);
 
     // With only a single account, more info will be displayed.
     const fullFetch = addresses.length === 1;
 
-    const addressesToFetch = uniq(addresses);
+    // Add accounts addresses (for notifications, accounts selection, etc.)
+    const addressesToFetch = uniq(addresses.concat(Object.keys(accounts)));
 
     return Promise
       .all(addressesToFetch.map((addr) => fetchAccount(addr, api, fullFetch)))

--- a/js/src/redux/providers/certifications/middleware.js
+++ b/js/src/redux/providers/certifications/middleware.js
@@ -218,6 +218,7 @@ export default class CertificationsMiddleware {
             const _addresses = action.addresses || [];
             addresses = uniq(addresses.concat(_addresses));
             fetchConfirmedEvents();
+            next(action);
 
             break;
           default:

--- a/js/src/redux/providers/personalActions.js
+++ b/js/src/redux/providers/personalActions.js
@@ -122,7 +122,7 @@ export function setVisibleAccounts (addresses) {
       return;
     }
 
-    dispatch(fetchBalances(addresses));
     dispatch(_setVisibleAccounts(addresses));
+    dispatch(fetchBalances(addresses));
   };
 }

--- a/js/src/redux/providers/personalReducer.js
+++ b/js/src/redux/providers/personalReducer.js
@@ -47,7 +47,7 @@ export default handleActions({
   setVisibleAccounts (state, action) {
     const addresses = (action.addresses || []).sort();
 
-    if (isEqual(addresses, state.addresses)) {
+    if (isEqual(addresses, state.visibleAccounts)) {
       return state;
     }
 


### PR DESCRIPTION
Balances weren't fetched properly. The visible accounts was always empty, and we were fetching all the accounts at each block, and not the user accounts + the visible accounts (user accounts at each block necessary for transaction notification).
Plus the number of outgoing transaction on an Account page wasn't working.