### PR TITLE
No reorg limit for ancient blocks

### DIFF
--- a/sync/src/chain.rs
+++ b/sync/src/chain.rs
@@ -583,7 +583,7 @@ impl ChainSync {
 			if let (Some(ancient_block_hash), Some(ancient_block_number)) = (chain.ancient_block_hash, chain.ancient_block_number) {
 
 				trace!(target: "sync", "Downloading old blocks from {:?} (#{}) till {:?} (#{:?})", ancient_block_hash, ancient_block_number, chain.first_block_hash, chain.first_block_number);
-				let mut downloader = BlockDownloader::new(true, &ancient_block_hash, ancient_block_number, pruning.state_history_size);
+				let mut downloader = BlockDownloader::new(true, &ancient_block_hash, ancient_block_number, None);
 				if let Some(hash) = chain.first_block_hash {
 					trace!(target: "sync", "Downloader target set to {:?}", hash);
 					downloader.set_target(&hash);


### PR DESCRIPTION
This removes the history check for ancient blocks since they don't require any state anyway. Currently the check is always performed against the best block, which results in stuck sync for old blocks download if it runs into a fork 