### PR TITLE
Fix wrong output format of peers

### DIFF
--- a/js/src/api/format/output.js
+++ b/js/src/api/format/output.js
@@ -129,12 +129,31 @@ export function outNumber (number) {
   return new BigNumber(number || 0);
 }
 
+export function outPeer (peer) {
+  const protocols = Object.keys(peer.protocols)
+    .reduce((obj, key) => {
+      if (peer.protocols[key]) {
+        obj[key] = {
+          ...peer.protocols[key],
+          difficulty: outNumber(peer.protocols[key].difficulty)
+        };
+      }
+
+      return obj;
+    }, {});
+
+  return {
+    ...peer,
+    protocols
+  };
+}
+
 export function outPeers (peers) {
   return {
     active: outNumber(peers.active),
     connected: outNumber(peers.connected),
     max: outNumber(peers.max),
-    peers: peers.peers.map(p => { Object.keys(p.protocols).forEach(k => { p.protocols[k].difficulty = outNumber(p.protocols[k].difficulty); }); return p; })
+    peers: peers.peers.map((peer) => outPeer(peer))
   };
 }
 

--- a/js/src/api/format/output.spec.js
+++ b/js/src/api/format/output.spec.js
@@ -16,7 +16,7 @@
 
 import BigNumber from 'bignumber.js';
 
-import { outBlock, outAccountInfo, outAddress, outChainStatus, outDate, outHistogram, outNumber, outPeers, outReceipt, outSyncing, outTransaction, outTrace } from './output';
+import { outBlock, outAccountInfo, outAddress, outChainStatus, outDate, outHistogram, outNumber, outPeer, outPeers, outReceipt, outSyncing, outTransaction, outTrace } from './output';
 import { isAddress, isBigNumber, isInstanceOf } from '../../../test/types';
 
 describe('api/format/output', () => {
@@ -162,6 +162,66 @@ describe('api/format/output', () => {
 
     it('assumes 0 when ivalid input', () => {
       expect(outNumber().eq(0)).to.be.true;
+    });
+  });
+
+  describe('outPeer', () => {
+    it('converts all internal numbers to BigNumbers', () => {
+      expect(outPeer({
+        caps: ['par/1'],
+        id: '0x01',
+        name: 'Parity',
+        network: {
+          localAddress: '10.0.0.1',
+          remoteAddress: '10.0.0.1'
+        },
+        protocols: {
+          par: {
+            difficulty: '0x0f',
+            head: '0x02',
+            version: 63
+          }
+        }
+      })).to.deep.equal({
+        caps: ['par/1'],
+        id: '0x01',
+        name: 'Parity',
+        network: {
+          localAddress: '10.0.0.1',
+          remoteAddress: '10.0.0.1'
+        },
+        protocols: {
+          par: {
+            difficulty: new BigNumber(15),
+            head: '0x02',
+            version: 63
+          }
+        }
+      });
+    });
+
+    it('does not output null protocols', () => {
+      expect(outPeer({
+        caps: ['par/1'],
+        id: '0x01',
+        name: 'Parity',
+        network: {
+          localAddress: '10.0.0.1',
+          remoteAddress: '10.0.0.1'
+        },
+        protocols: {
+          les: null
+        }
+      })).to.deep.equal({
+        caps: ['par/1'],
+        id: '0x01',
+        name: 'Parity',
+        network: {
+          localAddress: '10.0.0.1',
+          remoteAddress: '10.0.0.1'
+        },
+        protocols: {}
+      });
     });
   });
 

--- a/js/src/api/format/output.spec.js
+++ b/js/src/api/format/output.spec.js
@@ -185,7 +185,8 @@ describe('api/format/output', () => {
                 difficulty: '0x0f',
                 head: '0x02',
                 version: 63
-              }
+              },
+              les: null
             }
           }
         ]


### PR DESCRIPTION
It seems that from 1.6 the `parity_netPeers` RPC call could return peers with `null` protocol. The UI wouldn't properly work.