### PR TITLE
Fix TnC overflows on small screens

### DIFF
--- a/js/src/modals/FirstRun/TnC/tnc.css
+++ b/js/src/modals/FirstRun/TnC/tnc.css
@@ -16,7 +16,6 @@
 */
 
 .body {
-  height: 400px;
   overflow-y: auto;
 }
 


### PR DESCRIPTION
TnC on startup were displaying two scroll bars on small screen

![image](https://cloud.githubusercontent.com/assets/2864519/22809257/3817cbfe-ef31-11e6-9d53-aaec1e1cbfa8.png)
