### PR TITLE
Optimized hash lookups

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -383,6 +383,7 @@ version = "0.1.2"
 dependencies = [
  "bigint 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "heapsize 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "libc 0.2.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
 ]

--- a/util/bigint/Cargo.toml
+++ b/util/bigint/Cargo.toml
@@ -12,6 +12,7 @@ bigint = "1.0"
 rustc-serialize = "0.3"
 heapsize = "0.3"
 rand = "0.3.12"
+libc = "0.2"
 
 [features]
 x64asm_arithmetic=[]

--- a/util/bigint/src/hash.rs
+++ b/util/bigint/src/hash.rs
@@ -26,6 +26,7 @@ use rand::Rng;
 use rand::os::OsRng;
 use rustc_serialize::hex::{FromHex, FromHexError};
 use bigint::{Uint, U256};
+use libc::{c_void, memcmp};
 
 /// Trait for a fixed-size byte array to be used as the output of hash functions.
 pub trait FixedHash: Sized {
@@ -61,8 +62,6 @@ pub fn clean_0x(s: &str) -> &str {
 		s
 	}
 }
-
-extern { fn memcmp(s1: *const i8, s2: *const i8, n: usize) -> i32; }
 
 macro_rules! impl_hash {
 	($from: ident, $size: expr) => {
@@ -216,13 +215,13 @@ macro_rules! impl_hash {
 
 		impl PartialEq for $from {
 			fn eq(&self, other: &Self) -> bool {
-				unsafe { memcmp(self.0.as_ptr() as *const i8, other.0.as_ptr() as *const i8, $size) == 0 }
+				unsafe { memcmp(self.0.as_ptr() as *const c_void, other.0.as_ptr() as *const c_void, $size) == 0 }
 			}
 		}
 
 		impl Ord for $from {
 			fn cmp(&self, other: &Self) -> Ordering {
-				let r = unsafe { memcmp(self.0.as_ptr() as *const i8, other.0.as_ptr() as *const i8, $size) };
+				let r = unsafe { memcmp(self.0.as_ptr() as *const c_void, other.0.as_ptr() as *const c_void, $size) };
 				if r < 0 { return Ordering::Less }
 				if r > 0 { return Ordering::Greater }
 				return Ordering::Equal;

--- a/util/bigint/src/lib.rs
+++ b/util/bigint/src/lib.rs
@@ -21,6 +21,7 @@
 extern crate rand;
 extern crate rustc_serialize;
 extern crate bigint;
+extern crate libc;
 #[macro_use] extern crate heapsize;
 
 pub mod hash;


### PR DESCRIPTION
Profiling shows that `eq` is not compiled into the most efficient code and is on a hot path.