### PR TITLE
remove vertx from Webpack config

### DIFF
--- a/js/webpack/npm.js
+++ b/js/webpack/npm.js
@@ -48,8 +48,7 @@ module.exports = {
     umdNamedDefine: true
   },
   externals: {
-    'node-fetch': 'node-fetch',
-    'vertx': 'vertx'
+    'node-fetch': 'node-fetch'
   },
   module: {
     noParse: [


### PR DESCRIPTION
See https://github.com/stefanpenner/es6-promise/issues/100#issuecomment-95309254 for more details. We use `es6-promise@4`, the `browser: {vertx: false}` entry has been added to `es6-promise@2`. I manually checked that one can bundle the resulting `@parity/parity.js/library.js`.