### PR TITLE
Display ETH balance in overlay account selector

### DIFF
--- a/docker/hub/Dockerfile
+++ b/docker/hub/Dockerfile
@@ -1,4 +1,5 @@
 FROM ubuntu:14.04
+MAINTAINER Parity Technologies <devops@parity.io>
 WORKDIR /build
 # install tools and dependencies
 RUN apt-get update && \
@@ -25,46 +26,54 @@ RUN apt-get update && \
         # evmjit dependencies
         zlib1g-dev \
         libedit-dev \
-	libudev-dev
-
-# cmake and llvm ppas. then update ppas
-RUN add-apt-repository -y "ppa:george-edison55/cmake-3.x" && \
+	libudev-dev &&\
+# cmake and llvm ppa's. then update ppa's
+ add-apt-repository -y "ppa:george-edison55/cmake-3.x" && \
         add-apt-repository "deb http://llvm.org/apt/trusty/ llvm-toolchain-trusty-3.7 main" && \
         apt-get update && \
-        apt-get install -y --force-yes cmake llvm-3.7-dev
-
+        apt-get install -y --force-yes cmake llvm-3.7-dev && \
 # install evmjit
-RUN git clone https://github.com/debris/evmjit && \
+ git clone https://github.com/debris/evmjit && \
         cd evmjit && \
         mkdir build && cd build && \
-        cmake .. && make && make install && cd
-
+        cmake .. && make && make install && cd && \
 # install rustup
-RUN curl https://sh.rustup.rs -sSf | sh -s -- -y
-
+ curl https://sh.rustup.rs -sSf | sh -s -- -y && \
 # rustup directory
-ENV PATH /root/.cargo/bin:$PATH
-
+ PATH=/root/.cargo/bin:$PATH && \
 # show backtraces
-ENV RUST_BACKTRACE 1
-
-# show tools
-RUN rustc -vV && \
-cargo -V && \
-gcc -v &&\
-g++ -v
-
+ RUST_BACKTRACE=1 && \
 # build parity
-RUN git clone https://github.com/ethcore/parity && \
+ cd /build&&git clone https://github.com/ethcore/parity && \
         cd parity && \
-        git checkout $CI_BUILD_REF_NAME && \
-        cargo build --release --features final && \
-        ls /build/parity/target/release/parity && \
-        strip /build/parity/target/release/parity
-
-RUN file /build/parity/target/release/parity&&mkdir -p /parity&&cp /build/parity/target/release/parity /parity
+	git pull&& \
+	git checkout $CI_BUILD_REF_NAME && \
+        cargo build --verbose --release --features final && \
+        #ls /build/parity/target/release/parity && \
+        strip /build/parity/target/release/parity && \
+ file /build/parity/target/release/parity&&mkdir -p /parity&& cp /build/parity/target/release/parity /parity&&\
 #cleanup Docker image
-RUN rm -rf /root/.cargo&&rm -rf /root/.multirust&&rm -rf /root/.rustup&&rm -rf /build
-
+ rm -rf /root/.cargo&&rm -rf /root/.multirust&&rm -rf /root/.rustup&&rm -rf /build&&\
+ apt-get purge -y  \
+        # make
+        build-essential \
+        # add-apt-repository
+        software-properties-common \
+        make \
+        curl \
+        wget \
+        git \
+        g++ \
+        gcc \
+        binutils \
+        file \
+        pkg-config \
+        dpkg-dev \
+        # evmjit dependencies
+        zlib1g-dev \
+        libedit-dev \
+        cmake llvm-3.7-dev&&\
+ rm -rf /var/lib/apt/lists/*
+# setup ENTRYPOINT
 EXPOSE 8080 8545 8180
 ENTRYPOINT ["/parity/parity"]

--- a/js/src/modals/DappPermissions/dappPermissions.js
+++ b/js/src/modals/DappPermissions/dappPermissions.js
@@ -17,6 +17,7 @@
 import { observer } from 'mobx-react';
 import React, { Component, PropTypes } from 'react';
 import { FormattedMessage } from 'react-intl';
+import { connect } from 'react-redux';
 
 import { AccountCard, Portal, SectionList } from '~/ui';
 import { CheckIcon, StarIcon, StarOutlineIcon } from '~/ui/Icons';
@@ -24,15 +25,16 @@ import { CheckIcon, StarIcon, StarOutlineIcon } from '~/ui/Icons';
 import styles from './dappPermissions.css';
 
 @observer
-export default class DappPermissions extends Component {
+class DappPermissions extends Component {
   static propTypes = {
-    store: PropTypes.object.isRequired
+    balances: PropTypes.object,
+    permissionStore: PropTypes.object.isRequired
   };
 
   render () {
-    const { store } = this.props;
+    const { permissionStore } = this.props;
 
-    if (!store.modalOpen) {
+    if (!permissionStore.modalOpen) {
       return null;
     }
 
@@ -50,7 +52,7 @@ export default class DappPermissions extends Component {
             />
           </div>
         }
-        onClose={ store.closeModal }
+        onClose={ permissionStore.closeModal }
         open
         title={
           <FormattedMessage
@@ -61,7 +63,7 @@ export default class DappPermissions extends Component {
       >
         <div className={ styles.container }>
           <SectionList
-            items={ store.accounts }
+            items={ permissionStore.accounts }
             noStretch
             renderItem={ this.renderAccount }
           />
@@ -71,14 +73,15 @@ export default class DappPermissions extends Component {
   }
 
   renderAccount = (account) => {
-    const { store } = this.props;
+    const { balances, permissionStore } = this.props;
+    const balance = balances[account.address];
 
     const onMakeDefault = () => {
-      store.setDefaultAccount(account.address);
+      permissionStore.setDefaultAccount(account.address);
     };
 
     const onSelect = () => {
-      store.selectAccount(account.address);
+      permissionStore.selectAccount(account.address);
     };
 
     let className;
@@ -95,6 +98,7 @@ export default class DappPermissions extends Component {
       <div className={ styles.item }>
         <AccountCard
           account={ account }
+          balance={ balance }
           className={ className }
           onClick={ onSelect }
         />
@@ -114,3 +118,16 @@ export default class DappPermissions extends Component {
     );
   }
 }
+
+function mapStateToProps (state) {
+  const { balances } = state.balances;
+
+  return {
+    balances
+  };
+}
+
+export default connect(
+  mapStateToProps,
+  null
+)(DappPermissions);

--- a/js/src/modals/DappPermissions/dappPermissions.spec.js
+++ b/js/src/modals/DappPermissions/dappPermissions.spec.js
@@ -16,13 +16,40 @@
 
 import { shallow } from 'enzyme';
 import React from 'react';
+import sinon from 'sinon';
 
 import DappPermissions from './';
 
-function renderShallow (store = {}) {
-  return shallow(
-    <DappPermissions store={ store } />
-  );
+let component;
+let store;
+
+function createRedux () {
+  store = {
+    dispatch: sinon.stub(),
+    subscribe: sinon.stub(),
+    getState: () => {
+      return {
+        balances: {
+          balances: {}
+        }
+      };
+    }
+  };
+
+  return store;
+}
+
+function renderShallow (permissionStore = {}) {
+  component = shallow(
+    <DappPermissions permissionStore={ permissionStore } />,
+    {
+      context: {
+        store: createRedux()
+      }
+    }
+  ).find('DappPermissions').shallow();
+
+  return component;
 }
 
 describe('modals/DappPermissions', () => {

--- a/js/src/modals/VaultAccounts/vaultAccounts.js
+++ b/js/src/modals/VaultAccounts/vaultAccounts.js
@@ -35,6 +35,7 @@ class VaultAccounts extends Component {
 
   static propTypes = {
     accounts: PropTypes.object.isRequired,
+    balances: PropTypes.object.isRequired,
     newError: PropTypes.func.isRequired,
     personalAccountsInfo: PropTypes.func.isRequired,
     vaultStore: PropTypes.object.isRequired
@@ -105,7 +106,9 @@ class VaultAccounts extends Component {
   // (although that has defaults) and this one. A genrerix multi-select component
   // would be applicable going forward. (Originals passed in, new selections back)
   renderAccount = (account) => {
+    const { balances } = this.props;
     const { vaultName, selectedAccounts } = this.props.vaultStore;
+    const balance = balances[account.address];
     const isInVault = account.meta.vault === vaultName;
     const isSelected = isInVault
       ? !selectedAccounts[account.address]
@@ -119,6 +122,7 @@ class VaultAccounts extends Component {
       <div className={ styles.item }>
         <AccountCard
           account={ account }
+          balance={ balance }
           className={
             isSelected
               ? styles.selected
@@ -177,9 +181,13 @@ class VaultAccounts extends Component {
 }
 
 function mapStateToProps (state) {
+  const { balances } = state.balances;
   const { accounts } = state.personal;
 
-  return { accounts };
+  return {
+    accounts,
+    balances
+  };
 }
 
 function mapDispatchToProps (dispatch) {

--- a/js/src/modals/VaultAccounts/vaultAccounts.spec.js
+++ b/js/src/modals/VaultAccounts/vaultAccounts.spec.js
@@ -75,6 +75,9 @@ function createReduxStore () {
     subscribe: sinon.stub(),
     getState: () => {
       return {
+        balances: {
+          balances: {}
+        },
         personal: {
           accounts: ACCOUNTS
         }

--- a/js/src/ui/AccountCard/accountCard.css
+++ b/js/src/ui/AccountCard/accountCard.css
@@ -120,6 +120,9 @@
 
   .accountName {
     font-weight: 700 !important;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 }
 

--- a/js/src/ui/VaultCard/vaultCard.js
+++ b/js/src/ui/VaultCard/vaultCard.js
@@ -85,7 +85,10 @@ export default class VaultCard extends Component {
         {
           accounts.map((address) => {
             return (
-              <Link to={ `/accounts/${address}` }>
+              <Link
+                key={ address }
+                to={ `/accounts/${address}` }
+              >
                 <IdentityIcon
                   address={ address }
                   center

--- a/js/src/views/Dapps/dapps.js
+++ b/js/src/views/Dapps/dapps.js
@@ -80,7 +80,7 @@ class Dapps extends Component {
 
     return (
       <div>
-        <DappPermissions store={ this.permissionStore } />
+        <DappPermissions permissionStore={ this.permissionStore } />
         <DappsVisible store={ this.store } />
         <Actionbar
           className={ styles.toolbar }

--- a/js/src/views/ParityBar/parityBar.js
+++ b/js/src/views/ParityBar/parityBar.js
@@ -48,6 +48,7 @@ class ParityBar extends Component {
   };
 
   static propTypes = {
+    balances: PropTypes.object,
     dapp: PropTypes.bool,
     externalLink: PropTypes.string,
     pending: PropTypes.array
@@ -344,6 +345,8 @@ class ParityBar extends Component {
   }
 
   renderAccount = (account) => {
+    const { balances } = this.props;
+    const balance = balances[account.address];
     const makeDefaultAccount = () => {
       return this.accountStore
         .makeDefaultAccount(account.address)
@@ -363,6 +366,7 @@ class ParityBar extends Component {
       >
         <AccountCard
           account={ account }
+          balance={ balance }
           className={
             account.default
               ? styles.selected
@@ -658,9 +662,11 @@ class ParityBar extends Component {
 }
 
 function mapStateToProps (state) {
+  const { balances } = state.balances;
   const { pending } = state.signer;
 
   return {
+    balances,
     pending
   };
 }

--- a/js/src/views/ParityBar/parityBar.spec.js
+++ b/js/src/views/ParityBar/parityBar.spec.js
@@ -31,7 +31,14 @@ function createRedux (state = {}) {
   store = {
     dispatch: sinon.stub(),
     subscribe: sinon.stub(),
-    getState: () => Object.assign({ signer: { pending: [] } }, state)
+    getState: () => Object.assign({
+      balances: {
+        balances: {}
+      },
+      signer: {
+        pending: []
+      }
+    }, state)
   };
 
   return store;


### PR DESCRIPTION
- Closes https://github.com/ethcore/parity/issues/4524
- Add balance display to AccountCard for defaultAccount selectors
- Don't wrap account header (if name is longer ...)

![parity 2017-02-17 16-18-58](https://cloud.githubusercontent.com/assets/1424473/23070959/1756e556-f52d-11e6-8815-238d7484f731.png)

![parity 2017-02-17 16-31-37](https://cloud.githubusercontent.com/assets/1424473/23071490/cb1a442e-f52e-11e6-8e78-d3c175eea0a1.png)

![parity 2017-02-21 10-56-09](https://cloud.githubusercontent.com/assets/1424473/23159796/76247112-f824-11e6-9be4-69f108e6c345.png)

