### PR TITLE
Support HTML5-routed dapps

### DIFF
--- a/dapps/src/apps/mod.rs
+++ b/dapps/src/apps/mod.rs
@@ -38,6 +38,7 @@ pub const RPC_PATH: &'static str =  "rpc";
 pub const API_PATH: &'static str =  "api";
 pub const UTILS_PATH: &'static str =  "parity-utils";
 pub const WEB_PATH: &'static str = "web";
+pub const URL_REFERER: &'static str = "__referer=";
 
 pub fn utils() -> Box<Endpoint> {
 	Box::new(PageEndpoint::with_prefix(parity_ui::App::default(), UTILS_PATH.to_owned()))


### PR DESCRIPTION
Partially addresses #4171 

`http://contribution.melonport.com` still does not work, since it uses WebSockets connection to centralized server to fetch some additional data, which Parity cannot proxy because of insufficient data in upgrade request (For some reason Browser are not sending `Referer` header with Upgrade request and we don't know which server to redirect to), will probably need even more hacks to solve this (but it's not guaranteed it will work)