### PR TITLE
LES Peer Info

### DIFF
--- a/ethcore/light/src/net/context.rs
+++ b/ethcore/light/src/net/context.rs
@@ -77,7 +77,7 @@ impl<'a> IoContext for NetworkContext<'a> {
 	}
 }
 
-/// Basic context for a the protocol.
+/// Basic context for the protocol.
 pub trait BasicContext {
 	/// Returns the relevant's peer persistent Id (aka NodeId).
 	fn persistent_peer_id(&self, peer: PeerId) -> Option<NodeId>;

--- a/ethcore/light/src/net/mod.rs
+++ b/ethcore/light/src/net/mod.rs
@@ -269,6 +269,12 @@ impl LightProtocol {
 		}
 	}
 
+	/// Attempt to get peer status.
+	pub fn peer_status(&self, peer: &PeerId) -> Option<Status> {
+		self.peers.read().get(&peer)
+			.map(|peer| peer.lock().status.clone())
+	}
+
 	/// Check the maximum amount of requests of a specific type
 	/// which a peer would be able to serve. Returns zero if the
 	/// peer is unknown or has no buffer flow parameters.

--- a/rpc/src/v1/tests/helpers/sync_provider.rs
+++ b/rpc/src/v1/tests/helpers/sync_provider.rs
@@ -18,7 +18,7 @@
 
 use std::collections::BTreeMap;
 use util::{H256, RwLock};
-use ethsync::{SyncProvider, SyncStatus, SyncState, PeerInfo, TransactionStats};
+use ethsync::{SyncProvider, EthProtocolInfo, SyncStatus, SyncState, PeerInfo, TransactionStats};
 
 /// TestSyncProvider config.
 pub struct Config {
@@ -78,9 +78,12 @@ impl SyncProvider for TestSyncProvider {
 				capabilities: vec!["eth/62".to_owned(), "eth/63".to_owned()],
     			remote_address: "127.0.0.1:7777".to_owned(),
 				local_address: "127.0.0.1:8888".to_owned(),
-				eth_version: 62,
-				eth_difficulty: Some(40.into()),
-				eth_head: 50.into()
+				eth_info: Some(EthProtocolInfo {
+					version: 62,
+					difficulty: Some(40.into()),
+					head: 50.into(),
+				}),
+				les_info: None,
 			},
 			PeerInfo {
 				id: None,
@@ -88,9 +91,12 @@ impl SyncProvider for TestSyncProvider {
 				capabilities: vec!["eth/63".to_owned(), "eth/64".to_owned()],
     			remote_address: "Handshake".to_owned(),
 				local_address: "127.0.0.1:3333".to_owned(),
-				eth_version: 64,
-				eth_difficulty: None,
-				eth_head: 60.into()
+				eth_info: Some(EthProtocolInfo {
+					version: 64,
+					difficulty: None,
+					head: 60.into()
+				}),
+				les_info: None,
 			}
 		]
 	}

--- a/rpc/src/v1/tests/mocked/parity.rs
+++ b/rpc/src/v1/tests/mocked/parity.rs
@@ -265,7 +265,7 @@ fn rpc_parity_net_peers() {
 	let io = deps.default_client();
 
 	let request = r#"{"jsonrpc": "2.0", "method": "parity_netPeers", "params":[], "id": 1}"#;
-	let response = r#"{"jsonrpc":"2.0","result":{"active":0,"connected":120,"max":50,"peers":[{"caps":["eth/62","eth/63"],"id":"node1","name":"Parity/1","network":{"localAddress":"127.0.0.1:8888","remoteAddress":"127.0.0.1:7777"},"protocols":{"eth":{"difficulty":"0x28","head":"0000000000000000000000000000000000000000000000000000000000000032","version":62}}},{"caps":["eth/63","eth/64"],"id":null,"name":"Parity/2","network":{"localAddress":"127.0.0.1:3333","remoteAddress":"Handshake"},"protocols":{"eth":{"difficulty":null,"head":"000000000000000000000000000000000000000000000000000000000000003c","version":64}}}]},"id":1}"#;
+	let response = r#"{"jsonrpc":"2.0","result":{"active":0,"connected":120,"max":50,"peers":[{"caps":["eth/62","eth/63"],"id":"node1","name":"Parity/1","network":{"localAddress":"127.0.0.1:8888","remoteAddress":"127.0.0.1:7777"},"protocols":{"eth":{"difficulty":"0x28","head":"0000000000000000000000000000000000000000000000000000000000000032","version":62},"les":null}},{"caps":["eth/63","eth/64"],"id":null,"name":"Parity/2","network":{"localAddress":"127.0.0.1:3333","remoteAddress":"Handshake"},"protocols":{"eth":{"difficulty":null,"head":"000000000000000000000000000000000000000000000000000000000000003c","version":64},"les":null}}]},"id":1}"#;
 
 	assert_eq!(io.handle_request_sync(request), Some(response.to_owned()));
 }

--- a/rpc/src/v1/types/mod.rs.in
+++ b/rpc/src/v1/types/mod.rs.in
@@ -50,8 +50,8 @@ pub use self::hash::{H64, H160, H256, H512, H520, H2048};
 pub use self::index::Index;
 pub use self::log::Log;
 pub use self::sync::{
-	SyncStatus, SyncInfo, Peers, PeerInfo, PeerNetworkInfo, PeerProtocolsInfo, PeerEthereumProtocolInfo,
-	TransactionStats, ChainStatus
+	SyncStatus, SyncInfo, Peers, PeerInfo, PeerNetworkInfo, PeerProtocolsInfo,
+	TransactionStats, ChainStatus, EthProtocolInfo, LesProtocolInfo,
 };
 pub use self::transaction::{Transaction, RichRawTransaction, LocalTransactionStatus};
 pub use self::transaction_request::TransactionRequest;

--- a/rpc/src/v1/types/sync.rs
+++ b/rpc/src/v1/types/sync.rs
@@ -83,6 +83,8 @@ pub struct PeerNetworkInfo {
 pub struct PeerProtocolsInfo {
 	/// Ethereum protocol information
 	pub eth: Option<PeerEthereumProtocolInfo>,
+	/// LES protocol information.
+	pub les: Option<PeerEthereumProtocolInfo>,
 }
 
 /// Peer Ethereum protocol information

--- a/rpc/src/v1/types/sync.rs
+++ b/rpc/src/v1/types/sync.rs
@@ -15,7 +15,7 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 use std::collections::BTreeMap;
-use ethsync::{PeerInfo as SyncPeerInfo, TransactionStats as SyncTransactionStats};
+use ethsync::{self, PeerInfo as SyncPeerInfo, TransactionStats as SyncTransactionStats};
 use serde::{Serialize, Serializer};
 use v1::types::{U256, H512};
 
@@ -82,20 +82,51 @@ pub struct PeerNetworkInfo {
 #[derive(Default, Debug, Serialize)]
 pub struct PeerProtocolsInfo {
 	/// Ethereum protocol information
-	pub eth: Option<PeerEthereumProtocolInfo>,
+	pub eth: Option<EthProtocolInfo>,
 	/// LES protocol information.
-	pub les: Option<PeerEthereumProtocolInfo>,
+	pub les: Option<LesProtocolInfo>,
 }
 
 /// Peer Ethereum protocol information
 #[derive(Default, Debug, Serialize)]
-pub struct PeerEthereumProtocolInfo {
+pub struct EthProtocolInfo {
 	/// Negotiated ethereum protocol version
 	pub version: u32,
 	/// Peer total difficulty if known
 	pub difficulty: Option<U256>,
 	/// SHA3 of peer best block hash
 	pub head: String,
+}
+
+impl From<ethsync::EthProtocolInfo> for EthProtocolInfo {
+	fn from(info: ethsync::EthProtocolInfo) -> Self {
+		EthProtocolInfo {
+			version: info.version,
+			difficulty: info.difficulty.map(Into::into),
+			head: info.head.hex(),
+		}
+	}
+}
+
+/// Peer LES protocol information
+#[derive(Default, Debug, Serialize)]
+pub struct LesProtocolInfo {
+	/// Negotiated LES protocol version
+	pub version: u32,
+	/// Peer total difficulty
+	pub difficulty: U256,
+	/// SHA3 of peer best block hash
+	pub head: String,
+}
+
+impl From<ethsync::LesProtocolInfo> for LesProtocolInfo {
+	fn from(info: ethsync::LesProtocolInfo) -> Self {
+		LesProtocolInfo {
+			version: info.version,
+			difficulty: info.difficulty.into(),
+			head: info.head.hex(),
+		}
+	}
 }
 
 /// Sync status
@@ -139,11 +170,8 @@ impl From<SyncPeerInfo> for PeerInfo {
 				local_address: p.local_address,
 			},
 			protocols: PeerProtocolsInfo {
-				eth: Some(PeerEthereumProtocolInfo {
-					version: p.eth_version,
-					difficulty: p.eth_difficulty.map(|d| d.into()),
-					head: p.eth_head.hex(),
-				})
+				eth: p.eth_info.map(Into::into),
+				les: p.les_info.map(Into::into),
 			},
 		}
 	}

--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -75,7 +75,7 @@ mod api;
 pub use api::{
 	EthSync, Params, SyncProvider, ManageNetwork, SyncConfig,
 	ServiceConfiguration, NetworkConfiguration, PeerInfo, AllowIP, TransactionStats,
-	LightSync, LightSyncParams,
+	LightSync, LightSyncParams, LesProtocolInfo, EthProtocolInfo,
 };
 pub use chain::{SyncStatus, SyncState};
 pub use network::{is_valid_node_url, NonReservedPeerMode, NetworkError};

--- a/util/network/src/host.rs
+++ b/util/network/src/host.rs
@@ -542,6 +542,20 @@ impl Host {
 		Ok(())
 	}
 
+	/// Get all connected peers.
+	pub fn connected_peers(&self) -> Vec<PeerId> {
+		let sessions = self.sessions.read();
+		let sessions = &*sessions;
+
+		let mut peers = Vec::with_capacity(sessions.count());
+		for i in (0..MAX_SESSIONS).map(|x| x + FIRST_SESSION) {
+			if sessions.get(i).is_some() {
+				peers.push(i);
+			}
+		}
+		peers
+	}
+
 	fn init_public_interface(&self, io: &IoContext<NetworkIoMessage>) -> Result<(), NetworkError> {
 		if self.info.read().public_endpoint.is_some() {
 			return Ok(());

--- a/util/network/src/service.rs
+++ b/util/network/src/service.rs
@@ -16,7 +16,7 @@
 
 use {NetworkProtocolHandler, NetworkConfiguration, NonReservedPeerMode};
 use error::NetworkError;
-use host::{Host, NetworkContext, NetworkIoMessage, ProtocolId};
+use host::{Host, NetworkContext, NetworkIoMessage, PeerId, ProtocolId};
 use stats::NetworkStats;
 use io::*;
 use parking_lot::RwLock;
@@ -140,6 +140,11 @@ impl NetworkService {
 		}
 		*host = None;
 		Ok(())
+	}
+
+	/// Get a list of all connected peers by id.
+	pub fn connected_peers(&self) -> Vec<PeerId> {
+		self.host.read().as_ref().map(|h| h.connected_peers()).unwrap_or_else(Vec::new)
 	}
 
 	/// Try to add a reserved peer.


### PR DESCRIPTION
Closes #3900 

May add fields for capabilities or buffer flow in the future, but for now it's the same as `eth` info, with the single exception that the head TD is always known.

Also adds a utility function for iterating all peers in the network.