### PR TITLE
CHT calculations for full nodes

### DIFF
--- a/ethcore/light/src/cht.rs
+++ b/ethcore/light/src/cht.rs
@@ -20,3 +20,8 @@ pub const SIZE: u64 = 2048;
 pub fn block_to_cht_number(block_num: u64) -> u64 {
 	(block_num + 1) / SIZE
 }
+
+/// Get the starting block of a given CHT.
+pub fn start_number(cht_num: u64) -> u64 {
+	(cht_num * SIZE) + 1
+}

--- a/ethcore/light/src/cht.rs
+++ b/ethcore/light/src/cht.rs
@@ -17,11 +17,38 @@
 pub const SIZE: u64 = 2048;
 
 /// Convert a block number to a CHT number.
-pub fn block_to_cht_number(block_num: u64) -> u64 {
-	(block_num + 1) / SIZE
+/// Returns `None` for `block_num` == 0, `Some` otherwise.
+pub fn block_to_cht_number(block_num: u64) -> Option<u64> {
+	match block_num {
+		0 => None,
+		n => Some((n - 1) / SIZE),
+	}
 }
 
 /// Get the starting block of a given CHT.
+/// CHT 0 includes block 1...SIZE,
+/// CHT 1 includes block SIZE + 1 ... 2*SIZE
+/// More generally: CHT N includes block (1 + N*SIZE)...((N+1)*SIZE).
+/// This is because the genesis hash is assumed to be known
+/// and including it would be redundant.
 pub fn start_number(cht_num: u64) -> u64 {
 	(cht_num * SIZE) + 1
+}
+
+#[cfg(test)]
+mod tests {
+	#[test]
+	fn block_to_cht_number() {
+		assert!(::cht::block_to_cht_number(0).is_none());
+		assert_eq!(::cht::block_to_cht_number(1).unwrap(), 0);
+		assert_eq!(::cht::block_to_cht_number(::cht::SIZE + 1).unwrap(), 1);
+		assert_eq!(::cht::block_to_cht_number(::cht::SIZE).unwrap(), 0);
+	}
+
+	#[test]
+	fn start_number() {
+		assert_eq!(::cht::start_number(0), 1);
+		assert_eq!(::cht::start_number(1), ::cht::SIZE + 1);
+		assert_eq!(::cht::start_number(2), ::cht::SIZE * 2 + 1);
+	}
 }

--- a/ethcore/light/src/client/header_chain.rs
+++ b/ethcore/light/src/client/header_chain.rs
@@ -28,7 +28,7 @@
 
 use std::collections::{BTreeMap, HashMap};
 
-use client::cht;
+use cht;
 
 use ethcore::block_status::BlockStatus;
 use ethcore::error::BlockError;

--- a/ethcore/light/src/client/mod.rs
+++ b/ethcore/light/src/client/mod.rs
@@ -39,8 +39,6 @@ use self::header_chain::HeaderChain;
 
 pub use self::service::Service;
 
-pub mod cht;
-
 mod header_chain;
 mod service;
 

--- a/ethcore/light/src/lib.rs
+++ b/ethcore/light/src/lib.rs
@@ -33,6 +33,7 @@
 #![deny(missing_docs)]
 
 pub mod client;
+pub mod cht;
 pub mod net;
 pub mod on_demand;
 

--- a/ethcore/light/src/on_demand/mod.rs
+++ b/ethcore/light/src/on_demand/mod.rs
@@ -41,6 +41,8 @@ pub enum Error {
 	Canceled,
 	/// No suitable peers available to serve the request.
 	NoPeersAvailable,
+	/// Invalid request.
+	InvalidRequest,
 	/// Request timed out.
 	TimedOut,
 }
@@ -112,7 +114,15 @@ impl OnDemand {
 	// dispatch the request, completing the request if no peers available.
 	fn dispatch_header_by_number(&self, ctx: &BasicContext, req: request::HeaderByNumber, sender: Sender<encoded::Header>) {
 		let num = req.num;
-		let cht_num = ::cht::block_to_cht_number(req.num);
+		let cht_num = match ::cht::block_to_cht_number(req.num) {
+			Some(cht_num) => cht_num,
+			None => {
+				warn!(target: "on_demand", "Attempted to dispatch invalid header proof: req.num == 0");
+				sender.complete(Err(Error::InvalidRequest));
+				return;
+			}
+		};
+
 		let les_req = LesRequest::HeaderProofs(les_request::HeaderProofs {
 			requests: vec![les_request::HeaderProof {
 				cht_number: cht_num,

--- a/ethcore/light/src/on_demand/mod.rs
+++ b/ethcore/light/src/on_demand/mod.rs
@@ -112,7 +112,7 @@ impl OnDemand {
 	// dispatch the request, completing the request if no peers available.
 	fn dispatch_header_by_number(&self, ctx: &BasicContext, req: request::HeaderByNumber, sender: Sender<encoded::Header>) {
 		let num = req.num;
-		let cht_num = ::client::cht::block_to_cht_number(req.num);
+		let cht_num = ::cht::block_to_cht_number(req.num);
 		let les_req = LesRequest::HeaderProofs(les_request::HeaderProofs {
 			requests: vec![les_request::HeaderProof {
 				cht_number: cht_num,

--- a/ethcore/light/src/types/les_request.rs
+++ b/ethcore/light/src/types/les_request.rs
@@ -120,7 +120,7 @@ pub struct ContractCodes {
 pub struct HeaderProof {
 	/// Number of the CHT.
 	pub cht_number: u64,
-	/// Block number requested.
+	/// Block number requested. May not be 0: genesis isn't included in any CHT.
 	pub block_number: u64,
 	/// If greater than zero, trie nodes beyond this level may be omitted.
 	pub from_level: u32,


### PR DESCRIPTION
Closes #3458 (for now)

For now, Tries are always calculated on-demand. This will likely be changed in the future to maintain an LRU-Cache of recently-generated CHTs.

Also adds some more tests and documentation.