### PR TITLE
[beta] fix svg extension image webpack inlining

### DIFF
--- a/js/webpack/app.js
+++ b/js/webpack/app.js
@@ -118,7 +118,12 @@ module.exports = {
         use: [ 'file-loader?name=fonts/[name][hash:10].[ext]' ]
       },
       {
+        test: /parity-logo-white-no-text\.svg/,
+        use: [ 'url-loader' ]
+      },
+      {
         test: /\.svg(\?v=[0-9]\.[0-9]\.[0-9])?$/,
+        exclude: [ /parity-logo-white-no-text\.svg/ ],
         use: [ 'file-loader?name=assets/[name].[hash:10].[ext]' ]
       }
     ],


### PR DESCRIPTION
Pre fix -

![svg-pre](https://cloud.githubusercontent.com/assets/1424473/22624998/d8b9cd82-eb8a-11e6-8cd1-86c88fe6f73c.png)

Post fix -

![rouleth - roulette game on ethereum blockchain 2017-02-05 10-14-55](https://cloud.githubusercontent.com/assets/1424473/22625057/fc37e1a8-eb8b-11e6-8fb5-d85c496b8d1b.png)


(Both on beta binary builds)