### PR TITLE
verification: add mainnet BadgeReg ids

### DIFF
--- a/js/src/contracts/badgereg.js
+++ b/js/src/contracts/badgereg.js
@@ -73,6 +73,26 @@ export default class BadgeReg {
       });
   }
 
+  fetchCertifierByName (name) {
+    return this
+      .getContract()
+      .then((badgeReg) => {
+        return badgeReg.instance.fromName.call({}, [ name ]);
+      })
+      .then(([ id, address, owner ]) => {
+        if (address === ZERO20) {
+          throw new Error(`Certifier ${name} does not exist.`);
+        }
+
+        return this.fetchMeta(id)
+          .then(({ title, icon }) => {
+            const data = { address, id, name, title, icon };
+            this.certifiers[id] = data;
+            return data;
+          });
+      });
+  }
+
   fetchMeta (id) {
     return this
       .getContract()

--- a/js/src/modals/Verification/GatherData/gatherData.js
+++ b/js/src/modals/Verification/GatherData/gatherData.js
@@ -115,13 +115,26 @@ export default class GatherData extends Component {
     if (!fee) {
       return (<p>Fetching the fee…</p>);
     }
+    if (fee.eq(0)) {
+      return (
+        <div className={ styles.container }>
+          <InfoIcon />
+          <p className={ styles.message }>
+            <FormattedMessage
+              id='ui.verification.gatherData.nofee'
+              defaultMessage='There is not additional fee.'
+            />
+          </p>
+        </div>
+      );
+    }
     return (
       <div className={ styles.container }>
         <InfoIcon />
         <p className={ styles.message }>
           <FormattedMessage
             id='ui.verification.gatherData.fee'
-            defaultMessage='The fee is {amount} ETH.'
+            defaultMessage='The additional fee is {amount} ETH.'
             values={ {
               amount: fromWei(fee).toFixed(3)
             } }

--- a/js/src/modals/Verification/GatherData/gatherData.js
+++ b/js/src/modals/Verification/GatherData/gatherData.js
@@ -122,7 +122,7 @@ export default class GatherData extends Component {
           <p className={ styles.message }>
             <FormattedMessage
               id='ui.verification.gatherData.nofee'
-              defaultMessage='There is not additional fee.'
+              defaultMessage='There is no additional fee.'
             />
           </p>
         </div>

--- a/js/src/modals/Verification/email-store.js
+++ b/js/src/modals/Verification/email-store.js
@@ -24,7 +24,7 @@ import VerificationStore, {
 import { isServerRunning, postToServer } from '../../3rdparty/email-verification';
 
 // name in the `BadgeReg.sol` contract
-const EMAIL_VERIFICATION = '0x92ba1c9b48af87f408e2a11d6e919d1391b8100a264621fa89c0c0b5447cbc35';
+const EMAIL_VERIFICATION = 'emailverification';
 
 export default class EmailVerificationStore extends VerificationStore {
   @observable email = '';

--- a/js/src/modals/Verification/email-store.js
+++ b/js/src/modals/Verification/email-store.js
@@ -23,9 +23,8 @@ import VerificationStore, {
 } from './store';
 import { isServerRunning, postToServer } from '../../3rdparty/email-verification';
 
-// ids in the `BadgeReg.sol` contract
-const TESTNET_EMAIL_VERIFICATION = 7;
-const MAINNET_EMAIL_VERIFICATION = 0;
+// name in the `BadgeReg.sol` contract
+const EMAIL_VERIFICATION = '0x92ba1c9b48af87f408e2a11d6e919d1391b8100a264621fa89c0c0b5447cbc35';
 
 export default class EmailVerificationStore extends VerificationStore {
   @observable email = '';
@@ -58,8 +57,7 @@ export default class EmailVerificationStore extends VerificationStore {
   }
 
   constructor (api, account, isTestnet) {
-    const id = isTestnet ? TESTNET_EMAIL_VERIFICATION : MAINNET_EMAIL_VERIFICATION;
-    super(api, EmailVerificationABI, id, account, isTestnet);
+    super(api, EmailVerificationABI, EMAIL_VERIFICATION, account, isTestnet);
   }
 
   isServerRunning = () => {

--- a/js/src/modals/Verification/email-store.js
+++ b/js/src/modals/Verification/email-store.js
@@ -23,7 +23,9 @@ import VerificationStore, {
 } from './store';
 import { isServerRunning, postToServer } from '../../3rdparty/email-verification';
 
-const EMAIL_VERIFICATION = 7; // id in the `BadgeReg.sol` contract
+// ids in the `BadgeReg.sol` contract
+const TESTNET_EMAIL_VERIFICATION = 7;
+const MAINNET_EMAIL_VERIFICATION = 0;
 
 export default class EmailVerificationStore extends VerificationStore {
   @observable email = '';
@@ -56,7 +58,8 @@ export default class EmailVerificationStore extends VerificationStore {
   }
 
   constructor (api, account, isTestnet) {
-    super(api, EmailVerificationABI, EMAIL_VERIFICATION, account, isTestnet);
+    const id = isTestnet ? TESTNET_EMAIL_VERIFICATION : MAINNET_EMAIL_VERIFICATION;
+    super(api, EmailVerificationABI, id, account, isTestnet);
   }
 
   isServerRunning = () => {

--- a/js/src/modals/Verification/sms-store.js
+++ b/js/src/modals/Verification/sms-store.js
@@ -24,7 +24,7 @@ import VerificationStore, {
 import { isServerRunning, postToServer } from '../../3rdparty/sms-verification';
 
 // name in the `BadgeReg.sol` contract
-const SMS_VERIFICATION = '0x82ba1c9b48af87f408e2a11d6e919d1391b8100a264621fa89c0c0b5447cbc35';
+const SMS_VERIFICATION = 'smsverification';
 
 export default class SMSVerificationStore extends VerificationStore {
   @observable number = '';

--- a/js/src/modals/Verification/sms-store.js
+++ b/js/src/modals/Verification/sms-store.js
@@ -23,7 +23,9 @@ import VerificationStore, {
 } from './store';
 import { isServerRunning, postToServer } from '../../3rdparty/sms-verification';
 
-const SMS_VERIFICATION = 0; // id in the `BadgeReg.sol` contract
+// ids in the `BadgeReg.sol` contract
+const TESTNET_SMS_VERIFICATION = 0;
+const MAINNET_SMS_VERIFICATION = 1;
 
 export default class SMSVerificationStore extends VerificationStore {
   @observable number = '';
@@ -55,7 +57,8 @@ export default class SMSVerificationStore extends VerificationStore {
   }
 
   constructor (api, account, isTestnet) {
-    super(api, SMSVerificationABI, SMS_VERIFICATION, account, isTestnet);
+    const id = isTestnet ? TESTNET_SMS_VERIFICATION : MAINNET_SMS_VERIFICATION;
+    super(api, SMSVerificationABI, id, account, isTestnet);
   }
 
   isServerRunning = () => {

--- a/js/src/modals/Verification/sms-store.js
+++ b/js/src/modals/Verification/sms-store.js
@@ -23,9 +23,8 @@ import VerificationStore, {
 } from './store';
 import { isServerRunning, postToServer } from '../../3rdparty/sms-verification';
 
-// ids in the `BadgeReg.sol` contract
-const TESTNET_SMS_VERIFICATION = 0;
-const MAINNET_SMS_VERIFICATION = 1;
+// name in the `BadgeReg.sol` contract
+const SMS_VERIFICATION = '0x82ba1c9b48af87f408e2a11d6e919d1391b8100a264621fa89c0c0b5447cbc35';
 
 export default class SMSVerificationStore extends VerificationStore {
   @observable number = '';
@@ -57,8 +56,7 @@ export default class SMSVerificationStore extends VerificationStore {
   }
 
   constructor (api, account, isTestnet) {
-    const id = isTestnet ? TESTNET_SMS_VERIFICATION : MAINNET_SMS_VERIFICATION;
-    super(api, SMSVerificationABI, id, account, isTestnet);
+    super(api, SMSVerificationABI, SMS_VERIFICATION, account, isTestnet);
   }
 
   isServerRunning = () => {

--- a/js/src/modals/Verification/store.js
+++ b/js/src/modals/Verification/store.js
@@ -47,13 +47,13 @@ export default class VerificationStore {
   @observable isCodeValid = null;
   @observable confirmationTx = null;
 
-  constructor (api, abi, certifierId, account, isTestnet) {
+  constructor (api, abi, certifierName, account, isTestnet) {
     this.api = api;
     this.account = account;
     this.isTestnet = isTestnet;
 
     this.step = LOADING;
-    Contracts.get().badgeReg.fetchCertifier(certifierId)
+    Contracts.get().badgeReg.fetchCertifierByName(certifierName)
       .then(({ address }) => {
         this.contract = new Contract(api, abi).at(address);
         this.load();


### PR DESCRIPTION
They were `ropsten`-specific before. Not sure if this is the best place to store them.