### PR TITLE
Perform a sync between Rust and JS when generating markdown instead of in spec tests

### DIFF
--- a/js/scripts/helpers/log.js
+++ b/js/scripts/helpers/log.js
@@ -1,3 +1,19 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
 import chalk from 'chalk';
 
 // INFO Logging helper

--- a/js/scripts/helpers/log.js
+++ b/js/scripts/helpers/log.js
@@ -1,0 +1,16 @@
+import chalk from 'chalk';
+
+// INFO Logging helper
+export function info (log) {
+  console.log(chalk.blue(`INFO:\t${log}`));
+}
+
+// WARN Logging helper
+export function warn (log) {
+  console.warn(chalk.yellow(`WARN:\t${log}`));
+}
+
+// ERROR Logging helper
+export function error (log) {
+  console.error(chalk.red(`ERROR:\t${log}`));
+}

--- a/js/scripts/helpers/parsed-rpc-traits.js
+++ b/js/scripts/helpers/parsed-rpc-traits.js
@@ -1,0 +1,65 @@
+import fs from 'fs';
+import path from 'path';
+
+// ```js
+// rustMethods['eth']['call'] === true
+// ```
+const rustMethods = {};
+
+export default rustMethods;
+
+// Get a list of JSON-RPC from Rust trait source code
+function parseMethodsFromRust (source) {
+  // Matching the custom `rpc` attribute with it's doc comment
+  const attributePattern = /((?:\s*\/\/\/.*$)*)\s*#\[rpc\(([^)]+)\)]/gm;
+  const commentPattern = /\s*\/\/\/\s*/g;
+  const separatorPattern = /\s*,\s*/g;
+  const assignPattern = /([\S]+)\s*=\s*"([^"]*)"/;
+  const ignorePattern = /@(ignore|deprecated|unimplemented|alias)\b/i;
+
+  const methods = [];
+
+  source.toString().replace(attributePattern, (match, comment, props) => {
+    comment = comment.replace(commentPattern, '\n').trim();
+
+    // Skip deprecated methods
+    if (ignorePattern.test(comment)) {
+      return match;
+    }
+
+    props.split(separatorPattern).forEach((prop) => {
+      const [, key, value] = prop.split(assignPattern) || [];
+
+      if (key === 'name' && value != null) {
+        methods.push(value);
+      }
+    });
+
+    return match;
+  });
+
+  return methods;
+}
+
+// Get a list of all JSON-RPC methods from all defined traits
+function getMethodsFromRustTraits () {
+  const traitsDir = path.join(__dirname, '../../../rpc/src/v1/traits');
+
+  return fs.readdirSync(traitsDir)
+            .filter((name) => name !== 'mod.rs' && /\.rs$/.test(name))
+            .map((name) => fs.readFileSync(path.join(traitsDir, name)))
+            .map(parseMethodsFromRust)
+            .reduce((a, b) => a.concat(b));
+}
+
+getMethodsFromRustTraits().sort().forEach((method) => {
+  const [group, name] = method.split('_');
+
+  // Skip methods with malformed names
+  if (group == null || name == null) {
+    return;
+  }
+
+  rustMethods[group] = rustMethods[group] || {};
+  rustMethods[group][name] = true;
+});

--- a/js/scripts/helpers/parsed-rpc-traits.js
+++ b/js/scripts/helpers/parsed-rpc-traits.js
@@ -1,3 +1,19 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
 import fs from 'fs';
 import path from 'path';
 

--- a/js/src/jsonrpc/index.spec.js
+++ b/js/src/jsonrpc/index.spec.js
@@ -14,8 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-import fs from 'fs';
-import path from 'path';
 import interfaces from './';
 import * as customTypes from './types';
 
@@ -27,91 +25,13 @@ function verifyType (obj) {
   }
 }
 
-// Get a list of JSON-RPC from Rust trait source code
-function parseMethodsFromRust (source) {
-  // Matching the custom `rpc` attribute with it's doc comment
-  const attributePattern = /((?:\s*\/\/\/.*$)*)\s*#\[rpc\(([^)]+)\)]/gm;
-  const commentPattern = /\s*\/\/\/\s*/g;
-  const separatorPattern = /\s*,\s*/g;
-  const assignPattern = /([\S]+)\s*=\s*"([^"]*)"/;
-  const ignorePattern = /@(ignore|deprecated|unimplemented|alias)\b/i;
-
-  const methods = [];
-
-  source.toString().replace(attributePattern, (match, comment, props) => {
-    comment = comment.replace(commentPattern, '\n').trim();
-
-    // Skip deprecated methods
-    if (ignorePattern.test(comment)) {
-      return match;
-    }
-
-    props.split(separatorPattern).forEach((prop) => {
-      const [, key, value] = prop.split(assignPattern) || [];
-
-      if (key === 'name' && value != null) {
-        methods.push(value);
-      }
-    });
-
-    return match;
-  });
-
-  return methods;
-}
-
-// Get a list of all JSON-RPC methods from all defined traits
-function getMethodsFromRustTraits () {
-  const traitsDir = path.join(__dirname, '../../../rpc/src/v1/traits');
-
-  return fs.readdirSync(traitsDir)
-            .filter((name) => name !== 'mod.rs' && /\.rs$/.test(name))
-            .map((name) => fs.readFileSync(path.join(traitsDir, name)))
-            .map(parseMethodsFromRust)
-            .reduce((a, b) => a.concat(b));
-}
-
-const rustMethods = {};
-
-getMethodsFromRustTraits().sort().forEach((method) => {
-  const [group, name] = method.split('_');
-
-  // Skip methods with malformed names
-  if (group == null || name == null) {
-    return;
-  }
-
-  rustMethods[group] = rustMethods[group] || {};
-  rustMethods[group][name] = true;
-});
-
 describe('jsonrpc/interfaces', () => {
-  describe('Rust trait methods', () => {
-    Object.keys(rustMethods).forEach((group) => {
-      describe(group, () => {
-        Object.keys(rustMethods[group]).forEach((name) => {
-          describe(name, () => {
-            it('has a defined JS interface', () => {
-              expect(interfaces[group][name]).to.exist;
-            });
-          });
-        });
-      });
-    });
-  });
-
   Object.keys(interfaces).forEach((group) => {
     describe(group, () => {
       Object.keys(interfaces[group]).forEach((name) => {
         const method = interfaces[group][name];
 
         describe(name, () => {
-          if (!method.nodoc) {
-            it('is present in Rust codebase', () => {
-              expect(rustMethods[group][name]).to.exist;
-            });
-          }
-
           it('has the correct interface', () => {
             expect(method.desc).to.be.a('string');
             expect(method.params).to.be.an('array');


### PR DESCRIPTION
So builds stop failing when someone adds a method, but there will be a clear error when running `npm run build:markdown` - which is when you really want to see it (md files will still be generated).