### PR TITLE
HistoryStore for tracking relevant routes

### DIFF
--- a/js/src/routes.js
+++ b/js/src/routes.js
@@ -1,4 +1,4 @@
-// Copyright 2015-2016 Parity Technologies (UK) Ltd.
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
 // This file is part of Parity.
 
 // Parity is free software: you can redistribute it and/or modify

--- a/js/src/routes.js
+++ b/js/src/routes.js
@@ -86,8 +86,8 @@ const routes = [
   { path: '/address/:address', onEnter: handleDeprecatedRoute },
   { path: '/contract/:address', onEnter: handleDeprecatedRoute },
 
-  { path: '/', onEnter: redirectTo('/home') },
-  { path: '/auth', onEnter: redirectTo('/home') },
+  { path: '/', onEnter: redirectTo('/accounts') },
+  { path: '/auth', onEnter: redirectTo('/accounts') },
   { path: '/settings', onEnter: redirectTo('/settings/views') },
 
   {

--- a/js/src/views/Dapps/builtin.json
+++ b/js/src/views/Dapps/builtin.json
@@ -72,7 +72,8 @@
     "author": "Parity Team <admin@ethcore.io>",
     "version": "1.0.0",
     "visible": true,
-    "skipBuild": true
+    "skipBuild": true,
+    "skipHistory": true
   },
   {
     "id": "0xa635a9326814bded464190eddf0bdb90ce92d40ea2359cf553ea80e3c5a4076c",

--- a/js/src/views/historyStore.js
+++ b/js/src/views/historyStore.js
@@ -1,0 +1,61 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+import { action, observable } from 'mobx';
+import localStore from 'store';
+
+const LS_KEY = '_parity::history';
+const MAX_ENTRIES = 5;
+
+const instances = {};
+
+export default class Store {
+  @observable history = [];
+
+  constructor (type) {
+    this.historyKey = `${LS_KEY}::${type}`;
+    this.load();
+  }
+
+  @action add = (entry) => {
+    this.history = [{
+      timestamp: Date.now(),
+      entry
+    }].concat(this.history.filter((h) => h.entry !== entry)).slice(0, MAX_ENTRIES);
+    this.save();
+  }
+
+  @action clear = () => {
+    this.history = [];
+    this.save();
+  }
+
+  @action load = () => {
+    this.history = localStore.get(this.historyKey) || [];
+  }
+
+  save = () => {
+    return localStore.set(this.historyKey, this.history);
+  }
+
+  static get (type) {
+    if (!instances[type]) {
+      instances[type] = new Store(type);
+    }
+
+    return instances[type];
+  }
+}

--- a/js/src/views/historyStore.spec.js
+++ b/js/src/views/historyStore.spec.js
@@ -1,0 +1,71 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+import Store from './historyStore';
+
+const TEST_ENTRY_1 = 'testing 1';
+const TEST_ENTRY_2 = 'testing 2';
+const TEST_ENTRY_3 = 'testing 3';
+
+let store;
+
+function create () {
+  store = Store.get('test');
+  store.clear();
+
+  return store;
+}
+
+describe('views/HistoryStore', () => {
+  beforeEach(() => {
+    create();
+  });
+
+  describe('@action', () => {
+    describe('add', () => {
+      it('adds the url to the list (front)', () => {
+        store.add(TEST_ENTRY_1);
+        expect(store.history[0].entry).to.equal(TEST_ENTRY_1);
+      });
+
+      it('adds multiples to the list', () => {
+        store.add(TEST_ENTRY_1);
+        store.add(TEST_ENTRY_2);
+
+        expect(store.history.length).to.equal(2);
+        expect(store.history[0].entry).to.equal(TEST_ENTRY_2);
+        expect(store.history[1].entry).to.equal(TEST_ENTRY_1);
+      });
+
+      it('does not add duplicates', () => {
+        store.add(TEST_ENTRY_2);
+        store.add(TEST_ENTRY_2);
+
+        expect(store.history.length).to.equal(1);
+        expect(store.history[0].entry).to.equal(TEST_ENTRY_2);
+      });
+    });
+
+    describe('clear', () => {
+      it('empties the list', () => {
+        store.add(TEST_ENTRY_3);
+        store.clear();
+
+        expect(store.history.length).to.equal(0);
+      });
+    });
+  });
+});

--- a/js/src/views/index.js
+++ b/js/src/views/index.js
@@ -21,15 +21,16 @@ import Addresses from './Addresses';
 import Application from './Application';
 import Contract from './Contract';
 import Contracts from './Contracts';
-import WriteContract from './WriteContract';
 import Dapp from './Dapp';
-import Web from './Web';
 import Dapps from './Dapps';
+import HistoryStore from './historyStore';
 import ParityBar from './ParityBar';
 import Settings, { SettingsBackground, SettingsParity, SettingsProxy, SettingsViews } from './Settings';
 import Signer from './Signer';
 import Status from './Status';
 import Wallet from './Wallet';
+import Web from './Web';
+import WriteContract from './WriteContract';
 
 export {
   Account,
@@ -39,9 +40,9 @@ export {
   Application,
   Contract,
   Contracts,
-  WriteContract,
   Dapp,
   Dapps,
+  HistoryStore,
   ParityBar,
   Settings,
   SettingsBackground,
@@ -51,5 +52,6 @@ export {
   Signer,
   Status,
   Wallet,
-  Web
+  Web,
+  WriteContract
 };


### PR DESCRIPTION
Split from https://github.com/ethcore/parity/pull/4178

- stores navigation entries in localstorage
- currently enabled for dapps & accounts
- /home uses these to display the recently-used