### PR TITLE
Deprecate eth_compile* RPCs

### DIFF
--- a/rpc/src/v1/helpers/errors.rs
+++ b/rpc/src/v1/helpers/errors.rs
@@ -46,10 +46,10 @@ mod codes {
 	pub const REQUEST_REJECTED: i64 = -32040;
 	pub const REQUEST_REJECTED_LIMIT: i64 = -32041;
 	pub const REQUEST_NOT_FOUND: i64 = -32042;
-	pub const COMPILATION_ERROR: i64 = -32050;
 	pub const ENCRYPTION_ERROR: i64 = -32055;
 	pub const FETCH_ERROR: i64 = -32060;
 	pub const NO_LIGHT_PEERS: i64 = -32065;
+	pub const DEPRECATED: i64 = -32070;
 }
 
 pub fn unimplemented(details: Option<String>) -> Error {
@@ -89,14 +89,6 @@ pub fn account<T: fmt::Debug>(error: &str, details: T) -> Error {
 		code: ErrorCode::ServerError(codes::ACCOUNT_ERROR),
 		message: error.into(),
 		data: Some(Value::String(format!("{:?}", details))),
-	}
-}
-
-pub fn compilation<T: fmt::Debug>(error: T) -> Error {
-	Error {
-		code: ErrorCode::ServerError(codes::COMPILATION_ERROR),
-		message: "Error while compiling code.".into(),
-		data: Some(Value::String(format!("{:?}", error))),
 	}
 }
 
@@ -315,5 +307,13 @@ pub fn no_light_peers() -> Error {
 		code: ErrorCode::ServerError(codes::NO_LIGHT_PEERS),
 		message: "No light peers who can serve data".into(),
 		data: None,
+	}
+}
+
+pub fn deprecated<T: Into<Option<String>>>(message: T) -> Error {
+	Error {
+		code: ErrorCode::ServerError(codes::DEPRECATED),
+		message: "Method deprecated".into(),
+		data: message.into().map(Value::String),
 	}
 }

--- a/rpc/src/v1/tests/mocked/eth.rs
+++ b/rpc/src/v1/tests/mocked/eth.rs
@@ -1020,7 +1020,7 @@ fn rpc_eth_transaction_receipt_null() {
 #[test]
 fn rpc_eth_compilers() {
 	let request = r#"{"jsonrpc": "2.0", "method": "eth_getCompilers", "params": [], "id": 1}"#;
-	let response = r#"{"jsonrpc":"2.0","result":[],"id":1}"#;
+	let response = r#"{"jsonrpc":"2.0","error":{"code":-32070,"message":"Method deprecated","data":"Compilation functionality is deprecated."},"id":1}"#;
 
 	assert_eq!(EthTester::default().io.handle_request_sync(request), Some(response.to_owned()));
 }
@@ -1029,7 +1029,7 @@ fn rpc_eth_compilers() {
 #[test]
 fn rpc_eth_compile_lll() {
 	let request = r#"{"jsonrpc": "2.0", "method": "eth_compileLLL", "params": [], "id": 1}"#;
-	let response = r#"{"jsonrpc":"2.0","error":{"code":-32603,"message":"Internal error","data":null},"id":1}"#;
+	let response = r#"{"jsonrpc":"2.0","error":{"code":-32070,"message":"Method deprecated","data":"Compilation of LLL via RPC is deprecated"},"id":1}"#;
 
 	assert_eq!(EthTester::default().io.handle_request_sync(request), Some(response.to_owned()));
 }
@@ -1038,7 +1038,7 @@ fn rpc_eth_compile_lll() {
 #[test]
 fn rpc_eth_compile_solidity() {
 	let request = r#"{"jsonrpc": "2.0", "method": "eth_compileSolidity", "params": [], "id": 1}"#;
-	let response = r#"{"jsonrpc":"2.0","error":{"code":-32603,"message":"Internal error","data":null},"id":1}"#;
+	let response = r#"{"jsonrpc":"2.0","error":{"code":-32070,"message":"Method deprecated","data":"Compilation of Solidity via RPC is deprecated"},"id":1}"#;
 
 	assert_eq!(EthTester::default().io.handle_request_sync(request), Some(response.to_owned()));
 }
@@ -1047,7 +1047,7 @@ fn rpc_eth_compile_solidity() {
 #[test]
 fn rpc_eth_compile_serpent() {
 	let request = r#"{"jsonrpc": "2.0", "method": "eth_compileSerpent", "params": [], "id": 1}"#;
-	let response = r#"{"jsonrpc":"2.0","error":{"code":-32603,"message":"Internal error","data":null},"id":1}"#;
+	let response = r#"{"jsonrpc":"2.0","error":{"code":-32070,"message":"Method deprecated","data":"Compilation of Serpent via RPC is deprecated"},"id":1}"#;
 
 	assert_eq!(EthTester::default().io.handle_request_sync(request), Some(response.to_owned()));
 }

--- a/rpc/src/v1/traits/eth.rs
+++ b/rpc/src/v1/traits/eth.rs
@@ -142,18 +142,22 @@ build_rpc_trait! {
 		fn uncle_by_block_number_and_index(&self, BlockNumber, Index) -> Result<Option<RichBlock>, Error>;
 
 		/// Returns available compilers.
+		/// @deprecated
 		#[rpc(name = "eth_getCompilers")]
 		fn compilers(&self) -> Result<Vec<String>, Error>;
 
 		/// Compiles lll code.
+		/// @deprecated
 		#[rpc(name = "eth_compileLLL")]
 		fn compile_lll(&self, String) -> Result<Bytes, Error>;
 
 		/// Compiles solidity.
+		/// @deprecated
 		#[rpc(name = "eth_compileSolidity")]
 		fn compile_solidity(&self, String) -> Result<Bytes, Error>;
 
 		/// Compiles serpent.
+		/// @deprecated
 		#[rpc(name = "eth_compileSerpent")]
 		fn compile_serpent(&self, String) -> Result<Bytes, Error>;
 


### PR DESCRIPTION
See https://github.com/ethereum/EIPs/issues/209

We don't use this in the UI AFAIK, the contract editor just uses browser-solidity, right @ngotchac?