### PR TITLE
Fix key.meta.vault for root dir keys && read vault.meta without vault key

### DIFF
--- a/ethstore/src/dir/mod.rs
+++ b/ethstore/src/dir/mod.rs
@@ -72,6 +72,8 @@ pub trait VaultKeyDirectoryProvider {
 	fn open(&self, name: &str, key: VaultKey) -> Result<Box<VaultKeyDirectory>, Error>;
 	/// List all vaults
 	fn list_vaults(&self) -> Result<Vec<String>, Error>;
+	/// Get vault meta
+	fn vault_meta(&self, name: &str) -> Result<String, Error>;
 }
 
 /// Vault directory

--- a/ethstore/src/json/vault_file.rs
+++ b/ethstore/src/json/vault_file.rs
@@ -81,7 +81,7 @@ impl Visitor for VaultFileVisitor {
 		loop {
 			match visitor.visit_key()? {
 				Some(VaultFileField::Crypto) => { crypto = Some(visitor.visit_value()?); },
-				Some(VaultFileField::Meta) => { meta = Some(visitor.visit_value()?); }
+				Some(VaultFileField::Meta) => { meta = visitor.visit_value().ok(); }, // meta is optional
 				None => { break; },
 			}
 		}
@@ -134,6 +134,31 @@ mod test {
 				mac: "16381463ea11c6eb2239a9f339c2e780516d29d234ce30ac5f166f9080b5a262".into(),
 			},
 			meta: Some("{}".into()),
+		};
+
+		let serialized = serde_json::to_string(&file).unwrap();
+		let deserialized = serde_json::from_str(&serialized).unwrap();
+
+		assert_eq!(file, deserialized);
+	}
+
+	#[test]
+	fn to_and_from_json_no_meta() {
+		let file = VaultFile {
+			crypto: Crypto {
+				cipher: Cipher::Aes128Ctr(Aes128Ctr {
+					iv: "0155e3690be19fbfbecabcd440aa284b".into(),
+				}),
+				ciphertext: "4d6938a1f49b7782".into(),
+				kdf: Kdf::Pbkdf2(Pbkdf2 {
+					c: 1024,
+					dklen: 32,
+					prf: Prf::HmacSha256,
+					salt: "b6a9338a7ccd39288a86dba73bfecd9101b4f3db9c9830e7c76afdbd4f6872e5".into(),
+				}),
+				mac: "16381463ea11c6eb2239a9f339c2e780516d29d234ce30ac5f166f9080b5a262".into(),
+			},
+			meta: None,
 		};
 
 		let serialized = serde_json::to_string(&file).unwrap();

--- a/rpc/src/v1/tests/mocked/parity_accounts.rs
+++ b/rpc/src/v1/tests/mocked/parity_accounts.rs
@@ -366,6 +366,14 @@ fn rpc_parity_get_set_vault_meta() {
 	let tester = setup_with_vaults_support(temp_path.as_str());
 
 	assert!(tester.accounts.create_vault("vault1", "password1").is_ok());
+
+	// when no meta set
+	let request = r#"{"jsonrpc": "2.0", "method": "parity_getVaultMeta", "params":["vault1"], "id": 1}"#;
+	let response = r#"{"jsonrpc":"2.0","result":"{}","id":1}"#;
+
+	assert_eq!(tester.io.handle_request_sync(request), Some(response.to_owned()));
+
+	// when meta set
 	assert!(tester.accounts.set_vault_meta("vault1", "vault1_meta").is_ok());
 
 	let request = r#"{"jsonrpc": "2.0", "method": "parity_getVaultMeta", "params":["vault1"], "id": 1}"#;
@@ -373,11 +381,13 @@ fn rpc_parity_get_set_vault_meta() {
 
 	assert_eq!(tester.io.handle_request_sync(request), Some(response.to_owned()));
 
+	// change meta
 	let request = r#"{"jsonrpc": "2.0", "method": "parity_setVaultMeta", "params":["vault1", "updated_vault1_meta"], "id": 1}"#;
 	let response = r#"{"jsonrpc":"2.0","result":true,"id":1}"#;
 
 	assert_eq!(tester.io.handle_request_sync(request), Some(response.to_owned()));
 
+	// query changed meta
 	let request = r#"{"jsonrpc": "2.0", "method": "parity_getVaultMeta", "params":["vault1"], "id": 1}"#;
 	let response = r#"{"jsonrpc":"2.0","result":"updated_vault1_meta","id":1}"#;
 

--- a/rpc/src/v1/tests/mocked/parity_accounts.rs
+++ b/rpc/src/v1/tests/mocked/parity_accounts.rs
@@ -314,6 +314,14 @@ fn rpc_parity_vault_adds_vault_field_to_acount_meta() {
 	let response = format!(r#"{{"jsonrpc":"2.0","result":{{"0x{}":{{"meta":"{{\"vault\":\"vault1\"}}","name":"","uuid":"{}"}}}},"id":1}}"#, address1.hex(), uuid1);
 
 	assert_eq!(tester.io.handle_request_sync(request), Some(response.to_owned()));
+
+	// and then
+	assert!(tester.accounts.change_vault(address1, "").is_ok());
+
+	let request = r#"{"jsonrpc": "2.0", "method": "parity_allAccountsInfo", "params":[], "id": 1}"#;
+	let response = format!(r#"{{"jsonrpc":"2.0","result":{{"0x{}":{{"meta":"{{}}","name":"","uuid":"{}"}}}},"id":1}}"#, address1.hex(), uuid1);
+
+	assert_eq!(tester.io.handle_request_sync(request), Some(response.to_owned()));
 }
 
 #[test]


### PR DESCRIPTION
Details:
1. When key is moved from vault back to the root directory, it's meta still contains the `vault` field. Fixed + added test on RPC level
2. As vault meta is intended to contain hint for vault password, it was a bad idea to allow reading meta for opened vaults only => added support for reading unopened vaults meta + updated test.