### PR TITLE
Light protocol syncing improvements

### DIFF
--- a/ethcore/src/client/test_client.rs
+++ b/ethcore/src/client/test_client.rs
@@ -144,7 +144,7 @@ impl TestBlockChainClient {
 			genesis_hash: H256::new(),
 			extra_data: extra_data,
 			last_hash: RwLock::new(H256::new()),
-			difficulty: RwLock::new(From::from(0)),
+			difficulty: RwLock::new(spec.genesis_header().difficulty().clone()),
 			balances: RwLock::new(HashMap::new()),
 			nonces: RwLock::new(HashMap::new()),
 			storage: RwLock::new(HashMap::new()),

--- a/ethcore/src/verification/queue/kind.rs
+++ b/ethcore/src/verification/queue/kind.rs
@@ -177,7 +177,6 @@ pub mod headers {
 	}
 
 	/// A mode for verifying headers.
-	#[allow(dead_code)]
 	pub struct Headers;
 
 	impl Kind for Headers {

--- a/sync/src/light_sync/sync_round.rs
+++ b/sync/src/light_sync/sync_round.rs
@@ -30,13 +30,6 @@ use util::{Bytes, H256};
 
 use super::response;
 
-/// amount of blocks between each scaffold entry.
-// TODO: move these into parameters for `RoundStart::new`?
-pub const ROUND_SKIP: u64 = 255;
-
-// amount of scaffold frames: these are the blank spaces in "X___X___X"
-const ROUND_FRAMES: usize = 255;
-
 // number of attempts to make to get a full scaffold for a sync round.
 const SCAFFOLD_ATTEMPTS: usize = 3;
 
@@ -59,6 +52,8 @@ pub enum AbortReason {
 	BadScaffold(Vec<PeerId>),
 	/// No incoming data.
 	NoResponses,
+	/// Sync rounds completed.
+	TargetReached,
 }
 
 // A request for headers with a known starting header hash.
@@ -96,6 +91,7 @@ pub struct Fetcher {
 	scaffold_contributors: Vec<PeerId>,
 	ready: VecDeque<Header>,
 	end: (u64, H256),
+	target: (u64, H256),
 }
 
 impl Fetcher {
@@ -103,7 +99,7 @@ impl Fetcher {
 	// with a list of peers who helped produce the chain.
 	// The headers must be valid RLP at this point and must have a consistent
 	// non-zero gap between them. Will abort the round if found wrong.
-	fn new(sparse_headers: Vec<Header>, contributors: Vec<PeerId>) -> SyncRound {
+	fn new(sparse_headers: Vec<Header>, contributors: Vec<PeerId>, target: (u64, H256)) -> SyncRound {
 		let mut requests = BinaryHeap::with_capacity(sparse_headers.len() - 1);
 
 		for pair in sparse_headers.windows(2) {
@@ -144,6 +140,7 @@ impl Fetcher {
 			scaffold_contributors: contributors,
 			ready: VecDeque::new(),
 			end: end,
+			target: target,
 		})
 	}
 
@@ -170,6 +167,8 @@ impl Fetcher {
 		if self.sparse.len() == 1 {
 			self.ready.push_back(self.sparse.pop_back().expect("sparse known to have one entry; qed"))
 		}
+
+		trace!(target: "sync", "{} headers ready to drain", self.ready.len());
 	}
 
 	fn process_response<R: ResponseContext>(mut self, ctx: &R) -> SyncRound {
@@ -178,11 +177,16 @@ impl Fetcher {
 			None => return SyncRound::Fetch(self),
 		};
 
+		trace!(target: "sync", "Received response for subchain ({} -> {})",
+			request.subchain_parent.0 + 1, request.subchain_end.0);
+
 		let headers = ctx.data();
 
 		if headers.len() == 0 {
 			trace!(target: "sync", "Punishing peer {} for empty response", ctx.responder());
 			ctx.punish_responder();
+
+			self.requests.push(request);
 			return SyncRound::Fetch(self);
 		}
 
@@ -274,32 +278,63 @@ impl Fetcher {
 
 		if self.sparse.is_empty() && self.ready.is_empty() {
 			trace!(target: "sync", "sync round complete. Starting anew from {:?}", self.end);
-			SyncRound::Start(RoundStart::new(self.end))
+			SyncRound::begin(self.end, self.target)
 		} else {
 			SyncRound::Fetch(self)
 		}
 	}
 }
 
+// Compute scaffold parameters from distance between start and target block: (skip, frames).
+fn scaffold_params(diff: u64) -> (u64, usize) {
+	// default parameters.
+	// amount of blocks between each scaffold entry.
+	const ROUND_SKIP: u64 = 255;
+	// amount of scaffold frames: these are the blank spaces in "X___X___X"
+	const ROUND_FRAMES: usize = 255;
+
+	if diff <= ROUND_SKIP {
+		// just request headers from the start to the target.
+		(0, diff as usize)
+	} else {
+		let num_frames = ::std::cmp::min(diff / (ROUND_SKIP + 1), ROUND_FRAMES as u64) as usize;
+		(ROUND_SKIP, num_frames)
+	}
+}
+
 /// Round started: get stepped header chain.
-/// from a start block with number X we request 256 headers stepped by 256 from
-/// block X + 1.
+/// from a start block with number X we request ROUND_FRAMES headers stepped by ROUND_SKIP from
+/// block X + 1 to a target >= X + 1.
+/// If the sync target is within ROUND_SKIP of the start, we request
+/// only those blocks. If the sync target is within (ROUND_SKIP + 1) * ROUND_FRAMES of
+/// the start, we reduce the number of frames until the target is outside it.
 pub struct RoundStart {
 	start_block: (u64, H256),
+	target: (u64, H256),
 	pending_req: Option<(ReqId, HeadersRequest)>,
 	sparse_headers: Vec<Header>,
 	contributors: HashSet<PeerId>,
 	attempt: usize,
+	skip: u64,
+	frames: usize,
 }
 
 impl RoundStart {
-	fn new(start: (u64, H256)) -> Self {
+	fn new(start: (u64, H256), target: (u64, H256)) -> Self {
+		let (skip, frames) = scaffold_params(target.0 - start.0);
+
+		trace!(target: "sync", "Beginning sync round: {} frames and {} skip from block {}",
+			frames, skip, start.0);
+
 		RoundStart {
-			start_block: start.clone(),
+			start_block: start,
+			target: target,
 			pending_req: None,
 			sparse_headers: Vec::new(),
 			contributors: HashSet::new(),
 			attempt: 0,
+			skip: skip,
+			frames: frames,
 		}
 	}
 
@@ -309,10 +344,16 @@ impl RoundStart {
 		self.attempt += 1;
 
 		if self.attempt >= SCAFFOLD_ATTEMPTS {
-			if self.sparse_headers.len() > 1 {
-				Fetcher::new(self.sparse_headers, self.contributors.into_iter().collect())
+			return if self.sparse_headers.len() > 1 {
+				Fetcher::new(self.sparse_headers, self.contributors.into_iter().collect(), self.target)
 			} else {
-				SyncRound::Abort(AbortReason::NoResponses, self.sparse_headers.into())
+				let fetched_headers = if self.skip == 0 {
+					self.sparse_headers.into()
+				} else {
+					VecDeque::new()
+				};
+
+				SyncRound::abort(AbortReason::NoResponses, fetched_headers)
 			}
 		} else {
 			SyncRound::Start(self)
@@ -339,11 +380,18 @@ impl RoundStart {
 				self.contributors.insert(ctx.responder());
 				self.sparse_headers.extend(headers);
 
-				if self.sparse_headers.len() == ROUND_FRAMES + 1 {
-					trace!(target: "sync", "Beginning fetch of blocks between {} sparse headers",
-						self.sparse_headers.len());
-
-					return Fetcher::new(self.sparse_headers, self.contributors.into_iter().collect());
+				if self.sparse_headers.len() == self.frames + 1 {
+					return if self.skip == 0 {
+						SyncRound::abort(AbortReason::TargetReached, self.sparse_headers.into())
+					} else {
+						trace!(target: "sync", "Beginning fetch of blocks between {} sparse headers",
+							self.sparse_headers.len());
+						Fetcher::new(
+							self.sparse_headers,
+							self.contributors.into_iter().collect(),
+							self.target
+						)
+					}
 				}
 			}
 			Err(e) => {
@@ -376,20 +424,20 @@ impl RoundStart {
 		if self.pending_req.is_none() {
 			// beginning offset + first block expected after last header we have.
 			let start = (self.start_block.0 + 1)
-				+ self.sparse_headers.len() as u64 * (ROUND_SKIP + 1);
+				+ self.sparse_headers.len() as u64 * (self.skip + 1);
 
-			let max = (ROUND_FRAMES - 1) - self.sparse_headers.len();
+			let max = self.frames + 1 - self.sparse_headers.len();
 
 			let headers_request = HeadersRequest {
 				start: start.into(),
 				max: max,
-				skip: ROUND_SKIP,
+				skip: self.skip,
 				reverse: false,
 			};
 
 			if let Some(req_id) = dispatcher(headers_request.clone()) {
 				trace!(target: "sync", "Requesting scaffold: {} headers forward from {}, skip={}",
-					max, start, ROUND_SKIP);
+					max, start, self.skip);
 
 				self.pending_req = Some((req_id, headers_request));
 			}
@@ -416,9 +464,13 @@ impl SyncRound {
 		SyncRound::Abort(reason, remaining)
 	}
 
-	/// Begin sync rounds from a starting block.
-	pub fn begin(num: u64, hash: H256) -> Self {
-		SyncRound::Start(RoundStart::new((num, hash)))
+	/// Begin sync rounds from a starting block, but not to go past a given target
+	pub fn begin(start: (u64, H256), target: (u64, H256)) -> Self {
+		if target.0 <= start.0 {
+			SyncRound::abort(AbortReason::TargetReached, VecDeque::new())
+		} else {
+			SyncRound::Start(RoundStart::new(start, target))
+		}
 	}
 
 	/// Process an answer to a request. Unknown requests will be ignored.

--- a/sync/src/light_sync/tests/mod.rs
+++ b/sync/src/light_sync/tests/mod.rs
@@ -25,9 +25,10 @@ fn basic_sync() {
 	::env_logger::init().ok();
 
 	let mut net = TestNet::light(1, 2);
-	net.peer(1).chain().add_blocks(10000, EachBlockWith::Uncle);
-	net.peer(2).chain().add_blocks(12000, EachBlockWith::Uncle);
+	net.peer(1).chain().add_blocks(5000, EachBlockWith::Nothing);
+	net.peer(2).chain().add_blocks(6000, EachBlockWith::Nothing);
 
 	net.sync();
+
 	assert!(net.peer(0).light_chain().get_header(BlockId::Number(12000)).is_some())
 }

--- a/sync/src/light_sync/tests/mod.rs
+++ b/sync/src/light_sync/tests/mod.rs
@@ -16,19 +16,48 @@
 
 use tests::helpers::TestNet;
 
-use ethcore::client::{BlockId, EachBlockWith};
+use ethcore::client::{BlockChainClient, BlockId, EachBlockWith};
 
 mod test_net;
 
 #[test]
 fn basic_sync() {
-	::env_logger::init().ok();
-
 	let mut net = TestNet::light(1, 2);
 	net.peer(1).chain().add_blocks(5000, EachBlockWith::Nothing);
 	net.peer(2).chain().add_blocks(6000, EachBlockWith::Nothing);
 
 	net.sync();
 
-	assert!(net.peer(0).light_chain().get_header(BlockId::Number(12000)).is_some())
+	assert!(net.peer(0).light_chain().get_header(BlockId::Number(6000)).is_some());
+}
+
+#[test]
+fn fork_post_cht() {
+	const CHAIN_LENGTH: u64 = 50; // shouldn't be longer than ::light::cht::size();
+
+	let mut net = TestNet::light(1, 2);
+
+	// peer 2 is on a higher TD chain.
+	net.peer(1).chain().add_blocks(CHAIN_LENGTH as usize, EachBlockWith::Nothing);
+	net.peer(2).chain().add_blocks(CHAIN_LENGTH as usize + 1, EachBlockWith::Uncle);
+
+	// get the light peer on peer 1's chain.
+	for id in (0..CHAIN_LENGTH).map(|x| x + 1).map(BlockId::Number) {
+		let (light_peer, full_peer) = (net.peer(0), net.peer(1));
+		let light_chain = light_peer.light_chain();
+		let header = full_peer.chain().block_header(id).unwrap().decode();
+		let _  = light_chain.import_header(header);
+		light_chain.flush_queue();
+		light_chain.import_verified();
+		assert!(light_chain.get_header(id).is_some());
+	}
+
+	net.sync();
+
+	for id in (0..CHAIN_LENGTH).map(|x| x + 1).map(BlockId::Number) {
+		assert_eq!(
+			net.peer(0).light_chain().get_header(id),
+			net.peer(2).chain().block_header(id).map(|h| h.into_inner())
+		);
+	}
 }

--- a/sync/src/light_sync/tests/mod.rs
+++ b/sync/src/light_sync/tests/mod.rs
@@ -14,6 +14,20 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-#![allow(dead_code)]
+use tests::helpers::TestNet;
+
+use ethcore::client::{BlockId, EachBlockWith};
 
 mod test_net;
+
+#[test]
+fn basic_sync() {
+	::env_logger::init().ok();
+
+	let mut net = TestNet::light(1, 2);
+	net.peer(1).chain().add_blocks(10000, EachBlockWith::Uncle);
+	net.peer(2).chain().add_blocks(12000, EachBlockWith::Uncle);
+
+	net.sync();
+	assert!(net.peer(0).light_chain().get_header(BlockId::Number(12000)).is_some())
+}

--- a/sync/src/light_sync/tests/test_net.rs
+++ b/sync/src/light_sync/tests/test_net.rs
@@ -178,6 +178,7 @@ impl PeerLike for Peer {
 			PeerData::Light(_, ref client) => {
 				// should create a test light client which just imports
 				// headers directly and doesn't have a queue to drain.
+				client.import_verified();
 				client.queue_info().is_empty()
 			}
 			_ => true,

--- a/sync/src/light_sync/tests/test_net.rs
+++ b/sync/src/light_sync/tests/test_net.rs
@@ -174,13 +174,23 @@ impl PeerLike for Peer {
 	}
 
 	fn is_done(&self) -> bool {
-		self.queue.read().is_empty()
+		self.queue.read().is_empty() && match self.data {
+			PeerData::Light(_, ref client) => {
+				// should create a test light client which just imports
+				// headers directly and doesn't have a queue to drain.
+				client.queue_info().is_empty()
+			}
+			_ => true,
+		}
 	}
 
 	fn sync_step(&self) {
 		if let PeerData::Light(_, ref client) = self.data {
 			client.flush_queue();
-			client.import_verified();
+
+			while !client.queue_info().is_empty() {
+				client.import_verified()
+			}
 		}
 	}
 


### PR DESCRIPTION
Now handles the head of the chain correctly and doesn't choke on forks. There are still a couple of low-hanging fruit for improvement (namely, improving the dispatch function to check peer capabilities + buffer availability and avoiding a common ancestor search after every transition out of idle state), but this is good enough for now.

Also fixes a couple of bugs in the `HeaderChain` and in the test client.