### PR TITLE
Explicitly set seconds to 0 from selector

### DIFF
--- a/js/src/ui/GasPriceEditor/store.js
+++ b/js/src/ui/GasPriceEditor/store.js
@@ -85,7 +85,12 @@ export default class GasPriceEditor {
           break;
 
         case CONDITIONS.TIME:
-          this.condition = Object.assign({}, this.condition, { time: new Date() });
+          const time = new Date();
+
+          time.setMilliseconds(0); // ignored by/not passed to Parity
+          time.setSeconds(0); // current time selector doesn't allow seconds
+
+          this.condition = Object.assign({}, this.condition, { time });
           break;
 
         case CONDITIONS.NONE:

--- a/js/src/ui/GasPriceEditor/store.js
+++ b/js/src/ui/GasPriceEditor/store.js
@@ -103,7 +103,9 @@ export default class GasPriceEditor {
     });
   }
 
-  @action setConditionDateTime = (time) => {
+  @action setConditionDateTime = (_time) => {
+    const time = new Date(_time);
+
     time.setMilliseconds(0); // ignored by/not passed to Parity
     time.setSeconds(0); // current time selector doesn't allow seconds
 

--- a/js/src/ui/GasPriceEditor/store.js
+++ b/js/src/ui/GasPriceEditor/store.js
@@ -81,16 +81,11 @@ export default class GasPriceEditor {
 
       switch (conditionType) {
         case CONDITIONS.BLOCK:
-          this.condition = Object.assign({}, this.condition, { block: this.blockNumber || 1 });
+          this.setConditionBlockNumber(this.blockNumber || 1);
           break;
 
         case CONDITIONS.TIME:
-          const time = new Date();
-
-          time.setMilliseconds(0); // ignored by/not passed to Parity
-          time.setSeconds(0); // current time selector doesn't allow seconds
-
-          this.condition = Object.assign({}, this.condition, { time });
+          this.setConditionDateTime(new Date());
           break;
 
         case CONDITIONS.NONE:
@@ -109,6 +104,9 @@ export default class GasPriceEditor {
   }
 
   @action setConditionDateTime = (time) => {
+    time.setMilliseconds(0); // ignored by/not passed to Parity
+    time.setSeconds(0); // current time selector doesn't allow seconds
+
     this.condition = Object.assign({}, this.condition, { time });
   }
 

--- a/js/src/ui/GasPriceEditor/store.spec.js
+++ b/js/src/ui/GasPriceEditor/store.spec.js
@@ -162,9 +162,11 @@ describe('ui/GasPriceEditor/Store', () => {
     });
 
     describe('setConditionDateTime', () => {
-      it('sets the datatime', () => {
-        store.setConditionDateTime('testingDateTime');
-        expect(store.condition.time).to.equal('testingDateTime');
+      it('sets the datetime', () => {
+        const testTime = new Date('1973-06-11 07:52');
+
+        store.setConditionDateTime(testTime);
+        expect(store.condition.time.getTime()).to.equal(testTime.getTime());
       });
     });
 

--- a/js/src/ui/GasPriceEditor/store.spec.js
+++ b/js/src/ui/GasPriceEditor/store.spec.js
@@ -162,16 +162,17 @@ describe('ui/GasPriceEditor/Store', () => {
     });
 
     describe('setConditionDateTime', () => {
-      const zeroTime = new Date('1973-06-11 07:52:00.000').getTime();
+      const BASEDATE = '1973-06-11 07:52';
+      const ZEROTIME = new Date(BASEDATE).getTime();
 
       it('sets the datetime', () => {
-        store.setConditionDateTime(new Date('1973-06-11 07:52:00.000'));
-        expect(store.condition.time.getTime()).to.equal(zeroTime);
+        store.setConditionDateTime(new Date(`${BASEDATE}:00.000`));
+        expect(store.condition.time.getTime()).to.equal(ZEROTIME);
       });
 
       it('zeros both seconds and miliseconds', () => {
-        store.setConditionDateTime(new Date('1973-06-11 07:52:12.345'));
-        expect(store.condition.time.getTime()).to.equal(zeroTime);
+        store.setConditionDateTime(new Date(`${BASEDATE}:12.345`));
+        expect(store.condition.time.getTime()).to.equal(ZEROTIME);
       });
     });
 

--- a/js/src/ui/GasPriceEditor/store.spec.js
+++ b/js/src/ui/GasPriceEditor/store.spec.js
@@ -162,11 +162,16 @@ describe('ui/GasPriceEditor/Store', () => {
     });
 
     describe('setConditionDateTime', () => {
-      it('sets the datetime', () => {
-        const testTime = new Date('1973-06-11 07:52');
+      const zeroTime = new Date('1973-06-11 07:52:00.000').getTime();
 
-        store.setConditionDateTime(testTime);
-        expect(store.condition.time.getTime()).to.equal(testTime.getTime());
+      it('sets the datetime', () => {
+        store.setConditionDateTime(new Date('1973-06-11 07:52:00.000'));
+        expect(store.condition.time.getTime()).to.equal(zeroTime);
+      });
+
+      it('zeros both seconds and miliseconds', () => {
+        store.setConditionDateTime(new Date('1973-06-11 07:52:12.345'));
+        expect(store.condition.time.getTime()).to.equal(zeroTime);
       });
     });
 


### PR DESCRIPTION
Be explicit rather than assuming that timeselector zeros seconds. Sets -

- ms to 0 (ignored, not passed through to Parity)
- sec to 0 (be explicit in expectation)

If we do change the time selector component to be granular, the seconds setting can be removed.