### PR TITLE
Bumping hyper

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -872,7 +872,7 @@ dependencies = [
 [[package]]
 name = "hyper"
 version = "0.10.0-a.0"
-source = "git+https://github.com/ethcore/hyper#7d4f7fa0baddcb2b0c523f7c05855d67de94fe88"
+source = "git+https://github.com/ethcore/hyper#6baea9d444dd1652220ee9b4aeadaebb3de6a955"
 dependencies = [
  "cookie 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "httparse 1.1.2 (registry+https://github.com/rust-lang/crates.io-index)",


### PR DESCRIPTION
Contains a patch to avoid panicking if slab capacity is reached (amount of concurrent connections):
https://github.com/ethcore/hyper/compare/7d4f7fa0baddcb2b0c523f7c05855d67de94fe88...6baea9d444dd1652220ee9b4aeadaebb3de6a955