### PR TITLE
Add a Playground for the UI Components

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -174,6 +174,7 @@
     "react-copy-to-clipboard": "4.2.3",
     "react-dom": "15.4.1",
     "react-dropzone": "3.7.3",
+    "react-element-to-jsx-string": "6.0.0",
     "react-intl": "2.1.5",
     "react-portal": "3.0.0",
     "react-redux": "4.4.6",

--- a/js/src/playground/index.js
+++ b/js/src/playground/index.js
@@ -1,4 +1,4 @@
-// Copyright 2015, 2016 Parity Technologies (UK) Ltd.
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/js/src/playground/index.js
+++ b/js/src/playground/index.js
@@ -1,0 +1,17 @@
+// Copyright 2015, 2016 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+export default from './playground';

--- a/js/src/playground/playground.css
+++ b/js/src/playground/playground.css
@@ -1,4 +1,4 @@
-/* Copyright 2015, 2016 Parity Technologies (UK) Ltd.
+/* Copyright 2015-2017 Parity Technologies (UK) Ltd.
 /* This file is part of Parity.
 /*
 /* Parity is free software: you can redistribute it and/or modify

--- a/js/src/playground/playground.css
+++ b/js/src/playground/playground.css
@@ -69,11 +69,10 @@
 
   .code {
     flex: 1;
-    padding-right: 0.5em;
     overflow: auto;
     padding: 0.5em;
-    background-color: #002B36;
-    color: #93A1A1;
+    background-color: #002b36;
+    color: #93a1a1;
     font-size: 0.75em;
 
     code {

--- a/js/src/playground/playground.css
+++ b/js/src/playground/playground.css
@@ -23,4 +23,66 @@
   bottom: 0;
   left: 0;
   padding: 1em;
+  display: flex;
+  flex-direction: column;
+
+  .examples {
+    flex: 1;
+    overflow: auto;
+  }
+}
+
+.title {
+  font-size: 2.25em;
+  margin-bottom: 1em;
+
+  .select {
+    font-size: 0.85em;
+    font-family: monospace;
+    display: inline-block;
+    height: 1.5em;
+    border: 1px solid #aaa;
+    padding: 0 0.5em;
+    color: #555;
+    appearance: none;
+  }
+}
+
+.exampleContainer {
+  background-color: rgba(0, 0, 0, 0.5);
+  padding: 1em;
+  margin-bottom: 1em;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+
+  p {
+    font-size: 1.25em;
+    margin-top: 0;
+  }
+}
+
+.example {
+  display: flex;
+  flex-direction: row;
+
+  .code {
+    flex: 1;
+    padding-right: 0.5em;
+    overflow: auto;
+    padding: 0.5em;
+    background-color: #002B36;
+    color: #93A1A1;
+    font-size: 0.75em;
+
+    code {
+      white-space: pre;
+    }
+  }
+
+  .component {
+    flex: 3;
+    padding-left: 0.5em;
+  }
 }

--- a/js/src/playground/playground.css
+++ b/js/src/playground/playground.css
@@ -22,6 +22,5 @@
   right: 0;
   bottom: 0;
   left: 0;
-
   padding: 1em;
 }

--- a/js/src/playground/playground.css
+++ b/js/src/playground/playground.css
@@ -1,0 +1,27 @@
+/* Copyright 2015, 2016 Parity Technologies (UK) Ltd.
+/* This file is part of Parity.
+/*
+/* Parity is free software: you can redistribute it and/or modify
+/* it under the terms of the GNU General Public License as published by
+/* the Free Software Foundation, either version 3 of the License, or
+/* (at your option) any later version.
+/*
+/* Parity is distributed in the hope that it will be useful,
+/* but WITHOUT ANY WARRANTY; without even the implied warranty of
+/* MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+/* GNU General Public License for more details.
+/*
+/* You should have received a copy of the GNU General Public License
+/* along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+*/
+
+.container {
+  background-color: rgba(0, 0, 0, 0.5);
+  position: fixed;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  left: 0;
+
+  padding: 1em;
+}

--- a/js/src/playground/playground.css
+++ b/js/src/playground/playground.css
@@ -15,6 +15,9 @@
 /* along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 */
 
+$codeBackground: #002b36;
+$codeColor: #93a1a1;
+
 .container {
   background-color: rgba(0, 0, 0, 0.5);
   position: fixed;
@@ -71,8 +74,8 @@
     flex: 1;
     overflow: auto;
     padding: 0.5em;
-    background-color: #002b36;
-    color: #93a1a1;
+    background-color: #$codeBackground;
+    color: $codeColor;
     font-size: 0.75em;
 
     code {

--- a/js/src/playground/playground.js
+++ b/js/src/playground/playground.js
@@ -1,4 +1,4 @@
-// Copyright 2015, 2016 Parity Technologies (UK) Ltd.
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/js/src/playground/playground.js
+++ b/js/src/playground/playground.js
@@ -17,12 +17,12 @@
 import { observer } from 'mobx-react';
 import React, { Component } from 'react';
 
-import PlaygroundStore from './store';
-import styles from './playground.css';
-
 import CurrencySymbol from '~/ui/CurrencySymbol/currencySymbol.example';
 import QrCode from '~/ui/QrCode/qrCode.example';
 import SectionList from '~/ui/SectionList/sectionList.example';
+
+import PlaygroundStore from './store';
+import styles from './playground.css';
 
 PlaygroundStore.register(<CurrencySymbol />);
 PlaygroundStore.register(<QrCode />);

--- a/js/src/playground/playground.js
+++ b/js/src/playground/playground.js
@@ -14,20 +14,75 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
+import { observer } from 'mobx-react';
 import React, { Component } from 'react';
 
-import SectionList from '~/ui/SectionList/sectionList.example.js';
-
+import PlaygroundStore from './store';
 import styles from './playground.css';
 
+import CurrencySymbol from '~/ui/CurrencySymbol/currencySymbol.example';
+import QrCode from '~/ui/QrCode/qrCode.example';
+import SectionList from '~/ui/SectionList/sectionList.example';
+
+PlaygroundStore.register(<CurrencySymbol />);
+PlaygroundStore.register(<QrCode />);
+PlaygroundStore.register(<SectionList />);
+
+@observer
 export default class Playground extends Component {
+  state = {
+    selectedIndex: 0
+  };
+
+  store = PlaygroundStore.get();
+
   render () {
     return (
       <div className={ styles.container }>
-        <h1>Playground</h1>
+        <div className={ styles.title }>
+          <span>Playground > </span>
+          <select
+            className={ styles.select }
+            onChange={ this.handleChange }
+          >
+            { this.renderOptions() }
+          </select>
+        </div>
 
-        <SectionList />
+        <div className={ styles.examples }>
+          { this.renderComponent() }
+        </div>
       </div>
     );
+  }
+
+  renderOptions () {
+    const { components } = this.store;
+
+    return components.map((element, index) => {
+      const name = element.type.displayName || element.type.name;
+
+      return (
+        <option
+          key={ `${name}_${index}` }
+          value={ index }
+        >
+          { name }
+        </option>
+      );
+    });
+  }
+
+  renderComponent () {
+    const { components } = this.store;
+    const { selectedIndex } = this.state;
+
+    return components[selectedIndex];
+  }
+
+  handleChange = (event) => {
+    const { value } = event.target;
+
+    this.setState({ selectedIndex: value });
   }
 }

--- a/js/src/playground/playground.js
+++ b/js/src/playground/playground.js
@@ -1,0 +1,33 @@
+// Copyright 2015, 2016 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+import React, { Component } from 'react';
+
+import SectionList from '~/ui/SectionList/sectionList.example.js';
+
+import styles from './playground.css';
+
+export default class Playground extends Component {
+  render () {
+    return (
+      <div className={ styles.container }>
+        <h1>Playground</h1>
+
+        <SectionList />
+      </div>
+    );
+  }
+}

--- a/js/src/playground/playground.spec.js
+++ b/js/src/playground/playground.spec.js
@@ -1,0 +1,47 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import Playground from './playground';
+
+let component;
+let options;
+
+function render (props = {}) {
+  component = shallow(
+    <Playground />
+  );
+
+  options = component.find('option');
+
+  return component;
+}
+
+describe('playground', () => {
+  beforeEach(() => {
+    render();
+  });
+
+  it('renders defaults', () => {
+    expect(component).to.be.ok;
+  });
+
+  it('renders multiple options', () => {
+    expect(options.length).to.be.greaterThan(2);
+  });
+});

--- a/js/src/playground/playgroundExample.js
+++ b/js/src/playground/playgroundExample.js
@@ -1,4 +1,4 @@
-// Copyright 2015, 2016 Parity Technologies (UK) Ltd.
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/js/src/playground/playgroundExample.js
+++ b/js/src/playground/playgroundExample.js
@@ -15,51 +15,41 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 import React, { Component, PropTypes } from 'react';
-import { connect } from 'react-redux';
+import reactElementToJSXString from 'react-element-to-jsx-string';
 
-const SYMBOL_ETC = 'ETC';
-const SYMBOL_ETH = 'ETH';
-const SYMBOL_EXP = 'EXP';
+import styles from './playground.css';
 
-export class CurrencySymbol extends Component {
+export default class PlaygroundExample extends Component {
   static propTypes = {
-    className: PropTypes.string,
-    netChain: PropTypes.string.isRequired,
-  }
+    children: PropTypes.node,
+    name: PropTypes.string
+  };
 
   render () {
-    const { className } = this.props;
+    const { children, name } = this.props;
 
     return (
-      <span className={ className }>{ this.renderSymbol() }</span>
+      <div className={ styles.exampleContainer }>
+        { this.renderName(name) }
+        <div className={ styles.example }>
+          <div className={ styles.code }>
+            <code>{ reactElementToJSXString(children) }</code>
+          </div>
+          <div className={ styles.component }>
+            { children }
+          </div>
+        </div>
+      </div>
     );
   }
 
-  renderSymbol () {
-    const { netChain } = this.props;
-
-    switch (netChain) {
-      case 'classic':
-        return SYMBOL_ETC;
-
-      case 'expanse':
-        return SYMBOL_EXP;
-
-      default:
-        return SYMBOL_ETH;
+  renderName (name) {
+    if (!name) {
+      return null;
     }
+
+    return (
+      <p>{ name }</p>
+    );
   }
 }
-
-function mapStateToProps (state) {
-  const { netChain } = state.nodeStatus;
-
-  return {
-    netChain
-  };
-}
-
-export default connect(
-  mapStateToProps,
-  null
-)(CurrencySymbol);

--- a/js/src/playground/store.js
+++ b/js/src/playground/store.js
@@ -1,4 +1,4 @@
-// Copyright 2015, 2016 Parity Technologies (UK) Ltd.
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/js/src/playground/store.js
+++ b/js/src/playground/store.js
@@ -41,7 +41,7 @@ export default class PlaygroundStore {
 
       return name && cName && cName === name;
     });
-console.warn(name, hasComponent, component);
+
     if (hasComponent) {
       return;
     }

--- a/js/src/playground/store.js
+++ b/js/src/playground/store.js
@@ -1,0 +1,51 @@
+// Copyright 2015, 2016 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+import { action, observable } from 'mobx';
+
+let instance = null;
+
+export default class PlaygroundStore {
+  @observable components = [];
+
+  static get () {
+    if (!instance) {
+      instance = new PlaygroundStore();
+    }
+
+    return instance;
+  }
+
+  static register (component) {
+    PlaygroundStore.get().add(component);
+  }
+
+  @action
+  add (component) {
+    const name = component.type.displayName || component.type.name;
+    const hasComponent = this.components.find((c) => {
+      const cName = c.type.displayName || c.type.name;
+
+      return name && cName && cName === name;
+    });
+console.warn(name, hasComponent, component);
+    if (hasComponent) {
+      return;
+    }
+
+    this.components.push(component);
+  }
+}

--- a/js/src/playground/store.spec.js
+++ b/js/src/playground/store.spec.js
@@ -1,0 +1,40 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+import React from 'react';
+
+import QrCode from '~/ui/QrCode/qrCode.example';
+
+import PlaygroundStore from './store';
+
+describe('playground/store', () => {
+  let store = PlaygroundStore.get();
+
+  it('is available', () => {
+    expect(store).to.be.ok;
+  });
+
+  it('adds new Components', () => {
+    PlaygroundStore.register(<QrCode />);
+    expect(store.components.length).equal(1);
+  });
+
+  it('adds new Components only once', () => {
+    PlaygroundStore.register(<QrCode />);
+    PlaygroundStore.register(<QrCode />);
+    expect(store.components.length).equal(1);
+  });
+});

--- a/js/src/playground/store.spec.js
+++ b/js/src/playground/store.spec.js
@@ -24,17 +24,18 @@ describe('playground/store', () => {
   let store = PlaygroundStore.get();
 
   it('is available', () => {
-    expect(store).to.be.ok;
+    expect(PlaygroundStore.get()).to.be.ok;
   });
 
   it('adds new Components', () => {
     PlaygroundStore.register(<QrCode />);
-    expect(store.components.length).equal(1);
+    expect(store.components.length).greaterThan(0);
   });
 
   it('adds new Components only once', () => {
     PlaygroundStore.register(<QrCode />);
     PlaygroundStore.register(<QrCode />);
-    expect(store.components.length).equal(1);
+
+    expect(store.components.filter((c) => /QrCode/i.test(c.type.name)).length).equal(1);
   });
 });

--- a/js/src/routes.js
+++ b/js/src/routes.js
@@ -115,6 +115,7 @@ const appRoutes = [
   { path: 'signer', component: Signer }
 ];
 
+// TODO : use ES6 imports when supported
 if (process.env.NODE_ENV !== 'production') {
   const Playground = require('./playground').default;
 

--- a/js/src/routes.js
+++ b/js/src/routes.js
@@ -78,45 +78,56 @@ const routes = [
 
   { path: '/', onEnter: redirectTo('/accounts') },
   { path: '/auth', onEnter: redirectTo('/accounts') },
-  { path: '/settings', onEnter: redirectTo('/settings/views') },
-
-  {
-    path: '/',
-    component: Application,
-    childRoutes: [
-      {
-        path: 'accounts',
-        indexRoute: { component: Accounts },
-        childRoutes: accountsRoutes
-      },
-      {
-        path: 'addresses',
-        indexRoute: { component: Addresses },
-        childRoutes: addressesRoutes
-      },
-      {
-        path: 'contracts',
-        indexRoute: { component: Contracts },
-        childRoutes: contractsRoutes
-      },
-      {
-        path: 'status',
-        indexRoute: { component: Status },
-        childRoutes: statusRoutes
-      },
-      {
-        path: 'settings',
-        component: Settings,
-        childRoutes: settingsRoutes
-      },
-
-      { path: 'apps', component: Dapps },
-      { path: 'app/:id', component: Dapp },
-      { path: 'web', component: Web },
-      { path: 'web/:url', component: Web },
-      { path: 'signer', component: Signer }
-    ]
-  }
+  { path: '/settings', onEnter: redirectTo('/settings/views') }
 ];
+
+const appRoutes = [
+  {
+    path: 'accounts',
+    indexRoute: { component: Accounts },
+    childRoutes: accountsRoutes
+  },
+  {
+    path: 'addresses',
+    indexRoute: { component: Addresses },
+    childRoutes: addressesRoutes
+  },
+  {
+    path: 'contracts',
+    indexRoute: { component: Contracts },
+    childRoutes: contractsRoutes
+  },
+  {
+    path: 'status',
+    indexRoute: { component: Status },
+    childRoutes: statusRoutes
+  },
+  {
+    path: 'settings',
+    component: Settings,
+    childRoutes: settingsRoutes
+  },
+
+  { path: 'apps', component: Dapps },
+  { path: 'app/:id', component: Dapp },
+  { path: 'web', component: Web },
+  { path: 'web/:url', component: Web },
+  { path: 'signer', component: Signer }
+];
+
+if (process.env.NODE_ENV !== 'production') {
+  const Playground = require('./playground').default;
+
+  appRoutes.push({
+    path: 'playground',
+    component: Playground
+  });
+}
+
+routes.push({
+  path: '/',
+  component: Application,
+  childRoutes: appRoutes
+});
 
 export default routes;

--- a/js/src/ui/CurrencySymbol/currencySymbol.example.js
+++ b/js/src/ui/CurrencySymbol/currencySymbol.example.js
@@ -1,4 +1,4 @@
-// Copyright 2015, 2016 Parity Technologies (UK) Ltd.
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/js/src/ui/CurrencySymbol/currencySymbol.example.js
+++ b/js/src/ui/CurrencySymbol/currencySymbol.example.js
@@ -18,12 +18,16 @@ import React, { Component } from 'react';
 
 import PlaygroundExample from '~/playground/playgroundExample';
 
-import { CurrencySymbol } from './currencySymbol';
+import ConnectedCurrencySymbol, { CurrencySymbol } from './currencySymbol';
 
 export default class CurrencySymbolExample extends Component {
   render () {
     return (
       <div>
+        <PlaygroundExample name='Connected Currency Symbol'>
+          <ConnectedCurrencySymbol />
+        </PlaygroundExample>
+
         <PlaygroundExample name='Simple Currency Symbol'>
           <CurrencySymbol
             netChain='testnet'

--- a/js/src/ui/CurrencySymbol/currencySymbol.example.js
+++ b/js/src/ui/CurrencySymbol/currencySymbol.example.js
@@ -1,0 +1,47 @@
+// Copyright 2015, 2016 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+import React, { Component } from 'react';
+
+import PlaygroundExample from '~/playground/playgroundExample';
+
+import { CurrencySymbol } from './currencySymbol';
+
+export default class CurrencySymbolExample extends Component {
+  render () {
+    return (
+      <div>
+        <PlaygroundExample name='Simple Currency Symbol'>
+          <CurrencySymbol
+            netChain='testnet'
+          />
+        </PlaygroundExample>
+
+        <PlaygroundExample name='ETC Currency Symbol'>
+          <CurrencySymbol
+            netChain='classic'
+          />
+        </PlaygroundExample>
+
+        <PlaygroundExample name='EXP Currency Symbol'>
+          <CurrencySymbol
+            netChain='expanse'
+          />
+        </PlaygroundExample>
+      </div>
+    );
+  }
+}

--- a/js/src/ui/CurrencySymbol/currencySymbol.js
+++ b/js/src/ui/CurrencySymbol/currencySymbol.js
@@ -24,7 +24,7 @@ const SYMBOL_EXP = 'EXP';
 export class CurrencySymbol extends Component {
   static propTypes = {
     className: PropTypes.string,
-    netChain: PropTypes.string.isRequired,
+    netChain: PropTypes.string.isRequired
   }
 
   render () {

--- a/js/src/ui/CurrencySymbol/currencySymbol.spec.js
+++ b/js/src/ui/CurrencySymbol/currencySymbol.spec.js
@@ -78,4 +78,22 @@ describe('ui/CurrencySymbol', () => {
       expect(render('somethingElse').text()).equal('ETH');
     });
   });
+
+  describe('renderSymbol', () => {
+    it('render defaults', () => {
+      expect(render().instance().renderSymbol()).to.be.ok;
+    });
+
+    it('render ETH as default', () => {
+      expect(render().instance().renderSymbol()).equal('ETH');
+    });
+
+    it('render ETC', () => {
+      expect(render('classic').instance().renderSymbol()).equal('ETC');
+    });
+
+    it('render EXP', () => {
+      expect(render('expanse').instance().renderSymbol()).equal('EXP');
+    });
+  });
 });

--- a/js/src/ui/QrCode/qrCode.example.js
+++ b/js/src/ui/QrCode/qrCode.example.js
@@ -1,4 +1,4 @@
-// Copyright 2015, 2016 Parity Technologies (UK) Ltd.
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/js/src/ui/QrCode/qrCode.example.js
+++ b/js/src/ui/QrCode/qrCode.example.js
@@ -1,0 +1,49 @@
+// Copyright 2015, 2016 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+import React, { Component } from 'react';
+
+import PlaygroundExample from '~/playground/playgroundExample';
+
+import QrCode from './';
+
+export default class QrCodeExample extends Component {
+  render () {
+    return (
+      <div>
+        <PlaygroundExample name='Simple QRCode'>
+          <QrCode
+            value='this is a test'
+          />
+        </PlaygroundExample>
+
+        <PlaygroundExample name='Simple QRCode with margin'>
+          <QrCode
+            margin={ 10 }
+            value='this is a test'
+          />
+        </PlaygroundExample>
+
+        <PlaygroundExample name='Big QRCode'>
+          <QrCode
+            size={ 10 }
+            value='this is a test'
+          />
+        </PlaygroundExample>
+      </div>
+    );
+  }
+}

--- a/js/src/ui/QrCode/qrCode.example.js
+++ b/js/src/ui/QrCode/qrCode.example.js
@@ -37,6 +37,20 @@ export default class QrCodeExample extends Component {
           />
         </PlaygroundExample>
 
+        <PlaygroundExample name='Ethereum Address QRCode'>
+          <QrCode
+            margin={ 10 }
+            value='0x8c30393085C8C3fb4C1fB16165d9fBac5D86E1D9'
+          />
+        </PlaygroundExample>
+
+        <PlaygroundExample name='Bitcoin Address QRCode'>
+          <QrCode
+            margin={ 10 }
+            value='3J98t1WpEZ73CNmQviecrnyiWrnqRhWNLy'
+          />
+        </PlaygroundExample>
+
         <PlaygroundExample name='Big QRCode'>
           <QrCode
             size={ 10 }

--- a/js/src/ui/SectionList/sectionList.example.js
+++ b/js/src/ui/SectionList/sectionList.example.js
@@ -1,4 +1,4 @@
-// Copyright 2015, 2016 Parity Technologies (UK) Ltd.
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/js/src/ui/SectionList/sectionList.example.js
+++ b/js/src/ui/SectionList/sectionList.example.js
@@ -16,6 +16,7 @@
 
 import React, { Component } from 'react';
 
+import PlaygroundExample from '~/playground/playgroundExample';
 import SectionList from './';
 
 const ITEM_STYLE = {
@@ -38,11 +39,13 @@ export default class SectionListExample extends Component {
   render () {
     return (
       <div>
-        <p>Simple Usage</p>
-        { this.renderSimple() }
+        <PlaygroundExample name='Simple Usage'>
+          { this.renderSimple() }
+        </PlaygroundExample>
 
-        <p>With Overlay</p>
-        { this.renderWithOverlay() }
+        <PlaygroundExample name='With Overlay'>
+          { this.renderWithOverlay() }
+        </PlaygroundExample>
       </div>
     );
   }
@@ -59,8 +62,9 @@ export default class SectionListExample extends Component {
   renderWithOverlay () {
     const { showOverlay } = this.state;
     const overlay = (
-      <div onClick={ this.hideOverlay }>
+      <div>
         <p>Overlay</p>
+        <button onClick={ this.hideOverlay }>hide</button>
       </div>
     );
 
@@ -73,11 +77,7 @@ export default class SectionListExample extends Component {
     );
   }
 
-  hideOverlay = () => {
-    this.setState({ showOverlay: false });
-  }
-
-  renderItem = (item, index) => {
+  renderItem (item, index) {
     const { desc, name } = item;
 
     return (
@@ -86,5 +86,9 @@ export default class SectionListExample extends Component {
         <h3 data-hover='show'>{ desc }</h3>
       </div>
     );
+  }
+
+  hideOverlay = () => {
+    this.setState({ showOverlay: false });
   }
 }

--- a/js/src/ui/SectionList/sectionList.example.js
+++ b/js/src/ui/SectionList/sectionList.example.js
@@ -1,0 +1,90 @@
+// Copyright 2015, 2016 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+import React, { Component } from 'react';
+
+import SectionList from './';
+
+const ITEM_STYLE = {
+  backgroundColor: 'rgba(0, 0, 0, 0.75)',
+  padding: '1em'
+};
+
+const items = [
+  { name: 'Jack', desc: 'Item number 1' },
+  { name: 'Paul', desc: 'Item number 2' },
+  { name: 'Matt', desc: 'Item number 3' },
+  { name: 'Titi', desc: 'Item number 4' }
+];
+
+export default class SectionListExample extends Component {
+  state = {
+    showOverlay: true
+  };
+
+  render () {
+    return (
+      <div>
+        <p>Simple Usage</p>
+        { this.renderSimple() }
+
+        <p>With Overlay</p>
+        { this.renderWithOverlay() }
+      </div>
+    );
+  }
+
+  renderSimple () {
+    return (
+      <SectionList
+        items={ items }
+        renderItem={ this.renderItem }
+      />
+    );
+  }
+
+  renderWithOverlay () {
+    const { showOverlay } = this.state;
+    const overlay = (
+      <div onClick={ this.hideOverlay }>
+        <p>Overlay</p>
+      </div>
+    );
+
+    return (
+      <SectionList
+        items={ items }
+        overlay={ showOverlay ? overlay : null }
+        renderItem={ this.renderItem }
+      />
+    );
+  }
+
+  hideOverlay = () => {
+    this.setState({ showOverlay: false });
+  }
+
+  renderItem = (item, index) => {
+    const { desc, name } = item;
+
+    return (
+      <div style={ ITEM_STYLE }>
+        <h3>{ name }</h3>
+        <h3 data-hover='show'>{ desc }</h3>
+      </div>
+    );
+  }
+}

--- a/js/src/views/Application/application.js
+++ b/js/src/views/Application/application.js
@@ -57,6 +57,14 @@ class Application extends Component {
     const [root] = (window.location.hash || '').replace('#/', '').split('/');
     const isMinimized = root === 'app' || root === 'web';
 
+    if (process.env.NODE_ENV !== 'production' && root === 'playground') {
+      return (
+        <div>
+          { this.props.children }
+        </div>
+      );
+    }
+
     if (inFrame) {
       return (
         <FrameError />


### PR DESCRIPTION
Add a Playground to the UI, accessible via http://localhost:3000/#/playground
It's only available in non-dev environments (won't get included in production build).

Each UI Component can (and should) have a `foobar.example.js` that lists different uses-cases of the component, which props are passed, etc.

![image](https://cloud.githubusercontent.com/assets/2864519/22293479/fbda9702-e30f-11e6-96c8-51eb0d711196.png)
