### PR TITLE
parity.js api.parity.chainStatus should handle { blockGap: null }

### DIFF
--- a/js/src/api/format/output.js
+++ b/js/src/api/format/output.js
@@ -79,7 +79,9 @@ export function outChainStatus (status) {
     Object.keys(status).forEach((key) => {
       switch (key) {
         case 'blockGap':
-          status[key] = status[key].map(outNumber);
+          status[key] = status[key]
+            ? status[key].map(outNumber)
+            : status[key];
           break;
       }
     });

--- a/js/src/api/format/output.spec.js
+++ b/js/src/api/format/output.spec.js
@@ -135,6 +135,14 @@ describe('api/format/output', () => {
         blockGap: [new BigNumber(0x1234), new BigNumber(0x5678)]
       });
     });
+
+    it('handles null blockGap values', () => {
+      const status = {
+        blockGap: null
+      };
+
+      expect(outChainStatus(status)).to.deep.equal(status);
+    });
   });
 
   describe('outDate', () => {

--- a/js/src/api/rpc/parity/parity.e2e.js
+++ b/js/src/api/rpc/parity/parity.e2e.js
@@ -19,6 +19,14 @@ import { createHttpApi } from '../../../../test/e2e/ethapi';
 describe('ethapi.parity', () => {
   const ethapi = createHttpApi();
 
+  describe('chainStatus', () => {
+    it('returns and translates the status', () => {
+      return ethapi.parity.chainStatus().then((value) => {
+        expect(value).to.be.ok;
+      });
+    });
+  });
+
   describe('gasFloorTarget', () => {
     it('returns and translates the target', () => {
       return ethapi.parity.gasFloorTarget().then((value) => {


### PR DESCRIPTION
Fixes https://github.com/ethcore/parity/issues/4326