### PR TITLE
web browser dapp: prompt to install extension

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -193,6 +193,7 @@
     "scryptsy": "2.0.0",
     "solc": "ngotchac/solc-js",
     "store": "1.3.20",
+    "useragent.js": "0.5.6",
     "utf8": "2.1.2",
     "valid-url": "1.0.9",
     "validator": "6.2.0",

--- a/js/src/views/Web/extension-warning.js
+++ b/js/src/views/Web/extension-warning.js
@@ -19,7 +19,9 @@ import store from 'store';
 
 const LAST_HIDDEN = '_parity::extensionWarning::lastHidden';
 
-export const showShowWarning = () => {
+export const EXTENSION_PAGE = 'https://chrome.google.com/webstore/detail/fgodinogimdopkigkcoelpfkbnpngalc';
+
+export const shouldShowWarning = () => {
   const hasExtension = Symbol.for('parity.extension') in window;
 
   if (hasExtension) {
@@ -36,6 +38,22 @@ export const showShowWarning = () => {
   const lastHidden = store.get(LAST_HIDDEN) || 0;
 
   return (Date.now() - lastHidden) >= 24 * 60 * 60 * 1000;
+};
+
+export const installExtension = () => {
+  return new Promise((resolve, reject) => {
+    const link = document.createElement('link');
+
+    link.setAttribute('rel', 'chrome-webstore-item');
+    link.setAttribute('href', EXTENSION_PAGE);
+    document.querySelector('head').appendChild(link);
+
+    if (chrome && chrome.webstore && chrome.webstore.install) { // eslint-disable-line
+      chrome.webstore.install(EXTENSION_PAGE, resolve, reject); // eslint-disable-line
+    } else {
+      reject(new Error('Direct installation failed.'));
+    }
+  });
 };
 
 export const hideWarning = () => {

--- a/js/src/views/Web/extension-warning.js
+++ b/js/src/views/Web/extension-warning.js
@@ -1,0 +1,43 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+import browser from 'useragent.js/lib/browser';
+import store from 'store';
+
+const LAST_HIDDEN = '_parity::extensionWarning::lastHidden';
+
+export const showShowWarning = () => {
+  const hasExtension = Symbol.for('parity.extension') in window;
+
+  if (hasExtension) {
+    return false;
+  }
+
+  const ua = browser.analyze(navigator.userAgent || '');
+  const browserName = (ua || {}).name.toLowerCase();
+
+  if (browserName !== 'chrome') {
+    return false;
+  }
+
+  const lastHidden = store.get(LAST_HIDDEN) || 0;
+
+  return (Date.now() - lastHidden) >= 24 * 60 * 60 * 1000;
+};
+
+export const hideWarning = () => {
+  store.set(LAST_HIDDEN, Date.now());
+};

--- a/js/src/views/Web/web.js
+++ b/js/src/views/Web/web.js
@@ -19,11 +19,14 @@ import store from 'store';
 import { parse as parseUrl, format as formatUrl } from 'url';
 import { parse as parseQuery } from 'querystring';
 
+import { Button, Modal } from '~/ui';
+import { CancelIcon, CheckIcon } from '~/ui/Icons';
 import AddressBar from './AddressBar';
 
 import styles from './web.css';
 
 const LS_LAST_ADDRESS = '_parity::webLastAddress';
+const EXTENSION_PAGE = 'https://chrome.google.com/webstore/detail/parity-ethereum-integrati/fgodinogimdopkigkcoelpfkbnpngalc';
 
 const hasProtocol = /^https?:\/\//;
 
@@ -40,7 +43,8 @@ export default class Web extends Component {
     displayedUrl: null,
     isLoading: true,
     token: null,
-    url: null
+    url: null,
+    extensionWarningShown: false
   };
 
   componentDidMount () {
@@ -55,6 +59,12 @@ export default class Web extends Component {
       });
 
     this.setUrl(params.url);
+
+    if (!(Symbol.for('parity.extension') in window)) {
+      this.setState({
+        extensionWarningShown: true
+      });
+    }
   }
 
   componentWillReceiveProps (props) {
@@ -84,7 +94,7 @@ export default class Web extends Component {
     }
 
     const { dappsUrl } = this.context.api;
-    const { url } = this.state;
+    const { url, extensionWarningShown } = this.state;
 
     if (!url || !token) {
       return null;
@@ -96,6 +106,7 @@ export default class Web extends Component {
 
     return (
       <div className={ styles.wrapper }>
+        { extensionWarningShown ? this.renderExtensionWarning() : null }
         <AddressBar
           className={ styles.url }
           isLoading={ isLoading }
@@ -114,6 +125,45 @@ export default class Web extends Component {
         />
       </div>
     );
+  }
+
+  renderExtensionWarning () {
+    const cancel = (
+      <Button
+        icon={ <CancelIcon /> }
+        key='close'
+        label='No Thanks'
+        onClick={ this.hideExtensionWarning }
+      />
+    );
+    const install = (
+      <Button
+        icon={ <CheckIcon /> }
+        key='install'
+        label='Install'
+        onClick={ this.openExtensionPage }
+      />
+    );
+
+    return (
+      <Modal
+        actions={ [ cancel, install ] }
+        title='Install the Parity Extension'
+        visible
+      >
+        <p>Parity now has a Chrome extension. We strongly recommend to install it.</p>
+      </Modal>
+    );
+  }
+
+  hideExtensionWarning = () => {
+    this.setState({
+      extensionWarningShown: false
+    });
+  }
+
+  openExtensionPage = () => {
+    window.open(EXTENSION_PAGE, '_blank');
   }
 
   onUrlChange = (url) => {

--- a/js/src/views/Web/web.js
+++ b/js/src/views/Web/web.js
@@ -23,11 +23,10 @@ import { Button, Modal } from '~/ui';
 import { CancelIcon, CheckIcon } from '~/ui/Icons';
 import AddressBar from './AddressBar';
 
-import { showShowWarning, hideWarning } from './extension-warning';
+import { EXTENSION_PAGE, shouldShowWarning, installExtension, hideWarning } from './extension-warning';
 import styles from './web.css';
 
 const LS_LAST_ADDRESS = '_parity::webLastAddress';
-const EXTENSION_PAGE = 'https://chrome.google.com/webstore/detail/parity-ethereum-integrati/fgodinogimdopkigkcoelpfkbnpngalc';
 
 const hasProtocol = /^https?:\/\//;
 
@@ -61,7 +60,7 @@ export default class Web extends Component {
 
     this.setUrl(params.url);
 
-    if (showShowWarning()) {
+    if (shouldShowWarning()) {
       this.setState({
         extensionWarningShown: true
       });
@@ -165,7 +164,12 @@ export default class Web extends Component {
   }
 
   openExtensionPage = () => {
-    window.open(EXTENSION_PAGE, '_blank');
+    installExtension()
+      .then(hideWarning)
+      .catch((err) => {
+        console.error(err);
+        window.open(EXTENSION_PAGE, '_blank');
+      });
   }
 
   onUrlChange = (url) => {

--- a/js/src/views/Web/web.js
+++ b/js/src/views/Web/web.js
@@ -23,6 +23,7 @@ import { Button, Modal } from '~/ui';
 import { CancelIcon, CheckIcon } from '~/ui/Icons';
 import AddressBar from './AddressBar';
 
+import { showShowWarning, hideWarning } from './extension-warning';
 import styles from './web.css';
 
 const LS_LAST_ADDRESS = '_parity::webLastAddress';
@@ -60,7 +61,7 @@ export default class Web extends Component {
 
     this.setUrl(params.url);
 
-    if (!(Symbol.for('parity.extension') in window)) {
+    if (showShowWarning()) {
       this.setState({
         extensionWarningShown: true
       });
@@ -157,6 +158,7 @@ export default class Web extends Component {
   }
 
   hideExtensionWarning = () => {
+    hideWarning();
     this.setState({
       extensionWarningShown: false
     });


### PR DESCRIPTION
Fixes #4300. Tries inline installation first, falls back to opening a popup with the Chrome Web Store.

Will need a better description why to install the extension.