### PR TITLE
Fixing web3 in console

### DIFF
--- a/js/src/dapps/static/console.html
+++ b/js/src/dapps/static/console.html
@@ -4,8 +4,7 @@
     <meta charset="utf-8">
     <title>JS Console dapp</title>
     <link href="console.css" rel='stylesheet' type='text/css'>
-    <script src="/parity-utils/parity.js"></script>
-    <script src="/parity-utils/web3.js"></script>
+    <script src="/web3.js"></script>
   </head>
   <body>
    <div id="full-screen">


### PR DESCRIPTION
Since it's now marked as `secure` it can use `secureApi` instead of injecting `parity.js` and `web3.js` needs to be loaded from different path.