### PR TITLE
Fix contract queries bug

### DIFF
--- a/js/src/ui/Form/AddressSelect/addressSelect.css
+++ b/js/src/ui/Form/AddressSelect/addressSelect.css
@@ -107,6 +107,10 @@
   }
 }
 
+.container {
+  margin-bottom: 1em;
+}
+
 .categories {
   display: flex;
   flex: 1;

--- a/js/src/ui/Form/AddressSelect/addressSelect.js
+++ b/js/src/ui/Form/AddressSelect/addressSelect.js
@@ -206,12 +206,11 @@ class AddressSelect extends Component {
                 style={ BOTTOM_BORDER_STYLE }
               />
             </div>
-
-            { this.renderCurrentInput() }
-            { this.renderRegistryValues() }
           </div>
         }
       >
+        { this.renderCurrentInput() }
+        { this.renderRegistryValues() }
         { this.renderAccounts() }
       </Portal>
     );
@@ -245,8 +244,8 @@ class AddressSelect extends Component {
     }
 
     return (
-      <div>
-        { this.renderAccountCard({ address }) }
+      <div className={ styles.container }>
+        { this.renderAccountCard({ address, index: 'currentInput_0' }) }
       </div>
     );
   }
@@ -266,7 +265,7 @@ class AddressSelect extends Component {
       });
 
     return (
-      <div>
+      <div className={ styles.container }>
         { accounts }
       </div>
     );
@@ -361,7 +360,7 @@ class AddressSelect extends Component {
 
   validateCustomInput = () => {
     const { allowInput } = this.props;
-    const { inputValue } = this.store;
+    const { inputValue } = this.state;
     const { values } = this.store;
 
     // If input is HEX and allowInput === true, send it
@@ -587,7 +586,13 @@ class AddressSelect extends Component {
       this.handleDOMAction('inputAddress', 'focus');
     }
 
-    this.setState({ expanded: false });
+    this.store.resetRegistryValues();
+
+    this.setState({
+      expanded: false,
+      focusedItem: null,
+      inputValue: ''
+    });
   }
 
   handleInputBlur = () => {

--- a/js/src/ui/Form/AddressSelect/addressSelectStore.js
+++ b/js/src/ui/Form/AddressSelect/addressSelectStore.js
@@ -204,6 +204,10 @@ export default class AddressSelectStore {
     this.handleChange();
   }
 
+  @action resetRegistryValues = () => {
+    this.registryValues = [];
+  }
+
   @action handleChange = (value = '') => {
     let index = 0;
 

--- a/js/src/ui/Form/TypedInput/typedInput.js
+++ b/js/src/ui/Form/TypedInput/typedInput.js
@@ -125,7 +125,7 @@ export default class TypedInput extends Component {
       return (
         <div className={ styles.inputs }>
           <label>{ label }</label>
-          { fixedLength ? null : this.renderLength() }
+          { fixedLength || readOnly ? null : this.renderLength() }
           { inputs }
         </div>
       );

--- a/js/src/views/Contract/Queries/inputQuery.js
+++ b/js/src/views/Contract/Queries/inputQuery.js
@@ -14,7 +14,6 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-import BigNumber from 'bignumber.js';
 import React, { Component, PropTypes } from 'react';
 import LinearProgress from 'material-ui/LinearProgress';
 import { Card, CardActions, CardTitle, CardText } from 'material-ui/Card';

--- a/js/src/views/Contract/Queries/inputQuery.js
+++ b/js/src/views/Contract/Queries/inputQuery.js
@@ -17,13 +17,16 @@
 import React, { Component, PropTypes } from 'react';
 import LinearProgress from 'material-ui/LinearProgress';
 import { Card, CardActions, CardTitle, CardText } from 'material-ui/Card';
+import { connect } from 'react-redux';
+import { bindActionCreators } from 'redux';
 
+import { newError } from '~/redux/actions';
 import { Button, TypedInput } from '~/ui';
 import { arrayOrObjectProptype } from '~/util/proptypes';
 
 import styles from './queries.css';
 
-export default class InputQuery extends Component {
+class InputQuery extends Component {
   static contextTypes = {
     api: PropTypes.object
   };
@@ -34,12 +37,12 @@ export default class InputQuery extends Component {
     inputs: arrayOrObjectProptype().isRequired,
     outputs: arrayOrObjectProptype().isRequired,
     name: PropTypes.string.isRequired,
+    newError: PropTypes.func.isRequired,
     signature: PropTypes.string.isRequired,
     className: PropTypes.string
   };
 
   state = {
-    error: null,
     isValid: true,
     results: [],
     values: {}
@@ -54,23 +57,8 @@ export default class InputQuery extends Component {
           className={ styles.methodTitle }
           title={ name }
         />
-        { this.renderError() }
         { this.renderContent() }
       </Card>
-    );
-  }
-
-  renderError () {
-    const { error } = this.state;
-
-    if (!error) {
-      return null;
-    }
-
-    return (
-      <p className={ styles.error }>
-        { error.message }
-      </p>
     );
   }
 
@@ -213,7 +201,6 @@ export default class InputQuery extends Component {
         }
 
         this.setState({
-          error: null,
           isLoading: false,
           results
         });
@@ -221,10 +208,21 @@ export default class InputQuery extends Component {
       .catch((error) => {
         console.error(`sending ${name} with params`, inputValues, error.message);
 
+        this.props.newError(error);
         this.setState({
-          isLoading: false,
-          error
+          isLoading: false
         });
       });
   };
 }
+
+function mapDispatchToProps (dispatch) {
+  return bindActionCreators({
+    newError
+  }, dispatch);
+}
+
+export default connect(
+  null,
+  mapDispatchToProps
+)(InputQuery);

--- a/js/src/views/Contract/Queries/queries.css
+++ b/js/src/views/Contract/Queries/queries.css
@@ -77,12 +77,3 @@
   max-width: 100%;
   box-sizing: border-box;
 }
-
-.error {
-  background-color: rgba(231, 76, 60,1.0);
-  border-radius: 5px;
-  color: white;
-  font-size: 0.85em;
-  margin: 0 1em;
-  padding: 0.75em;
-}

--- a/js/src/views/Contract/Queries/queries.css
+++ b/js/src/views/Contract/Queries/queries.css
@@ -77,3 +77,12 @@
   max-width: 100%;
   box-sizing: border-box;
 }
+
+.error {
+  background-color: rgba(231, 76, 60,1.0);
+  border-radius: 5px;
+  color: white;
+  font-size: 0.85em;
+  margin: 0 1em;
+  padding: 0.75em;
+}

--- a/js/src/views/Contract/Queries/queries.js
+++ b/js/src/views/Contract/Queries/queries.js
@@ -61,12 +61,25 @@ export default class Queries extends Component {
     return (
       <Container title='queries'>
         <div className={ styles.methods }>
-          <div className={ styles.vMethods }>
-            { noInputQueries }
-          </div>
-          <div className={ styles.hMethods }>
-            { withInputQueries }
-          </div>
+          {
+            noInputQueries.length > 0
+            ? (
+              <div className={ styles.vMethods }>
+                { noInputQueries }
+              </div>
+            )
+            : null
+          }
+
+          {
+            withInputQueries.length > 0
+            ? (
+              <div className={ styles.hMethods }>
+                { withInputQueries }
+              </div>
+            )
+            : null
+          }
         </div>
       </Container>
     );


### PR DESCRIPTION
Fixes #4520

Add an option to the `call` method (for functions of a contract) to output the raw tokens (`Token` class, with `type` and `value` attributes) instead of `token.value`.

Fixes some UI and logic bugs in the Address Selector too.