### PR TITLE
[beta] Fixing histogram again

### DIFF
--- a/js/src/ui/GasPriceEditor/store.js
+++ b/js/src/ui/GasPriceEditor/store.js
@@ -180,7 +180,7 @@ export default class GasPriceEditor {
         // NOTE fetching histogram may fail if there is not enough data.
         // We fallback to empty histogram.
         this._api.parity.gasPriceHistogram().catch(() => ({
-          bucket_bounds: [],
+          bucketBounds: [],
           counts: []
         })),
         this._api.eth.gasPrice(),

--- a/js/src/ui/GasPriceEditor/store.spec.js
+++ b/js/src/ui/GasPriceEditor/store.spec.js
@@ -96,6 +96,7 @@ describe('ui/GasPriceEditor/Store', () => {
 
       setImmediate(() => {
         expect(store.histogram).not.to.be.null;
+        expect(store.histogram.bucketBounds).not.to.be.null;
         done();
       });
     });


### PR DESCRIPTION
Fixes a typo in JS code causing advanced mode to be broken in case histogram is not available.

(will require a forwardport)