### PR TITLE
Returning default account as coinbase + allow altering sender in signer

### DIFF
--- a/rpc/src/v1/impls/signer.rs
+++ b/rpc/src/v1/impls/signer.rs
@@ -76,6 +76,11 @@ impl<C: 'static, M: 'static> SignerClient<C, M> where C: MiningBlockChainClient,
 			let mut payload = confirmation.payload.clone();
 			// Modify payload
 			if let ConfirmationPayload::SendTransaction(ref mut request) = payload {
+				if let Some(sender) = modification.sender.clone() {
+					request.from = sender.into();
+					// Altering sender should always reset the nonce.
+					request.nonce = None;
+				}
 				if let Some(gas_price) = modification.gas_price {
 					request.gas_price = gas_price.into();
 				}

--- a/rpc/src/v1/tests/mocked/eth.rs
+++ b/rpc/src/v1/tests/mocked/eth.rs
@@ -327,7 +327,12 @@ fn rpc_eth_author() {
 		"id": 1
 	}"#;
 
+	// No accounts - returns zero
 	assert_eq!(tester.io.handle_request_sync(req), Some(make_res(Address::zero())));
+
+	// Account set - return first account
+	let addr = tester.accounts_provider.new_account("123").unwrap();
+	assert_eq!(tester.io.handle_request_sync(req), Some(make_res(addr)));
 
 	for i in 0..20 {
 		let addr = tester.accounts_provider.new_account(&format!("{}", i)).unwrap();

--- a/rpc/src/v1/tests/mocked/parity.rs
+++ b/rpc/src/v1/tests/mocked/parity.rs
@@ -25,6 +25,7 @@ use ethstore::ethkey::{Generator, Random};
 
 use jsonrpc_core::IoHandler;
 use v1::{Parity, ParityClient};
+use v1::metadata::Metadata;
 use v1::helpers::{SignerService, NetworkSettings};
 use v1::tests::helpers::{TestSyncProvider, Config, TestMinerService, TestUpdater};
 use super::manage_network::TestManageNetwork;
@@ -86,13 +87,13 @@ impl Dependencies {
 		)
 	}
 
-	fn default_client(&self) -> IoHandler {
+	fn default_client(&self) -> IoHandler<Metadata> {
 		let mut io = IoHandler::default();
 		io.extend_with(self.client(None).to_delegate());
 		io
 	}
 
-	fn with_signer(&self, signer: SignerService) -> IoHandler {
+	fn with_signer(&self, signer: SignerService) -> IoHandler<Metadata> {
 		let mut io = IoHandler::default();
 		io.extend_with(self.client(Some(Arc::new(signer))).to_delegate());
 		io
@@ -120,6 +121,29 @@ fn rpc_parity_accounts_info() {
 	deps.accounts.set_new_dapps_whitelist(Some(vec![1.into()])).unwrap();
 	let request = r#"{"jsonrpc": "2.0", "method": "parity_accountsInfo", "params": [], "id": 1}"#;
 	let response = format!("{{\"jsonrpc\":\"2.0\",\"result\":{{}},\"id\":1}}");
+	assert_eq!(io.handle_request_sync(request), Some(response));
+}
+
+#[test]
+fn rpc_parity_default_account() {
+	let deps = Dependencies::new();
+	let io = deps.default_client();
+
+
+	// Check empty
+	let address = Address::default();
+	let request = r#"{"jsonrpc": "2.0", "method": "parity_defaultAccount", "params": [], "id": 1}"#;
+	let response = format!("{{\"jsonrpc\":\"2.0\",\"result\":\"0x{}\",\"id\":1}}", address.hex());
+	assert_eq!(io.handle_request_sync(request), Some(response));
+
+	// With account
+	deps.accounts.new_account("").unwrap();
+	let accounts = deps.accounts.accounts().unwrap();
+	assert_eq!(accounts.len(), 1);
+	let address = accounts[0];
+
+	let request = r#"{"jsonrpc": "2.0", "method": "parity_defaultAccount", "params": [], "id": 1}"#;
+	let response = format!("{{\"jsonrpc\":\"2.0\",\"result\":\"0x{}\",\"id\":1}}", address.hex());
 	assert_eq!(io.handle_request_sync(request), Some(response));
 }
 

--- a/rpc/src/v1/tests/mocked/signing.rs
+++ b/rpc/src/v1/tests/mocked/signing.rs
@@ -20,6 +20,7 @@ use rlp;
 
 use jsonrpc_core::{IoHandler, Success};
 use v1::impls::SigningQueueClient;
+use v1::metadata::Metadata;
 use v1::traits::{EthSigning, ParitySigning, Parity};
 use v1::helpers::{SignerService, SigningQueue};
 use v1::types::ConfirmationResponse;
@@ -39,7 +40,7 @@ struct SigningTester {
 	pub client: Arc<TestBlockChainClient>,
 	pub miner: Arc<TestMinerService>,
 	pub accounts: Arc<AccountProvider>,
-	pub io: IoHandler,
+	pub io: IoHandler<Metadata>,
 }
 
 impl Default for SigningTester {

--- a/rpc/src/v1/traits/eth.rs
+++ b/rpc/src/v1/traits/eth.rs
@@ -42,8 +42,8 @@ build_rpc_trait! {
 		fn hashrate(&self) -> Result<U256, Error>;
 
 		/// Returns block author.
-		#[rpc(name = "eth_coinbase")]
-		fn author(&self) -> Result<H160, Error>;
+		#[rpc(meta, name = "eth_coinbase")]
+		fn author(&self, Self::Metadata) -> BoxFuture<H160, Error>;
 
 		/// Returns true if client is actively mining new blocks.
 		#[rpc(name = "eth_mining")]

--- a/rpc/src/v1/traits/parity.rs
+++ b/rpc/src/v1/traits/parity.rs
@@ -20,6 +20,7 @@ use std::collections::BTreeMap;
 
 use jsonrpc_core::Error;
 use jsonrpc_macros::Trailing;
+use futures::BoxFuture;
 
 use v1::types::{
 	H160, H256, H512, U256, Bytes,
@@ -32,9 +33,15 @@ use v1::types::{
 build_rpc_trait! {
 	/// Parity-specific rpc interface.
 	pub trait Parity {
+		type Metadata;
+
 		/// Returns accounts information.
 		#[rpc(name = "parity_accountsInfo")]
 		fn accounts_info(&self, Trailing<DappId>) -> Result<BTreeMap<String, BTreeMap<String, String>>, Error>;
+
+		/// Returns default account for dapp.
+		#[rpc(meta, name = "parity_defaultAccount")]
+		fn default_account(&self, Self::Metadata) -> BoxFuture<H160, Error>;
 
 		/// Returns current transactions limit.
 		#[rpc(name = "parity_transactionsLimit")]

--- a/rpc/src/v1/types/confirmations.rs
+++ b/rpc/src/v1/types/confirmations.rs
@@ -188,6 +188,8 @@ impl From<helpers::ConfirmationPayload> for ConfirmationPayload {
 #[derive(Debug, PartialEq, Serialize, Deserialize)]
 #[serde(deny_unknown_fields)]
 pub struct TransactionModification {
+	/// Modified transaction sender
+	pub sender: Option<H160>,
 	/// Modified gas price
 	#[serde(rename="gasPrice")]
 	pub gas_price: Option<U256>,
@@ -329,6 +331,7 @@ mod tests {
 	fn should_deserialize_modification() {
 		// given
 		let s1 = r#"{
+			"sender": "0x000000000000000000000000000000000000000a",
 			"gasPrice":"0xba43b7400",
 			"minBlock":"0x42"
 		}"#;
@@ -342,16 +345,19 @@ mod tests {
 
 		// then
 		assert_eq!(res1, TransactionModification {
+			sender: Some(10.into()),
 			gas_price: Some(U256::from_str("0ba43b7400").unwrap()),
 			gas: None,
 			min_block: Some(Some(BlockNumber::Num(0x42))),
 		});
 		assert_eq!(res2, TransactionModification {
+			sender: None,
 			gas_price: None,
 			gas: Some(U256::from_str("1233").unwrap()),
 			min_block: None,
 		});
 		assert_eq!(res3, TransactionModification {
+			sender: None,
 			gas_price: None,
 			gas: None,
 			min_block: None,

--- a/rpc_client/src/signer_client.rs
+++ b/rpc_client/src/signer_client.rs
@@ -28,7 +28,7 @@ impl SignerRpc {
 	{
 		self.rpc.request("signer_confirmRequest", vec![
 			to_value(&format!("{:#x}", id)),
-			to_value(&TransactionModification { gas_price: new_gas_price, gas: new_gas, min_block: new_min_block }),
+			to_value(&TransactionModification { sender: None, gas_price: new_gas_price, gas: new_gas, min_block: new_min_block }),
 			to_value(&pwd),
 		])
 	}


### PR DESCRIPTION
Coinbase will now return first account for particular dapp (so you can either use `web3.eth.accounts[0]` or `web3.eth.coinbase`) to get default account.
We agreed with @jacogr that the UI will always set default account as first on the list (either using `parity_setDappsAddresses(dapp, [accounts])` or `parity_setNewDappsWhitelist([accounts])`)

Additionally signer RPC now allows to override transaction sender. PR allowing to omit `from` in `TransactionRequest` will follow.

Related: #3797 