### PR TITLE
Split Dapp icon into ui/DappIcon (re-use)

### DIFF
--- a/js/src/ui/DappIcon/dappIcon.css
+++ b/js/src/ui/DappIcon/dappIcon.css
@@ -15,27 +15,17 @@
 /* along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-.container {
-  height: 100%;
-  position: relative;
+.icon {
+  border-radius: 50%;
+  margin: 0 0.75em 0 0;
 }
 
-.image {
-  left: 1.5em;
-  position: absolute;
-  top: 1.5em;
+.normal {
+  height: 56px;
+  width: 56px;
 }
 
-.description {
-  margin-left: 72px;
-}
-
-.title {
-  mragin-bottom: 0.5em;
-}
-
-.author, .version {
-  font-size: 0.75em;
-  opacity: 0.5;
-  margin-top: 0.5em;
+.small {
+  height: 32px;
+  width: 32px;
 }

--- a/js/src/ui/DappIcon/dappIcon.js
+++ b/js/src/ui/DappIcon/dappIcon.js
@@ -1,0 +1,49 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+import React, { Component, PropTypes } from 'react';
+
+import styles from './dappIcon.css';
+
+export default class DappIcon extends Component {
+  static contextTypes = {
+    api: PropTypes.object.isRequired
+  };
+
+  static propTypes = {
+    app: PropTypes.object.isRequired,
+    className: PropTypes.string,
+    small: PropTypes.bool
+  };
+
+  render () {
+    const { dappsUrl } = this.context.api;
+    const { app, className, small } = this.props;
+
+    return (
+      <img
+        className={
+          [styles.icon, styles[small ? 'small' : 'normal'], className].join(' ')
+        }
+        src={
+          app.type === 'local'
+            ? `${dappsUrl}/${app.id}/${app.iconUrl}`
+            : `${dappsUrl}${app.image}`
+        }
+      />
+    );
+  }
+}

--- a/js/src/ui/DappIcon/dappIcon.spec.js
+++ b/js/src/ui/DappIcon/dappIcon.spec.js
@@ -1,0 +1,70 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+import { shallow } from 'enzyme';
+import React from 'react';
+
+import DappIcon from './';
+
+const DAPPS_URL = 'http://test';
+
+let api;
+let component;
+
+function createApi () {
+  api = {
+    dappsUrl: DAPPS_URL
+  };
+
+  return api;
+}
+
+function render (props = {}) {
+  if (!props.app) {
+    props.app = {};
+  }
+
+  component = shallow(
+    <DappIcon { ...props } />,
+    {
+      context: { api: createApi() }
+    }
+  );
+
+  return component;
+}
+
+describe('ui/DappIcon', () => {
+  it('renders defaults', () => {
+    expect(render()).to.be.ok;
+  });
+
+  it('adds specified className', () => {
+    expect(render({ className: 'testClass' }).hasClass('testClass')).to.be.true;
+  });
+
+  it('renders local apps with correct URL', () => {
+    expect(render({ app: { id: 'test', type: 'local', iconUrl: 'test.img' } }).props().src).to.equal(
+      `${DAPPS_URL}/test/test.img`
+    );
+  });
+
+  it('renders other apps with correct URL', () => {
+    expect(render({ app: { id: 'test', image: '/test.img' } }).props().src).to.equal(
+      `${DAPPS_URL}/test.img`
+    );
+  });
+});

--- a/js/src/ui/DappIcon/index.js
+++ b/js/src/ui/DappIcon/index.js
@@ -1,0 +1,17 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+export default from './dappIcon';

--- a/js/src/ui/index.js
+++ b/js/src/ui/index.js
@@ -29,6 +29,7 @@ import Container, { Title as ContainerTitle } from './Container';
 import ContextProvider from './ContextProvider';
 import CopyToClipboard from './CopyToClipboard';
 import CurrencySymbol from './CurrencySymbol';
+import DappIcon from './DappIcon';
 import Editor from './Editor';
 import Errors from './Errors';
 import Features, { FEATURES, FeaturesStore } from './Features';
@@ -74,6 +75,7 @@ export {
   ContextProvider,
   CopyToClipboard,
   CurrencySymbol,
+  DappIcon,
   Editor,
   Errors,
   FEATURES,

--- a/js/src/views/Dapps/Summary/summary.js
+++ b/js/src/views/Dapps/Summary/summary.js
@@ -17,34 +17,31 @@
 import React, { Component, PropTypes } from 'react';
 import { Link } from 'react-router';
 
-import { Container, ContainerTitle, Tags } from '~/ui';
+import { Container, ContainerTitle, DappIcon, Tags } from '~/ui';
 
 import styles from './summary.css';
 
 export default class Summary extends Component {
-  static contextTypes = {
-    api: React.PropTypes.object
-  }
-
   static propTypes = {
     app: PropTypes.object.isRequired,
     children: PropTypes.node
   }
 
   render () {
-    const { dappsUrl } = this.context.api;
     const { app } = this.props;
 
     if (!app) {
       return null;
     }
 
-    const image = this.renderImage(dappsUrl, app);
     const link = this.renderLink(app);
 
     return (
       <Container className={ styles.container }>
-        { image }
+        <DappIcon
+          app={ app }
+          className={ styles.image }
+        />
         <Tags tags={ [app.type] } />
         <div className={ styles.description }>
           <ContainerTitle
@@ -58,18 +55,6 @@ export default class Summary extends Component {
           { this.props.children }
         </div>
       </Container>
-    );
-  }
-
-  renderImage (dappsUrl, app) {
-    if (app.type === 'local') {
-      return (
-        <img src={ `${dappsUrl}/${app.id}/${app.iconUrl}` } className={ styles.image } />
-      );
-    }
-
-    return (
-      <img src={ `${dappsUrl}${app.image}` } className={ styles.image } />
     );
   }
 


### PR DESCRIPTION
Split from https://github.com/ethcore/parity/pull/4178

Create a re-usable DappIcon component that renders the icon associated with a specific dapp (along the same lines as IdentityIcon for addresses)