### PR TITLE
expose util as Api.util

### DIFF
--- a/js/src/api/api.js
+++ b/js/src/api/api.js
@@ -131,6 +131,8 @@ export default class Api extends EventEmitter {
     });
   }
 
+  static util = util
+
   static Transport = {
     Http: Http,
     Ws: Ws

--- a/js/src/api/api.spec.js
+++ b/js/src/api/api.spec.js
@@ -16,6 +16,7 @@
 
 import { TEST_HTTP_URL, endpointTest } from '../../test/mockRpc';
 
+import util from './util';
 import Api from './api';
 
 import ethereumRpc from '../jsonrpc/';
@@ -43,5 +44,9 @@ describe('api/Api', () => {
         });
       });
     });
+  });
+
+  it('exposes util as static property', () => {
+    expect(Api.util).to.equal(util);
   });
 });


### PR DESCRIPTION
It's not possible to use the (static) tools in `api/util` right now without instantiating an API, which means connecting to a node. This PR adds a static property `Api.util`.