### PR TITLE
Fix broken token images

### DIFF
--- a/js/src/ui/Balance/balance.js
+++ b/js/src/ui/Balance/balance.js
@@ -62,11 +62,15 @@ class Balance extends Component {
           value = api.util.fromWei(balance.value).toFormat(3);
         }
 
-        let imagesrc = token.image;
-        if (!imagesrc) {
-          imagesrc = images[token.address]
-            ? `${api.dappsUrl}${images[token.address]}`
-            : unknownImage;
+        const imageurl = token.image || images[token.address];
+        let imagesrc = unknownImage;
+
+        if (imageurl) {
+          const host = /^(\/)?api/.test(imageurl)
+            ? api.dappsUrl
+            : '';
+
+          imagesrc = `${host}${imageurl}`;
         }
 
         return (

--- a/js/src/ui/Form/TypedInput/typedInput.js
+++ b/js/src/ui/Form/TypedInput/typedInput.js
@@ -71,7 +71,9 @@ export default class TypedInput extends Component {
     const { isEth, value } = this.props;
 
     if (typeof isEth === 'boolean' && value) {
-      const ethValue = isEth ? fromWei(value) : value;
+      // Remove formatting commas
+      const sanitizedValue = typeof value === 'string' ? value.replace(/,/g, '') : value;
+      const ethValue = isEth ? fromWei(sanitizedValue) : value;
       this.setState({ isEth, ethValue });
     }
   }
@@ -393,7 +395,9 @@ export default class TypedInput extends Component {
       return this.setState({ isEth: !isEth });
     }
 
-    const value = isEth ? toWei(ethValue) : fromWei(ethValue);
+    // Remove formatting commas
+    const sanitizedValue = typeof ethValue === 'string' ? ethValue.replace(/,/g, '') : ethValue;
+    const value = isEth ? toWei(sanitizedValue) : fromWei(sanitizedValue);
     this.setState({ isEth: !isEth, ethValue: value }, () => {
       this.onEthValueChange(null, value);
     });


### PR DESCRIPTION
Tokens images weren't loaded from the right port.
Also, in a Contract view, queries displaying uint values as results would break when toggling the `ETH` toggle.