### PR TITLE
Remainder of RPC APIs implemented for the light client

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -393,6 +393,7 @@ dependencies = [
  "rust-crypto 0.2.36 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.19 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.5.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stats 0.1.0",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "transient-hashmap 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -615,6 +616,7 @@ dependencies = [
  "serde 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_json 0.9.5 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stats 0.1.0",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
  "transient-hashmap 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2128,6 +2130,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 name = "stable-heap"
 version = "0.1.0"
 source = "git+https://github.com/carllerche/stable-heap?rev=3c5cd1ca47#3c5cd1ca4706f167a1de85658b5af0d6d3e65165"
+
+[[package]]
+name = "stats"
+version = "0.1.0"
+dependencies = [
+ "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
+]
 
 [[package]]
 name = "strsim"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -427,7 +427,7 @@ dependencies = [
  "ethcore-rpc 1.6.0",
  "ethcore-util 1.6.0",
  "fetch 0.1.0",
- "futures 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.10.0-a.0 (git+https://github.com/ethcore/hyper)",
  "jsonrpc-core 6.0.0 (git+https://github.com/ethcore/jsonrpc.git)",
  "jsonrpc-http-server 6.0.0 (git+https://github.com/ethcore/jsonrpc.git)",
@@ -536,12 +536,13 @@ dependencies = [
  "ethcore-ipc-codegen 1.6.0",
  "ethcore-network 1.6.0",
  "ethcore-util 1.6.0",
- "futures 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "itertools 0.5.9 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "rlp 0.1.0",
  "smallvec 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
+ "stats 0.1.0",
  "time 0.1.35 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -601,7 +602,7 @@ dependencies = [
  "ethstore 0.1.0",
  "ethsync 1.6.0",
  "fetch 0.1.0",
- "futures 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 6.0.0 (git+https://github.com/ethcore/jsonrpc.git)",
  "jsonrpc-http-server 6.0.0 (git+https://github.com/ethcore/jsonrpc.git)",
  "jsonrpc-ipc-server 6.0.0 (git+https://github.com/ethcore/jsonrpc.git)",
@@ -650,7 +651,7 @@ dependencies = [
  "ethcore-ipc-codegen 1.6.0",
  "ethcore-ipc-nano 1.6.0",
  "ethcore-util 1.6.0",
- "futures 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 6.0.0 (git+https://github.com/ethcore/jsonrpc.git)",
  "jsonrpc-macros 6.0.0 (git+https://github.com/ethcore/jsonrpc.git)",
  "jsonrpc-tcp-server 6.0.0 (git+https://github.com/ethcore/jsonrpc.git)",
@@ -813,7 +814,7 @@ dependencies = [
 name = "fetch"
 version = "0.1.0"
 dependencies = [
- "futures 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "futures-cpupool 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -832,7 +833,7 @@ dependencies = [
 
 [[package]]
 name = "futures"
-version = "0.1.6"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -844,7 +845,7 @@ version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "crossbeam 0.2.10 (registry+https://github.com/rust-lang/crates.io-index)",
- "futures 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "num_cpus 1.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1045,7 +1046,7 @@ name = "jsonrpc-core"
 version = "6.0.0"
 source = "git+https://github.com/ethcore/jsonrpc.git#86d7a89c85f324b5f6671315d9b71010ca995300"
 dependencies = [
- "futures 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "serde_derive 0.9.6 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1565,7 +1566,7 @@ dependencies = [
  "ethabi 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "ethcore-util 1.6.0",
  "fetch 0.1.0",
- "futures 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)",
  "mime_guess 1.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1578,7 +1579,7 @@ dependencies = [
 name = "parity-reactor"
 version = "0.1.0"
 dependencies = [
- "futures 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "tokio-core 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
@@ -1589,7 +1590,7 @@ dependencies = [
  "ethcore-rpc 1.6.0",
  "ethcore-signer 1.6.0",
  "ethcore-util 1.6.0",
- "futures 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "jsonrpc-core 6.0.0 (git+https://github.com/ethcore/jsonrpc.git)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -1898,7 +1899,7 @@ dependencies = [
  "ethcore-bigint 0.1.2",
  "ethcore-rpc 1.6.0",
  "ethcore-util 1.6.0",
- "futures 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "parity-rpc-client 1.4.0",
  "rpassword 0.3.0 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
@@ -2249,7 +2250,7 @@ name = "tokio-core"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "mio 0.6.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "scoped-tls 0.1.0 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2261,7 +2262,7 @@ name = "tokio-proto"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
  "log 0.3.6 (registry+https://github.com/rust-lang/crates.io-index)",
  "net2 0.2.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "rand 0.3.14 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -2277,7 +2278,7 @@ name = "tokio-service"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
- "futures 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "futures 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
 
 [[package]]
@@ -2503,7 +2504,7 @@ dependencies = [
 "checksum ethabi 1.0.0 (registry+https://github.com/rust-lang/crates.io-index)" = "5d8f6cc4c1acd005f48e1d17b06a461adac8fb6eeeb331fbf19a0e656fba91cd"
 "checksum fdlimit 0.1.1 (registry+https://github.com/rust-lang/crates.io-index)" = "b1ee15a7050e5580b3712877157068ea713b245b080ff302ae2ca973cfcd9baa"
 "checksum flate2 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)" = "3eeb481e957304178d2e782f2da1257f1434dfecbae883bafb61ada2a9fea3bb"
-"checksum futures 0.1.6 (registry+https://github.com/rust-lang/crates.io-index)" = "0bad0a2ac64b227fdc10c254051ae5af542cf19c9328704fd4092f7914196897"
+"checksum futures 0.1.10 (registry+https://github.com/rust-lang/crates.io-index)" = "c1913eb7083840b1bbcbf9631b7fda55eaf35fe7ead13cca034e8946f9e2bc41"
 "checksum futures-cpupool 0.1.2 (registry+https://github.com/rust-lang/crates.io-index)" = "bb982bb25cd8fa5da6a8eb3a460354c984ff1113da82bcb4f0b0862b5795db82"
 "checksum gcc 0.3.35 (registry+https://github.com/rust-lang/crates.io-index)" = "91ecd03771effb0c968fd6950b37e89476a578aaf1c70297d8e92b6516ec3312"
 "checksum gdi32-sys 0.2.0 (registry+https://github.com/rust-lang/crates.io-index)" = "0912515a8ff24ba900422ecda800b52f4016a56251922d397c576bf92c690518"

--- a/ethcore/Cargo.toml
+++ b/ethcore/Cargo.toml
@@ -43,6 +43,7 @@ rlp = { path = "../util/rlp" }
 ethcore-stratum = { path = "../stratum" }
 ethcore-bloom-journal = { path = "../util/bloom" }
 hardware-wallet = { path = "../hw" }
+stats = { path = "../util/stats" }
 
 [dependencies.hyper]
 git = "https://github.com/ethcore/hyper"

--- a/ethcore/light/Cargo.toml
+++ b/ethcore/light/Cargo.toml
@@ -23,6 +23,7 @@ smallvec = "0.3.1"
 futures = "0.1"
 rand = "0.3"
 itertools = "0.5"
+stats = { path = "../../util/stats" }
 
 [features]
 default = []

--- a/ethcore/light/src/cache.rs
+++ b/ethcore/light/src/cache.rs
@@ -156,7 +156,7 @@ impl Cache {
 #[cfg(test)]
 mod tests {
 	use super::Cache;
-	use time::{Duration, SteadyTime};
+	use time::Duration;
 
 	#[test]
 	fn corpus_inaccessible() {

--- a/ethcore/light/src/cache.rs
+++ b/ethcore/light/src/cache.rs
@@ -24,6 +24,7 @@ use ethcore::encoded;
 use ethcore::header::BlockNumber;
 use ethcore::receipt::Receipt;
 
+use stats::Corpus;
 use time::{SteadyTime, Duration};
 use util::{U256, H256};
 use util::cache::MemoryLruCache;
@@ -66,7 +67,7 @@ pub struct Cache {
 	bodies: MemoryLruCache<H256, encoded::Body>,
 	receipts: MemoryLruCache<H256, Vec<Receipt>>,
 	chain_score: MemoryLruCache<H256, U256>,
-	corpus: Option<(Vec<U256>, SteadyTime)>,
+	corpus: Option<(Corpus<U256>, SteadyTime)>,
 	corpus_expiration: Duration,
 }
 
@@ -135,7 +136,7 @@ impl Cache {
 	}
 
 	/// Get gas price corpus, if recent enough.
-	pub fn gas_price_corpus(&self) -> Option<Vec<U256>> {
+	pub fn gas_price_corpus(&self) -> Option<Corpus<U256>> {
 		let now = SteadyTime::now();
 
 		self.corpus.as_ref().and_then(|&(ref corpus, ref tm)| {
@@ -148,7 +149,7 @@ impl Cache {
 	}
 
 	/// Set the cached gas price corpus.
-	pub fn set_gas_price_corpus(&mut self, corpus: Vec<U256>) {
+	pub fn set_gas_price_corpus(&mut self, corpus: Corpus<U256>) {
 		self.corpus = Some((corpus, SteadyTime::now()))
 	}
 }
@@ -162,8 +163,8 @@ mod tests {
 	fn corpus_inaccessible() {
 		let mut cache = Cache::new(Default::default(), Duration::hours(5));
 
-		cache.set_gas_price_corpus(vec![]);
-		assert_eq!(cache.gas_price_corpus(), Some(vec![]));
+		cache.set_gas_price_corpus(vec![].into());
+		assert_eq!(cache.gas_price_corpus(), Some(vec![].into()));
 
 		{
 			let corpus_time = &mut cache.corpus.as_mut().unwrap().1;

--- a/ethcore/light/src/cache.rs
+++ b/ethcore/light/src/cache.rs
@@ -1,0 +1,174 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Cache for data fetched from the network.
+//!
+//! Stores ancient block headers, bodies, receipts, and total difficulties.
+//! Furthermore, stores a "gas price corpus" of relative recency, which is a sorted
+//! vector of all gas prices from a recent range of blocks.
+
+use ethcore::encoded;
+use ethcore::header::BlockNumber;
+use ethcore::receipt::Receipt;
+
+use time::{SteadyTime, Duration};
+use util::{U256, H256};
+use util::cache::MemoryLruCache;
+
+/// Configuration for how much data to cache.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct CacheSizes {
+	/// Maximum size, in bytes, of cached headers.
+	pub headers: usize,
+	/// Maximum size, in bytes, of cached canonical hashes.
+	pub canon_hashes: usize,
+	/// Maximum size, in bytes, of cached block bodies.
+	pub bodies: usize,
+	/// Maximum size, in bytes, of cached block receipts.
+	pub receipts: usize,
+	/// Maximum size, in bytes, of cached chain score for the block.
+	pub chain_score: usize,
+}
+
+impl Default for CacheSizes {
+	fn default() -> Self {
+		const MB: usize = 1024 * 1024;
+		CacheSizes {
+			headers: 10 * MB,
+			canon_hashes: 3 * MB,
+			bodies: 20 * MB,
+			receipts: 10 * MB,
+			chain_score: 7 * MB,
+		}
+	}
+}
+
+/// The light client data cache.
+///
+/// Note that almost all getter methods take `&mut self` due to the necessity to update
+/// the underlying LRU-caches on read.
+pub struct Cache {
+	headers: MemoryLruCache<H256, encoded::Header>,
+	canon_hashes: MemoryLruCache<BlockNumber, H256>,
+	bodies: MemoryLruCache<H256, encoded::Body>,
+	receipts: MemoryLruCache<H256, Vec<Receipt>>,
+	chain_score: MemoryLruCache<H256, U256>,
+	corpus: Option<(Vec<U256>, SteadyTime)>,
+	corpus_expiration: Duration,
+}
+
+impl Cache {
+	/// Create a new data cache with the given sizes and gas price corpus expiration time.
+	pub fn new(sizes: CacheSizes, corpus_expiration: Duration) -> Self {
+		Cache {
+			headers: MemoryLruCache::new(sizes.headers),
+			canon_hashes: MemoryLruCache::new(sizes.canon_hashes),
+			bodies: MemoryLruCache::new(sizes.bodies),
+			receipts: MemoryLruCache::new(sizes.receipts),
+			chain_score: MemoryLruCache::new(sizes.chain_score),
+			corpus: None,
+			corpus_expiration: corpus_expiration,
+		}
+	}
+
+	/// Query header by hash.
+	pub fn block_header(&mut self, hash: &H256) -> Option<encoded::Header> {
+		self.headers.get_mut(hash).map(|x| x.clone())
+	}
+
+	/// Query hash by number.
+	pub fn block_hash(&mut self, num: &BlockNumber) -> Option<H256> {
+		self.canon_hashes.get_mut(num).map(|x| x.clone())
+	}
+
+	/// Query block body by block hash.
+	pub fn block_body(&mut self, hash: &H256) -> Option<encoded::Body> {
+		self.bodies.get_mut(hash).map(|x| x.clone())
+	}
+
+	/// Query block receipts by block hash.
+	pub fn block_receipts(&mut self, hash: &H256) -> Option<Vec<Receipt>> {
+		self.receipts.get_mut(hash).map(|x| x.clone())
+	}
+
+	/// Query chain score by block hash.
+	pub fn chain_score(&mut self, hash: &H256) -> Option<U256> {
+		self.chain_score.get_mut(hash).map(|x| x.clone())
+	}
+
+	/// Cache the given header.
+	pub fn insert_block_header(&mut self, hash: H256, hdr: encoded::Header) {
+		self.headers.insert(hash, hdr);
+	}
+
+	/// Cache the given canonical block hash.
+	pub fn insert_block_hash(&mut self, num: BlockNumber, hash: H256) {
+		self.canon_hashes.insert(num, hash);
+	}
+
+	/// Cache the given block body.
+	pub fn insert_block_body(&mut self, hash: H256, body: encoded::Body) {
+		self.bodies.insert(hash, body);
+	}
+
+	/// Cache the given block receipts.
+	pub fn insert_block_receipts(&mut self, hash: H256, receipts: Vec<Receipt>) {
+		self.receipts.insert(hash, receipts);
+	}
+
+	/// Cache the given chain scoring.
+	pub fn insert_chain_score(&mut self, hash: H256, score: U256) {
+		self.chain_score.insert(hash, score);
+	}
+
+	/// Get gas price corpus, if recent enough.
+	pub fn gas_price_corpus(&self) -> Option<Vec<U256>> {
+		let now = SteadyTime::now();
+
+		self.corpus.as_ref().and_then(|&(ref corpus, ref tm)| {
+			if *tm + self.corpus_expiration >= now {
+				Some(corpus.clone())
+			} else {
+				None
+			}
+		})
+	}
+
+	/// Set the cached gas price corpus.
+	pub fn set_gas_price_corpus(&mut self, corpus: Vec<U256>) {
+		self.corpus = Some((corpus, SteadyTime::now()))
+	}
+}
+
+#[cfg(test)]
+mod tests {
+	use super::Cache;
+	use time::{Duration, SteadyTime};
+
+	#[test]
+	fn corpus_inaccessible() {
+		let mut cache = Cache::new(Default::default(), Duration::hours(5));
+
+		cache.set_gas_price_corpus(vec![]);
+		assert_eq!(cache.gas_price_corpus(), Some(vec![]));
+
+		{
+			let corpus_time = &mut cache.corpus.as_mut().unwrap().1;
+			*corpus_time = *corpus_time - Duration::hours(6);
+		}
+		assert!(cache.gas_price_corpus().is_none());
+	}
+}

--- a/ethcore/light/src/client/mod.rs
+++ b/ethcore/light/src/client/mod.rs
@@ -20,7 +20,7 @@ use std::sync::Arc;
 
 use ethcore::block_import_error::BlockImportError;
 use ethcore::block_status::BlockStatus;
-use ethcore::client::ClientReport;
+use ethcore::client::{ClientReport, EnvInfo};
 use ethcore::engines::Engine;
 use ethcore::ids::BlockId;
 use ethcore::header::Header;
@@ -61,6 +61,9 @@ pub trait LightChainClient: Send + Sync {
 
 	/// Get the best block header.
 	fn best_block_header(&self) -> encoded::Header;
+
+	/// Get the signing network ID.
+	fn signing_network_id(&self) -> Option<u64>;
 
 	/// Query whether a block is known.
 	fn is_known(&self, hash: &H256) -> bool;
@@ -164,6 +167,11 @@ impl Client {
 		self.chain.best_header()
 	}
 
+	/// Get the signing network id.
+	pub fn signing_network_id(&self) -> Option<u64> {
+		self.engine.signing_network_id(&self.latest_env_info())
+	}
+
 	/// Flush the header queue.
 	pub fn flush_queue(&self) {
 		self.queue.flush()
@@ -217,6 +225,33 @@ impl Client {
 	pub fn engine(&self) -> &Engine {
 		&*self.engine
 	}
+
+	fn latest_env_info(&self) -> EnvInfo {
+		let header = self.best_block_header();
+
+		EnvInfo {
+			number: header.number(),
+			author: header.author(),
+			timestamp: header.timestamp(),
+			difficulty: header.difficulty(),
+			last_hashes: self.build_last_hashes(header.hash()),
+			gas_used: Default::default(),
+			gas_limit: header.gas_limit(),
+		}
+	}
+
+	fn build_last_hashes(&self, mut parent_hash: H256) -> Arc<Vec<H256>> {
+		let mut v = Vec::with_capacity(256);
+		for _ in 0..255 {
+			v.push(parent_hash);
+			match self.block_header(BlockId::Hash(parent_hash)) {
+				Some(header) => parent_hash = header.hash(),
+				None => break,
+			}
+		}
+
+		Arc::new(v)
+	}
 }
 
 impl LightChainClient for Client {
@@ -232,6 +267,10 @@ impl LightChainClient for Client {
 
 	fn best_block_header(&self) -> encoded::Header {
 		Client::best_block_header(self)
+	}
+
+	fn signing_network_id(&self) -> Option<u64> {
+		Client::signing_network_id(self)
 	}
 
 	fn is_known(&self, hash: &H256) -> bool {

--- a/ethcore/light/src/lib.rs
+++ b/ethcore/light/src/lib.rs
@@ -72,6 +72,7 @@ extern crate time;
 extern crate futures;
 extern crate rand;
 extern crate itertools;
+extern crate stats;
 
 #[cfg(feature = "ipc")]
 extern crate ethcore_ipc as ipc;

--- a/ethcore/light/src/lib.rs
+++ b/ethcore/light/src/lib.rs
@@ -37,6 +37,7 @@ pub mod cht;
 pub mod net;
 pub mod on_demand;
 pub mod transaction_queue;
+pub mod cache;
 
 #[cfg(not(feature = "ipc"))]
 pub mod provider;

--- a/ethcore/light/src/net/mod.rs
+++ b/ethcore/light/src/net/mod.rs
@@ -322,6 +322,16 @@ impl LightProtocol {
 			.map(|peer| peer.lock().status.clone())
 	}
 
+	/// Get number of (connected, active) peers.
+	pub fn peer_count(&self) -> (usize, usize) {
+		let num_pending = self.pending_peers.read().len();
+		let peers = self.peers.read();
+		(
+			num_pending + peers.len(),
+			peers.values().filter(|p| !p.lock().pending_requests.is_empty()).count(),
+		)
+	}
+
 	/// Check the maximum amount of requests of a specific type
 	/// which a peer would be able to serve. Returns zero if the
 	/// peer is unknown or has no buffer flow parameters.

--- a/ethcore/light/src/net/request_set.rs
+++ b/ethcore/light/src/net/request_set.rs
@@ -110,6 +110,14 @@ impl RequestSet {
 	pub fn collect_ids<F>(&self) -> F where F: FromIterator<ReqId> {
 		self.ids.keys().cloned().collect()
 	}
+
+	/// Number of requests in the set.
+	pub fn len(&self) -> usize {
+		self.ids.len()
+	}
+
+	/// Whether the set is empty.
+	pub fn is_empty(&self) -> bool { self.len() == 0 }
 }
 
 #[cfg(test)]

--- a/ethcore/src/client/traits.rs
+++ b/ethcore/src/client/traits.rs
@@ -16,7 +16,6 @@
 
 use std::collections::BTreeMap;
 use util::{U256, Address, H256, H2048, Bytes, Itertools};
-use util::stats::Histogram;
 use blockchain::TreeRoute;
 use verification::queue::QueueInfo as BlockQueueInfo;
 use block::{OpenBlock, SealedBlock};
@@ -212,38 +211,24 @@ pub trait BlockChainClient : Sync + Send {
 	fn ready_transactions(&self) -> Vec<PendingTransaction>;
 
 	/// Sorted list of transaction gas prices from at least last sample_size blocks.
-	fn gas_price_corpus(&self, sample_size: usize) -> Vec<U256> {
+	fn gas_price_corpus(&self, sample_size: usize) -> ::stats::Corpus<U256> {
 		let mut h = self.chain_info().best_block_hash;
 		let mut corpus = Vec::new();
 		while corpus.is_empty() {
 			for _ in 0..sample_size {
-				let block = self.block(BlockId::Hash(h)).expect("h is either the best_block_hash or an ancestor; qed");
-				let header = block.header_view();
-				if header.number() == 0 {
-					corpus.sort();
-					return corpus;
+				let block = match self.block(BlockId::Hash(h)) {
+					Some(block) => block,
+					None => return corpus.into(),
+				};
+
+				if block.number() == 0 {
+					return corpus.into();
 				}
 				block.transaction_views().iter().foreach(|t| corpus.push(t.gas_price()));
-				h = header.parent_hash().clone();
+				h = block.parent_hash().clone();
 			}
 		}
-		corpus.sort();
-		corpus
-	}
-
-	/// Calculate median gas price from recent blocks if they have any transactions.
-	fn gas_price_median(&self, sample_size: usize) -> Option<U256> {
-		let corpus = self.gas_price_corpus(sample_size);
-		corpus.get(corpus.len() / 2).cloned()
-	}
-
-	/// Get the gas price distribution based on recent blocks if they have any transactions.
-	fn gas_price_histogram(&self, sample_size: usize, bucket_number: usize) -> Option<Histogram> {
-		let raw_corpus = self.gas_price_corpus(sample_size);
-		let raw_len = raw_corpus.len();
-		// Throw out outliers.
-		let (corpus, _) = raw_corpus.split_at(raw_len - raw_len / 40);
-		Histogram::new(corpus, bucket_number)
+		corpus.into()
 	}
 
 	/// Get the preferred network ID to sign on

--- a/ethcore/src/lib.rs
+++ b/ethcore/src/lib.rs
@@ -106,6 +106,7 @@ extern crate lru_cache;
 extern crate ethcore_stratum;
 extern crate ethabi;
 extern crate hardware_wallet;
+extern crate stats;
 
 #[macro_use]
 extern crate log;

--- a/ethcore/src/tests/client.rs
+++ b/ethcore/src/tests/client.rs
@@ -27,7 +27,6 @@ use miner::Miner;
 use rlp::View;
 use spec::Spec;
 use views::BlockView;
-use util::stats::Histogram;
 use ethkey::{KeyPair, Secret};
 use transaction::{PendingTransaction, Transaction, Action, Condition};
 use miner::MinerService;
@@ -208,11 +207,11 @@ fn can_collect_garbage() {
 fn can_generate_gas_price_median() {
 	let client_result = generate_dummy_client_with_data(3, 1, slice_into![1, 2, 3]);
 	let client = client_result.reference();
-	assert_eq!(Some(U256::from(2)), client.gas_price_median(3));
+	assert_eq!(Some(&U256::from(2)), client.gas_price_corpus(3).median());
 
 	let client_result = generate_dummy_client_with_data(4, 1, slice_into![1, 4, 3, 2]);
 	let client = client_result.reference();
-	assert_eq!(Some(U256::from(3)), client.gas_price_median(4));
+	assert_eq!(Some(&U256::from(3)), client.gas_price_corpus(3).median());
 }
 
 #[test]
@@ -220,8 +219,8 @@ fn can_generate_gas_price_histogram() {
 	let client_result = generate_dummy_client_with_data(20, 1, slice_into![6354,8593,6065,4842,7845,7002,689,4958,4250,6098,5804,4320,643,8895,2296,8589,7145,2000,2512,1408]);
 	let client = client_result.reference();
 
-	let hist = client.gas_price_histogram(20, 5).unwrap();
-	let correct_hist = Histogram { bucket_bounds: vec_into![643, 2294, 3945, 5596, 7247, 8898], counts: vec![4,2,4,6,4] };
+	let hist = client.gas_price_corpus(20).histogram(5).unwrap();
+	let correct_hist = ::stats::Histogram { bucket_bounds: vec_into![643, 2294, 3945, 5596, 7247, 8898], counts: vec![4,2,4,6,4] };
 	assert_eq!(hist, correct_hist);
 }
 
@@ -230,7 +229,7 @@ fn empty_gas_price_histogram() {
 	let client_result = generate_dummy_client_with_data(20, 0, slice_into![]);
 	let client = client_result.reference();
 
-	assert!(client.gas_price_histogram(20, 5).is_none());
+	assert!(client.gas_price_corpus(20).histogram(5).is_none());
 }
 
 #[test]

--- a/rpc/Cargo.toml
+++ b/rpc/Cargo.toml
@@ -39,6 +39,7 @@ rlp = { path = "../util/rlp" }
 fetch = { path = "../util/fetch" }
 parity-reactor = { path = "../util/reactor" }
 clippy = { version = "0.0.103", optional = true}
+stats = { path = "../util/stats" }
 
 [features]
 dev = ["clippy", "ethcore/dev", "ethcore-util/dev", "ethsync/dev"]

--- a/rpc/src/lib.rs
+++ b/rpc/src/lib.rs
@@ -44,6 +44,7 @@ extern crate futures;
 extern crate order_stat;
 extern crate parity_updater as updater;
 extern crate parity_reactor;
+extern crate stats;
 
 #[macro_use]
 extern crate log;

--- a/rpc/src/v1/helpers/dispatch.rs
+++ b/rpc/src/v1/helpers/dispatch.rs
@@ -207,7 +207,7 @@ impl Dispatcher for LightDispatcher {
 	fn sign(&self, accounts: Arc<AccountProvider>, filled: FilledTransactionRequest, password: SignWith)
 		-> BoxFuture<WithToken<SignedTransaction>, Error>
 	{
-		let network_id = None; // TODO: fetch from client.
+		let network_id = self.client.signing_network_id();
 		let address = filled.from;
 		let best_header = self.client.best_block_header();
 

--- a/rpc/src/v1/helpers/errors.rs
+++ b/rpc/src/v1/helpers/errors.rs
@@ -60,6 +60,14 @@ pub fn unimplemented(details: Option<String>) -> Error {
 	}
 }
 
+pub fn light_unimplemented(details: Option<String>) -> Error {
+	Error {
+		code: ErrorCode::ServerError(codes::UNSUPPORTED_REQUEST),
+		message: "This request is unsupported for light clients.".into(),
+		data: details.map(Value::String),
+	}
+}
+
 pub fn request_not_found() -> Error {
 	Error {
 		code: ErrorCode::ServerError(codes::REQUEST_NOT_FOUND),

--- a/rpc/src/v1/impls/light/eth.rs
+++ b/rpc/src/v1/impls/light/eth.rs
@@ -108,7 +108,7 @@ impl EthClient {
 
 						self.sync.with_context(|ctx|
 							self.on_demand.header_by_number(ctx, req)
-								.map(|(h, _)| Some(h))
+								.map(Some)
 								.map_err(err_premature_cancel)
 								.boxed()
 						)

--- a/rpc/src/v1/impls/light/eth.rs
+++ b/rpc/src/v1/impls/light/eth.rs
@@ -62,11 +62,6 @@ pub struct EthClient {
 	accounts: Arc<AccountProvider>,
 }
 
-// helper for internal error: no network context.
-fn err_no_context() -> Error {
-	errors::internal("network service detached", "")
-}
-
 // helper for internal error: on demand sender cancelled.
 fn err_premature_cancel(_cancel: oneshot::Canceled) -> Error {
 	errors::internal("on-demand sender prematurely cancelled", "")
@@ -128,10 +123,9 @@ impl EthClient {
 			_ => None, // latest, earliest, and pending will have all already returned.
 		};
 
-		// todo: cache returned values (header, TD)
 		match maybe_future {
 			Some(recv) => recv,
-			None => future::err(err_no_context()).boxed()
+			None => future::err(errors::network_disabled()).boxed()
 		}
 	}
 
@@ -150,7 +144,7 @@ impl EthClient {
 				address: address,
 			}).map(Some))
 				.map(|x| x.map_err(err_premature_cancel).boxed())
-				.unwrap_or_else(|| future::err(err_no_context()).boxed())
+				.unwrap_or_else(|| future::err(errors::network_disabled()).boxed())
 		}).boxed()
 	}
 }
@@ -235,7 +229,7 @@ impl Eth for EthClient {
 				sync.with_context(|ctx| on_demand.block(ctx, request::Body::new(hdr)))
 					.map(|x| x.map(|b| Some(U256::from(b.transactions_count()).into())))
 					.map(|x| x.map_err(err_premature_cancel).boxed())
-					.unwrap_or_else(|| future::err(err_no_context()).boxed())
+					.unwrap_or_else(|| future::err(errors::network_disabled()).boxed())
 			}
 		}).boxed()
 	}
@@ -255,7 +249,7 @@ impl Eth for EthClient {
 				sync.with_context(|ctx| on_demand.block(ctx, request::Body::new(hdr)))
 					.map(|x| x.map(|b| Some(U256::from(b.transactions_count()).into())))
 					.map(|x| x.map_err(err_premature_cancel).boxed())
-					.unwrap_or_else(|| future::err(err_no_context()).boxed())
+					.unwrap_or_else(|| future::err(errors::network_disabled()).boxed())
 			}
 		}).boxed()
 	}
@@ -275,7 +269,7 @@ impl Eth for EthClient {
 				sync.with_context(|ctx| on_demand.block(ctx, request::Body::new(hdr)))
 					.map(|x| x.map(|b| Some(U256::from(b.uncles_count()).into())))
 					.map(|x| x.map_err(err_premature_cancel).boxed())
-					.unwrap_or_else(|| future::err(err_no_context()).boxed())
+					.unwrap_or_else(|| future::err(errors::network_disabled()).boxed())
 			}
 		}).boxed()
 	}
@@ -295,7 +289,7 @@ impl Eth for EthClient {
 				sync.with_context(|ctx| on_demand.block(ctx, request::Body::new(hdr)))
 					.map(|x| x.map(|b| Some(U256::from(b.uncles_count()).into())))
 					.map(|x| x.map_err(err_premature_cancel).boxed())
-					.unwrap_or_else(|| future::err(err_no_context()).boxed())
+					.unwrap_or_else(|| future::err(errors::network_disabled()).boxed())
 			}
 		}).boxed()
 	}

--- a/rpc/src/v1/impls/light/mod.rs
+++ b/rpc/src/v1/impls/light/mod.rs
@@ -22,6 +22,7 @@
 pub mod eth;
 pub mod parity;
 pub mod parity_set;
+pub mod trace;
 
 pub use self::eth::EthClient;
 pub use self::parity::ParityClient;

--- a/rpc/src/v1/impls/light/mod.rs
+++ b/rpc/src/v1/impls/light/mod.rs
@@ -21,6 +21,8 @@
 
 pub mod eth;
 pub mod parity;
+pub mod parity_set;
 
 pub use self::eth::EthClient;
 pub use self::parity::ParityClient;
+pub use self::parity_set::ParitySetClient;

--- a/rpc/src/v1/impls/light/mod.rs
+++ b/rpc/src/v1/impls/light/mod.rs
@@ -15,7 +15,12 @@
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
 //! RPC implementations for the light client.
+//!
+//! This doesn't re-implement all of the RPC APIs, just those which aren't
+//! significantly generic to be reused.
 
 pub mod eth;
+pub mod parity;
 
 pub use self::eth::EthClient;
+pub use self::parity::ParityClient;

--- a/rpc/src/v1/impls/light/parity_set.rs
+++ b/rpc/src/v1/impls/light/parity_set.rs
@@ -18,16 +18,12 @@
 //! Implementation for light client.
 
 use std::io;
-use std::sync::{Arc, Weak};
+use std::sync::Arc;
 
-use ethcore::miner::MinerService;
-use ethcore::client::MiningBlockChainClient;
-use ethcore::mode::Mode;
 use ethsync::ManageNetwork;
-use fetch::{self, Fetch};
+use fetch::Fetch;
 use futures::{BoxFuture, Future};
 use util::sha3;
-use updater::{Service as UpdateService};
 
 use jsonrpc_core::Error;
 use v1::helpers::errors;
@@ -51,7 +47,6 @@ impl<F: Fetch> ParitySetClient<F> {
 }
 
 impl<F: Fetch> ParitySet for ParitySetClient<F> {
-
 	fn set_min_gas_price(&self, _gas_price: U256) -> Result<bool, Error> {
 		Err(errors::light_unimplemented(None))
 	}
@@ -118,7 +113,7 @@ impl<F: Fetch> ParitySet for ParitySetClient<F> {
 		Ok(true)
 	}
 
-	fn set_mode(&self, mode: String) -> Result<bool, Error> {
+	fn set_mode(&self, _mode: String) -> Result<bool, Error> {
 		Err(errors::light_unimplemented(None))
 	}
 

--- a/rpc/src/v1/impls/light/parity_set.rs
+++ b/rpc/src/v1/impls/light/parity_set.rs
@@ -1,0 +1,143 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Parity-specific rpc interface for operations altering the settings.
+//! Implementation for light client.
+
+use std::io;
+use std::sync::{Arc, Weak};
+
+use ethcore::miner::MinerService;
+use ethcore::client::MiningBlockChainClient;
+use ethcore::mode::Mode;
+use ethsync::ManageNetwork;
+use fetch::{self, Fetch};
+use futures::{BoxFuture, Future};
+use util::sha3;
+use updater::{Service as UpdateService};
+
+use jsonrpc_core::Error;
+use v1::helpers::errors;
+use v1::traits::ParitySet;
+use v1::types::{Bytes, H160, H256, U256, ReleaseInfo};
+
+/// Parity-specific rpc interface for operations altering the settings.
+pub struct ParitySetClient<F> {
+	net: Arc<ManageNetwork>,
+	fetch: F,
+}
+
+impl<F: Fetch> ParitySetClient<F> {
+	/// Creates new `ParitySetClient` with given `Fetch`.
+	pub fn new(net: Arc<ManageNetwork>, fetch: F) -> Self {
+		ParitySetClient {
+			net: net,
+			fetch: fetch,
+		}
+	}
+}
+
+impl<F: Fetch> ParitySet for ParitySetClient<F> {
+
+	fn set_min_gas_price(&self, _gas_price: U256) -> Result<bool, Error> {
+		Err(errors::light_unimplemented(None))
+	}
+
+	fn set_gas_floor_target(&self, _target: U256) -> Result<bool, Error> {
+		Err(errors::light_unimplemented(None))
+	}
+
+	fn set_gas_ceil_target(&self, _target: U256) -> Result<bool, Error> {
+		Err(errors::light_unimplemented(None))
+	}
+
+	fn set_extra_data(&self, _extra_data: Bytes) -> Result<bool, Error> {
+		Err(errors::light_unimplemented(None))
+	}
+
+	fn set_author(&self, _author: H160) -> Result<bool, Error> {
+		Err(errors::light_unimplemented(None))
+	}
+
+	fn set_engine_signer(&self, _address: H160, _password: String) -> Result<bool, Error> {
+		Err(errors::light_unimplemented(None))
+	}
+
+	fn set_transactions_limit(&self, _limit: usize) -> Result<bool, Error> {
+		Err(errors::light_unimplemented(None))
+	}
+
+	fn set_tx_gas_limit(&self, _limit: U256) -> Result<bool, Error> {
+		Err(errors::light_unimplemented(None))
+	}
+
+	fn add_reserved_peer(&self, peer: String) -> Result<bool, Error> {
+		match self.net.add_reserved_peer(peer) {
+			Ok(()) => Ok(true),
+			Err(e) => Err(errors::invalid_params("Peer address", e)),
+		}
+	}
+
+	fn remove_reserved_peer(&self, peer: String) -> Result<bool, Error> {
+		match self.net.remove_reserved_peer(peer) {
+			Ok(()) => Ok(true),
+			Err(e) => Err(errors::invalid_params("Peer address", e)),
+		}
+	}
+
+	fn drop_non_reserved_peers(&self) -> Result<bool, Error> {
+		self.net.deny_unreserved_peers();
+		Ok(true)
+	}
+
+	fn accept_non_reserved_peers(&self) -> Result<bool, Error> {
+		self.net.accept_unreserved_peers();
+		Ok(true)
+	}
+
+	fn start_network(&self) -> Result<bool, Error> {
+		self.net.start_network();
+		Ok(true)
+	}
+
+	fn stop_network(&self) -> Result<bool, Error> {
+		self.net.stop_network();
+		Ok(true)
+	}
+
+	fn set_mode(&self, mode: String) -> Result<bool, Error> {
+		Err(errors::light_unimplemented(None))
+	}
+
+	fn hash_content(&self, url: String) -> BoxFuture<H256, Error> {
+		self.fetch.process(self.fetch.fetch(&url).then(move |result| {
+			result
+				.map_err(errors::from_fetch_error)
+				.and_then(|response| {
+					sha3(&mut io::BufReader::new(response)).map_err(errors::from_fetch_error)
+				})
+				.map(Into::into)
+		}))
+	}
+
+	fn upgrade_ready(&self) -> Result<Option<ReleaseInfo>, Error> {
+		Err(errors::light_unimplemented(None))
+	}
+
+	fn execute_upgrade(&self) -> Result<bool, Error> {
+		Err(errors::light_unimplemented(None))
+	}
+}

--- a/rpc/src/v1/impls/light/trace.rs
+++ b/rpc/src/v1/impls/light/trace.rs
@@ -1,0 +1,57 @@
+// Copyright 2015-2017 Parity Technologies (UK) Ltd.
+// This file is part of Parity.
+
+// Parity is free software: you can redistribute it and/or modify
+// it under the terms of the GNU General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+
+// Parity is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU General Public License for more details.
+
+// You should have received a copy of the GNU General Public License
+// along with Parity.  If not, see <http://www.gnu.org/licenses/>.
+
+//! Traces api implementation.
+
+use jsonrpc_core::Error;
+use jsonrpc_macros::Trailing;
+use v1::traits::Traces;
+use v1::helpers::errors;
+use v1::types::{TraceFilter, LocalizedTrace, BlockNumber, Index, CallRequest, Bytes, TraceResults, H256};
+
+/// Traces api implementation.
+// TODO: all calling APIs should be possible w. proved remote TX execution.
+pub struct TracesClient;
+
+impl Traces for TracesClient {
+	fn filter(&self, _filter: TraceFilter) -> Result<Vec<LocalizedTrace>, Error> {
+		Err(errors::light_unimplemented(None))
+	}
+
+	fn block_traces(&self, _block_number: BlockNumber) -> Result<Vec<LocalizedTrace>, Error> {
+		Err(errors::light_unimplemented(None))
+	}
+
+	fn transaction_traces(&self, _transaction_hash: H256) -> Result<Vec<LocalizedTrace>, Error> {
+		Err(errors::light_unimplemented(None))
+	}
+
+	fn trace(&self, _transaction_hash: H256, _address: Vec<Index>) -> Result<Option<LocalizedTrace>, Error> {
+		Err(errors::light_unimplemented(None))
+	}
+
+	fn call(&self, _request: CallRequest, _flags: Vec<String>, _block: Trailing<BlockNumber>) -> Result<Option<TraceResults>, Error> {
+		Err(errors::light_unimplemented(None))
+	}
+
+	fn raw_transaction(&self, _raw_transaction: Bytes, _flags: Vec<String>, _block: Trailing<BlockNumber>) -> Result<Option<TraceResults>, Error> {
+		Err(errors::light_unimplemented(None))
+	}
+
+	fn replay_transaction(&self, _transaction_hash: H256, _flags: Vec<String>) -> Result<Option<TraceResults>, Error> {
+		Err(errors::light_unimplemented(None))
+	}
+}

--- a/rpc/src/v1/impls/parity.rs
+++ b/rpc/src/v1/impls/parity.rs
@@ -236,7 +236,7 @@ impl<C, M, S: ?Sized, U> Parity for ParityClient<C, M, S, U> where
 	}
 
 	fn gas_price_histogram(&self) -> Result<Histogram, Error> {
-		take_weak!(self.client).gas_price_histogram(100, 10).ok_or_else(errors::not_enough_data).map(Into::into)
+		take_weak!(self.client).gas_price_corpus(100).histogram(10).ok_or_else(errors::not_enough_data).map(Into::into)
 	}
 
 	fn unsigned_transactions_count(&self) -> Result<usize, Error> {

--- a/rpc/src/v1/traits/parity.rs
+++ b/rpc/src/v1/traits/parity.rs
@@ -101,8 +101,8 @@ build_rpc_trait! {
 		fn default_extra_data(&self) -> Result<Bytes, Error>;
 
 		/// Returns distribution of gas price in latest blocks.
-		#[rpc(name = "parity_gasPriceHistogram")]
-		fn gas_price_histogram(&self) -> Result<Histogram, Error>;
+		#[rpc(async, name = "parity_gasPriceHistogram")]
+		fn gas_price_histogram(&self) -> BoxFuture<Histogram, Error>;
 
 		/// Returns number of unsigned transactions waiting in the signer queue (if signer enabled)
 		/// Returns error when signer is disabled
@@ -164,8 +164,8 @@ build_rpc_trait! {
 		fn dapps_interface(&self) -> Result<String, Error>;
 
 		/// Returns next nonce for particular sender. Should include all transactions in the queue.
-		#[rpc(name = "parity_nextNonce")]
-		fn next_nonce(&self, H160) -> Result<U256, Error>;
+		#[rpc(async, name = "parity_nextNonce")]
+		fn next_nonce(&self, H160) -> BoxFuture<U256, Error>;
 
 		/// Get the mode. Results one of: "active", "passive", "dark", "offline".
 		#[rpc(name = "parity_mode")]

--- a/rpc/src/v1/types/histogram.rs
+++ b/rpc/src/v1/types/histogram.rs
@@ -17,7 +17,6 @@
 //! Gas prices histogram.
 
 use v1::types::U256;
-use util::stats;
 
 /// Values of RPC settings.
 #[derive(Serialize, Deserialize)]
@@ -27,11 +26,11 @@ pub struct Histogram {
 	#[serde(rename="bucketBounds")]
 	pub bucket_bounds: Vec<U256>,
 	/// Transacion counts for each bucket.
-	pub counts: Vec<u64>,
+	pub counts: Vec<usize>,
 }
 
-impl From<stats::Histogram> for Histogram {
-	fn from(h: stats::Histogram) -> Self {
+impl From<::stats::Histogram<::util::U256>> for Histogram {
+	fn from(h: ::stats::Histogram<::util::U256>) -> Self {
 		Histogram {
 			bucket_bounds: h.bucket_bounds.into_iter().map(Into::into).collect(),
 			counts: h.counts

--- a/sync/src/lib.rs
+++ b/sync/src/lib.rs
@@ -72,11 +72,7 @@ mod api {
 #[cfg(not(feature = "ipc"))]
 mod api;
 
-pub use api::{
-	EthSync, Params, SyncProvider, ManageNetwork, SyncConfig,
-	ServiceConfiguration, NetworkConfiguration, PeerInfo, AllowIP, TransactionStats,
-	LightSync, LightSyncParams, LesProtocolInfo, EthProtocolInfo,
-};
+pub use api::*;
 pub use chain::{SyncStatus, SyncState};
 pub use network::{is_valid_node_url, NonReservedPeerMode, NetworkError};
 

--- a/util/src/lib.rs
+++ b/util/src/lib.rs
@@ -142,7 +142,6 @@ pub mod semantic_version;
 pub mod log;
 pub mod path;
 pub mod snappy;
-pub mod stats;
 pub mod cache;
 mod timer;
 

--- a/util/stats/Cargo.toml
+++ b/util/stats/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "stats"
+version = "0.1.0"
+authors = ["Parity Technologies <admin@parity.io>"]
+
+[dependencies]
+log = "0.3"

--- a/util/stats/src/lib.rs
+++ b/util/stats/src/lib.rs
@@ -14,22 +14,77 @@
 // You should have received a copy of the GNU General Public License
 // along with Parity.  If not, see <http://www.gnu.org/licenses/>.
 
-//! Statistical functions.
+//! Statistical functions and helpers.
 
-use bigint::prelude::*;
+use std::iter::FromIterator;
+use std::ops::{Add, Sub, Div};
+
+#[macro_use]
+extern crate log;
+
+/// Sorted corpus of data.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Corpus<T: Ord>(Vec<T>);
+
+impl<T: Ord> From<Vec<T>> for Corpus<T> {
+	fn from(mut data: Vec<T>) -> Self {
+		data.sort();
+		Corpus(data)
+	}
+}
+
+impl<T: Ord> FromIterator<T> for Corpus<T> {
+	fn from_iter<I: IntoIterator<Item=T>>(iterable: I) -> Self {
+		iterable.into_iter().collect::<Vec<_>>().into()
+	}
+}
+
+impl<T: Ord> Corpus<T> {
+	/// Get the median element, if it exists.
+	pub fn median(&self) -> Option<&T> {
+		self.0.get(self.0.len() / 2)
+	}
+
+	/// Whether the corpus is empty.
+	pub fn is_empty(&self) -> bool {
+		self.0.is_empty()
+	}
+
+	/// Number of elements in the corpus.
+	pub fn len(&self) -> usize {
+		self.0.len()
+	}
+
+	/// Split the corpus at a given point.
+	pub fn split_at(self, idx: usize) -> (Self, Self) {
+		let (left, right) = self.0.split_at(idx);
+		(Corpus(left), Corpus(right))
+	}
+}
+
+impl<T: Ord + Copy + ::std::fmt::Display> Corpus<T>
+	where T: Add<Output=T> + Sub<Output=T> + Div<Output=T> + From<usize>
+{
+	/// Create a histogram of this corpus if it at least spans the buckets. Bounds are left closed.
+	pub fn histogram(&self, bucket_number: usize) -> Option<Histogram<T>> {
+		Histogram::create(&self.0, bucket_number)
+	}
+}
 
 /// Discretised histogram.
 #[derive(Debug, PartialEq)]
-pub struct Histogram {
+pub struct Histogram<T> {
 	/// Bounds of each bucket.
-	pub bucket_bounds: Vec<U256>,
+	pub bucket_bounds: Vec<T>,
 	/// Count within each bucket.
-	pub counts: Vec<u64>
+	pub counts: Vec<usize>,
 }
 
-impl Histogram {
-	/// Histogram of a sorted corpus if it at least spans the buckets. Bounds are left closed.
-	pub fn new(corpus: &[U256], bucket_number: usize) -> Option<Histogram> {
+impl<T: Ord + Copy + ::std::fmt::Display> Histogram<T>
+	where T: Add<Output=T> + Sub<Output=T> + Div<Output=T> + From<usize>
+{
+	// Histogram of a sorted corpus if it at least spans the buckets. Bounds are left closed.
+	fn create(corpus: &[T], bucket_number: usize) -> Option<Histogram<T>> {
 		if corpus.len() < 1 { return None; }
 		let corpus_end = corpus.last().expect("there is at least 1 element; qed").clone();
 		let corpus_start = corpus.first().expect("there is at least 1 element; qed").clone();
@@ -63,42 +118,41 @@ impl Histogram {
 
 #[cfg(test)]
 mod tests {
-	use bigint::prelude::U256;
 	use super::Histogram;
 
 	#[test]
 	fn check_histogram() {
-		let hist = Histogram::new(slice_into![643,689,1408,2000,2296,2512,4250,4320,4842,4958,5804,6065,6098,6354,7002,7145,7845,8589,8593,8895], 5).unwrap();
-		let correct_bounds: Vec<U256> = vec_into![643, 2294, 3945, 5596, 7247, 8898];
+		let hist = Histogram::create(&[643,689,1408,2000,2296,2512,4250,4320,4842,4958,5804,6065,6098,6354,7002,7145,7845,8589,8593,8895], 5).unwrap();
+		let correct_bounds: Vec<usize> = vec![643, 2294, 3945, 5596, 7247, 8898];
 		assert_eq!(Histogram { bucket_bounds: correct_bounds, counts: vec![4,2,4,6,4] }, hist);
 	}
 
 	#[test]
 	fn smaller_data_range_than_bucket_range() {
 		assert_eq!(
-			Histogram::new(slice_into![1, 2, 2], 3),
-			Some(Histogram { bucket_bounds: vec_into![1, 2, 3, 4], counts: vec![1, 2, 0] })
+			Histogram::create(&[1, 2, 2], 3),
+			Some(Histogram { bucket_bounds: vec![1, 2, 3, 4], counts: vec![1, 2, 0] })
 		);
 	}
 
 	#[test]
 	fn data_range_is_not_multiple_of_bucket_range() {
 		assert_eq!(
-			Histogram::new(slice_into![1, 2, 5], 2),
-			Some(Histogram { bucket_bounds: vec_into![1, 4, 7], counts: vec![2, 1] })
+			Histogram::create(&[1, 2, 5], 2),
+			Some(Histogram { bucket_bounds: vec![1, 4, 7], counts: vec![2, 1] })
 		);
 	}
 
 	#[test]
 	fn data_range_is_multiple_of_bucket_range() {
 		assert_eq!(
-			Histogram::new(slice_into![1, 2, 6], 2),
-			Some(Histogram { bucket_bounds: vec_into![1, 4, 7], counts: vec![2, 1] })
+			Histogram::create(&[1, 2, 6], 2),
+			Some(Histogram { bucket_bounds: vec![1, 4, 7], counts: vec![2, 1] })
 		);
 	}
 
 	#[test]
 	fn none_when_too_few_data() {
-		assert!(Histogram::new(slice_into![], 1).is_none());
+		assert!(Histogram::<usize>::create(&[], 1).is_none());
 	}
 }


### PR DESCRIPTION
Closes #4435 

Some are just stubs (like traces), lots of mining/sealing-related functionality not available yet.
Data fetched from the network is now cached. We fetch block bodies and compute a gas price corpus to estimate gas price. This corpus can be reused until it "expires" after a set amount of time, which will probably be 6 or 12 hours.
