### PR TITLE
Fixing embedded bar not closing in chrome extension

### DIFF
--- a/js/src/views/ParityBar/parityBar.js
+++ b/js/src/views/ParityBar/parityBar.js
@@ -161,6 +161,7 @@ class ParityBar extends Component {
         onMouseLeave={ this.onMouseLeave }
         onMouseMove={ this.onMouseMove }
         onMouseUp={ this.onMouseUp }
+        ref={ this.onRef }
       >
         <ParityBackground
           className={ parityBgClassNames.join(' ') }
@@ -187,7 +188,6 @@ class ParityBar extends Component {
     return (
       <div
         className={ styles.cornercolor }
-        ref={ this.onRef }
       >
         {
           this.renderLink(


### PR DESCRIPTION
Currently bar was not triggering closing events (because the ref was attached to invalid element)