### PR TITLE
Use secure websocket from HTTPS clients

### DIFF
--- a/js/src/index.js
+++ b/js/src/index.js
@@ -55,6 +55,7 @@ if (process.env.NODE_ENV === 'development') {
 
 const AUTH_HASH = '#/auth?';
 const parityUrl = process.env.PARITY_URL || window.location.host;
+const urlScheme = window.location.href.match(/^https/) ? 'wss://' : 'ws://';
 
 let token = null;
 
@@ -62,7 +63,7 @@ if (window.location.hash && window.location.hash.indexOf(AUTH_HASH) === 0) {
   token = qs.parse(window.location.hash.substr(AUTH_HASH.length)).token;
 }
 
-const api = new SecureApi(`ws://${parityUrl}`, token);
+const api = new SecureApi(`${urlScheme}${parityUrl}`, token);
 
 patchApi(api);
 ContractInstances.create(api);


### PR DESCRIPTION
Currently, the unsecure `ws://` scheme is hardcoded. With this change, the scheme will dynamically change to the secure `wss://` when the frontend is requested from an HTTPS origin.

I might have missed something, and I'm entirely new to this codebase, so please excuse me if this doesn't make sense. We just stumbled into `ws://` failing for our parity node after enabling HTTPS and this is what I found as the most likely cause of the issue.