### PR TITLE
modalCompatible flag for Title waiting bars

### DIFF
--- a/js/src/ui/Modal/modal.js
+++ b/js/src/ui/Modal/modal.js
@@ -67,6 +67,7 @@ class Modal extends Component {
         busy={ busy }
         busySteps={ waiting }
         className={ styles.title }
+        modalCompatible
         steps={ steps }
         title={ title }
       />

--- a/js/src/ui/Title/title.css
+++ b/js/src/ui/Title/title.css
@@ -23,6 +23,11 @@
 
   .waiting {
     margin: 1em -1.5em 0 -1.5em;
+
+    /* TODO: remove once all modals are converted to Portal (only used by ui/Modal) */
+    &.compatible {
+      margin: 1em -1em -1em -1em;
+    }
   }
 }
 

--- a/js/src/ui/Title/title.js
+++ b/js/src/ui/Title/title.js
@@ -36,6 +36,7 @@ export default class Title extends Component {
     byline: nodeOrStringProptype(),
     className: PropTypes.string,
     isSubTitle: PropTypes.bool,
+    modalCompatible: PropTypes.bool,
     steps: PropTypes.array,
     title: nodeOrStringProptype()
   }
@@ -104,15 +105,25 @@ export default class Title extends Component {
   }
 
   renderWaiting () {
-    const { activeStep, busy, busySteps } = this.props;
+    const { activeStep, busy, busySteps, modalCompatible } = this.props;
     const isWaiting = busy || (busySteps || []).includes(activeStep);
 
     if (!isWaiting) {
       return null;
     }
 
+    // TODO modalCompatible flag to be removed when all Portal conversions are done (only used by ui/Modal)
     return (
-      <div className={ styles.waiting }>
+      <div
+        className={
+          [
+            styles.waiting,
+            modalCompatible
+              ? styles.compatible
+              : null
+          ].join(' ')
+        }
+      >
         <LinearProgress />
       </div>
     );


### PR DESCRIPTION
Closes https://github.com/ethcore/parity/issues/4620

Header sizing has been changed between Portal & Modals - align waiting bars until full conversion is done, catering for both old & new. (As per TODOs, compatible flag should be removed once conversion is done - https://github.com/ethcore/parity/pull/4625)

![parity 2017-02-21 12-46-54](https://cloud.githubusercontent.com/assets/1424473/23163778/31a997b4-f834-11e6-9cdc-4a13cb24f422.png)
