### PR TITLE
whatwg-fetch -> isomorphic-fetch

### DIFF
--- a/js/package.json
+++ b/js/package.json
@@ -199,7 +199,6 @@
     "valid-url": "1.0.9",
     "validator": "6.2.0",
     "web3": "0.17.0-beta",
-    "whatwg-fetch": "2.0.1",
     "zxcvbn": "4.4.1"
   }
 }

--- a/js/src/embed.js
+++ b/js/src/embed.js
@@ -15,10 +15,11 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 import 'babel-polyfill';
-import 'whatwg-fetch';
 
 import es6Promise from 'es6-promise';
 es6Promise.polyfill();
+
+import 'isomorphic-fetch';
 
 import React from 'react';
 import ReactDOM from 'react-dom';

--- a/js/src/index.js
+++ b/js/src/index.js
@@ -15,10 +15,11 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 import 'babel-polyfill';
-import 'whatwg-fetch';
 
 import es6Promise from 'es6-promise';
 es6Promise.polyfill();
+
+import 'isomorphic-fetch';
 
 import React from 'react';
 import ReactDOM from 'react-dom';

--- a/js/src/library.etherscan.js
+++ b/js/src/library.etherscan.js
@@ -18,16 +18,7 @@ import 'babel-polyfill/dist/polyfill.js';
 import es6Promise from 'es6-promise';
 es6Promise.polyfill();
 
-const isNode = typeof global !== 'undefined' && typeof global !== 'undefined';
-const isBrowser = typeof self !== 'undefined' && typeof self.window !== 'undefined';
-
-if (isBrowser) {
-  require('whatwg-fetch');
-}
-
-if (isNode) {
-  global.fetch = require('node-fetch');
-}
+require('isomorphic-fetch');
 
 import Etherscan from './3rdparty/etherscan';
 

--- a/js/src/library.parity.js
+++ b/js/src/library.parity.js
@@ -18,16 +18,7 @@ import 'babel-polyfill/dist/polyfill.js';
 import es6Promise from 'es6-promise';
 es6Promise.polyfill();
 
-const isNode = typeof global !== 'undefined' && typeof global !== 'undefined';
-const isBrowser = typeof self !== 'undefined' && typeof self.window !== 'undefined';
-
-if (isBrowser) {
-  require('whatwg-fetch');
-}
-
-if (isNode) {
-  global.fetch = require('node-fetch');
-}
+require('isomorphic-fetch');
 
 import Abi from './abi';
 import Api from './api';

--- a/js/src/library.shapeshift.js
+++ b/js/src/library.shapeshift.js
@@ -18,16 +18,7 @@ import 'babel-polyfill/dist/polyfill.js';
 import es6Promise from 'es6-promise';
 es6Promise.polyfill();
 
-const isNode = typeof global !== 'undefined' && typeof global !== 'undefined';
-const isBrowser = typeof self !== 'undefined' && typeof self.window !== 'undefined';
-
-if (isBrowser) {
-  require('whatwg-fetch');
-}
-
-if (isNode) {
-  global.fetch = require('node-fetch');
-}
+require('isomorphic-fetch');
 
 import ShapeShift from './3rdparty/shapeshift';
 

--- a/js/src/parity.js
+++ b/js/src/parity.js
@@ -15,10 +15,11 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 import 'babel-polyfill';
-import 'whatwg-fetch';
 
 import es6Promise from 'es6-promise';
 es6Promise.polyfill();
+
+import 'isomorphic-fetch';
 
 import Api from './api';
 

--- a/js/test/mocha.config.js
+++ b/js/test/mocha.config.js
@@ -14,11 +14,12 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-import 'isomorphic-fetch';
 import 'mock-local-storage';
 
 import es6Promise from 'es6-promise';
 es6Promise.polyfill();
+
+import 'isomorphic-fetch';
 
 import injectTapEventPlugin from 'react-tap-event-plugin';
 injectTapEventPlugin();

--- a/js/webpack/npm.js
+++ b/js/webpack/npm.js
@@ -48,7 +48,7 @@ module.exports = {
     umdNamedDefine: true
   },
   externals: {
-    'node-fetch': 'node-fetch',
+    'isomorphic-fetch': 'isomorphic-fetch',
     'vertx': 'vertx'
   },
   module: {


### PR DESCRIPTION
In order to make `@parity/parity.js` more portable, this PR removes the brittle & discouraged environment sniffing and uses [`isomorphic-fetch`](https://github.com/matthew-andrews/isomorphic-fetch), which adds a cross-platform global `fetch`.