### PR TITLE
Contracts interface expansion

### DIFF
--- a/js/src/contracts/githubhint.js
+++ b/js/src/contracts/githubhint.js
@@ -18,6 +18,7 @@ export default class GithubHint {
   constructor (api, registry) {
     this._api = api;
     this._registry = registry;
+    this._instance = null;
 
     this.getInstance();
   }
@@ -27,6 +28,19 @@ export default class GithubHint {
   }
 
   getInstance () {
-    return this.getContract().instance;
+    if (this._instance) {
+      return Promise.resolve(this._instance);
+    }
+
+    return this.getContract().then((contract) => {
+      this._instance = contract.instance;
+      return this._instance;
+    });
+  }
+
+  getEntry (entryId) {
+    return this.getInstance().then((instance) => {
+      return instance.entries.call({}, [entryId]);
+    });
   }
 }

--- a/js/src/contracts/githubhint.spec.js
+++ b/js/src/contracts/githubhint.spec.js
@@ -1,0 +1,66 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+import sinon from 'sinon';
+
+import GithubHint from './githubhint';
+
+let githubHint;
+let instance;
+let registry;
+
+function create () {
+  instance = {
+    __id: 'testInstance',
+    entries: {
+      call: sinon.stub().resolves('testValue')
+    }
+  };
+  registry = {
+    getContract: sinon.stub().resolves({ instance })
+  };
+  githubHint = new GithubHint({}, registry);
+
+  return githubHint;
+}
+
+describe('contracts/GithubHint', () => {
+  beforeEach(() => {
+    create();
+
+    return githubHint.getInstance();
+  });
+
+  it('instantiates successfully', () => {
+    expect(githubHint).to.be.ok;
+  });
+
+  it('attaches the instance on create', () => {
+    expect(githubHint._instance.__id).to.equal('testInstance');
+  });
+
+  describe('interface', () => {
+    describe('getEntry', () => {
+      beforeEach(() => {
+        return githubHint.getEntry('testId');
+      });
+
+      it('calls entries on the instance', () => {
+        expect(instance.entries.call).to.have.been.calledWith({}, ['testId']);
+      });
+    });
+  });
+});

--- a/js/src/contracts/registry.js
+++ b/js/src/contracts/registry.js
@@ -89,29 +89,34 @@ export default class Registry {
       .then((contract) => contract.instance);
   }
 
-  lookupAddress (_name) {
+  _createGetParams (_name, key) {
     const name = _name.toLowerCase();
     const sha3 = this._api.util.sha3.text(name);
 
-    return this.getInstance().then((instance) => {
-      return instance.getAddress.call({}, [sha3, 'A']);
-    })
-    .then((address) => {
-      console.log('[lookupAddress]', `(${sha3}) ${name}: ${address}`);
-      return address;
-    });
+    return [sha3, key];
   }
 
-  lookupMeta (_name, key) {
-    const name = _name.toLowerCase();
-    const sha3 = this._api.util.sha3.text(name);
+  lookupAddress (name) {
+    return this
+      .getInstance()
+      .then((instance) => {
+        return instance.getAddress.call({}, this._createGetParams(name, 'A'));
+      })
+      .then((address) => {
+        console.log('[lookupAddress]', `${name}: ${address}`);
+        return address;
+      });
+  }
 
-    return this.getInstance().then((instance) => {
-      return instance.get.call({}, [sha3, key]);
-    })
-    .then((meta) => {
-      console.log('[lookupMeta]', `(${sha3}) ${name}.${key}: ${meta}`);
-      return meta;
-    });
+  lookupMeta (name, key) {
+    return this
+      .getInstance()
+      .then((instance) => {
+        return instance.get.call({}, this._createGetParams(name, key));
+      })
+      .then((meta) => {
+        console.log('[lookupMeta]', `${name}.${key}: ${meta}`);
+        return meta;
+      });
   }
 }

--- a/js/src/contracts/registry.js
+++ b/js/src/contracts/registry.js
@@ -113,10 +113,6 @@ export default class Registry {
       .getInstance()
       .then((instance) => {
         return instance.get.call({}, this._createGetParams(name, key));
-      })
-      .then((meta) => {
-        console.log('[lookupMeta]', `${name}.${key}: ${meta}`);
-        return meta;
       });
   }
 }

--- a/js/src/contracts/registry.js
+++ b/js/src/contracts/registry.js
@@ -101,4 +101,17 @@ export default class Registry {
       return address;
     });
   }
+
+  lookupMeta (_name, key) {
+    const name = _name.toLowerCase();
+    const sha3 = this._api.util.sha3.text(name);
+
+    return this.getInstance().then((instance) => {
+      return instance.get.call({}, [sha3, key]);
+    })
+    .then((meta) => {
+      console.log('[lookupMeta]', `(${sha3}) ${name}.${key}: ${meta}`);
+      return meta;
+    });
+  }
 }

--- a/js/src/contracts/registry.spec.js
+++ b/js/src/contracts/registry.spec.js
@@ -1,0 +1,83 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+import sinon from 'sinon';
+
+import apiutil from '~/api/util';
+
+import Registry from './registry';
+
+const GHH_NAME = 'githubhint';
+const GHH_SHA3 = '0x058740ee9a5a3fb9f1cfa10752baec87e09cc45cd7027fd54708271aca300c75';
+
+let api;
+let instance;
+let registry;
+
+function create () {
+  instance = {
+    __id: 'testInstance',
+    get: {
+      call: sinon.stub().resolves('testGet')
+    }
+  };
+  api = {
+    parity: {
+      registryAddress: sinon.stub().resolves('testRegistryAddress')
+    },
+    util: apiutil,
+    newContract: sinon.stub().returns({ instance })
+  };
+  registry = new Registry(api);
+
+  return registry;
+}
+
+describe('contracts/Registry', () => {
+  beforeEach(() => {
+    create();
+
+    return registry.getInstance();
+  });
+
+  it('instantiates successfully', () => {
+    expect(registry).to.be.ok;
+  });
+
+  it('retrieves the registry on create', () => {
+    expect(api.parity.registryAddress).to.have.been.called;
+  });
+
+  it('attaches the instance on create', () => {
+    expect(registry._instance.__id).to.equal('testInstance');
+  });
+
+  describe('interface', () => {
+    describe('lookupMeta', () => {
+      it('calls get on the contract', () => {
+        return registry.lookupMeta(GHH_NAME, 'key').then(() => {
+          expect(instance.get.call).to.have.been.calledWith({}, [GHH_SHA3, 'key']);
+        });
+      });
+
+      it('converts names to lowercase', () => {
+        return registry.lookupMeta(GHH_NAME.toUpperCase(), 'key').then(() => {
+          expect(instance.get.call).to.have.been.calledWith({}, [GHH_SHA3, 'key']);
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
0. Modify `contracts/Registry` to have `lookupMeta` (interface to contract `get`) method
0. Fixed `contracts/GithubHint` to retrieve instance properly & add `getEntry` to retrieve a specific entry

(Split from https://github.com/ethcore/parity/pull/4178)
