### PR TITLE
[beta] Explicitly set seconds to 0 from selector (#4559)

### DIFF
--- a/js/src/ui/GasPriceEditor/store.js
+++ b/js/src/ui/GasPriceEditor/store.js
@@ -81,11 +81,11 @@ export default class GasPriceEditor {
 
       switch (conditionType) {
         case CONDITIONS.BLOCK:
-          this.condition = Object.assign({}, this.condition, { block: this.blockNumber || 1 });
+          this.setConditionBlockNumber(this.blockNumber || 1);
           break;
 
         case CONDITIONS.TIME:
-          this.condition = Object.assign({}, this.condition, { time: new Date() });
+          this.setConditionDateTime(new Date());
           break;
 
         case CONDITIONS.NONE:
@@ -103,7 +103,12 @@ export default class GasPriceEditor {
     });
   }
 
-  @action setConditionDateTime = (time) => {
+  @action setConditionDateTime = (_time) => {
+    const time = new Date(_time);
+
+    time.setMilliseconds(0); // ignored by/not passed to Parity
+    time.setSeconds(0); // current time selector doesn't allow seconds
+
     this.condition = Object.assign({}, this.condition, { time });
   }
 

--- a/js/src/ui/GasPriceEditor/store.spec.js
+++ b/js/src/ui/GasPriceEditor/store.spec.js
@@ -162,9 +162,17 @@ describe('ui/GasPriceEditor/Store', () => {
     });
 
     describe('setConditionDateTime', () => {
-      it('sets the datatime', () => {
-        store.setConditionDateTime('testingDateTime');
-        expect(store.condition.time).to.equal('testingDateTime');
+      const BASEDATE = '1973-06-11 07:52';
+      const ZEROTIME = new Date(BASEDATE).getTime();
+
+      it('sets the datetime', () => {
+        store.setConditionDateTime(new Date(`${BASEDATE}:00.000`));
+        expect(store.condition.time.getTime()).to.equal(ZEROTIME);
+      });
+
+      it('zeros both seconds and miliseconds', () => {
+        store.setConditionDateTime(new Date(`${BASEDATE}:12.345`));
+        expect(store.condition.time.getTime()).to.equal(ZEROTIME);
       });
     });
 


### PR DESCRIPTION
* Explicitly set seconds/milli to 0

* Use condition time & block setters consistently

* Fix failing test

* test for 0 ms & sec

* It cannot hurt, clone date before setting

* Prettier date test constants (OCD)