### PR TITLE
[beta] Fix Geth account import

### DIFF
--- a/js/src/api/rpc/parity/parity.js
+++ b/js/src/api/rpc/parity/parity.js
@@ -174,7 +174,7 @@ export default class Parity {
 
   importGethAccounts (accounts) {
     return this._transport
-      .execute('parity_importGethAccounts', inAddresses)
+      .execute('parity_importGethAccounts', inAddresses(accounts))
       .then(outAddresses);
   }
 

--- a/js/src/modals/CreateAccount/NewGeth/newGeth.js
+++ b/js/src/modals/CreateAccount/NewGeth/newGeth.js
@@ -106,7 +106,7 @@ export default class NewGeth extends Component {
     api.parity
       .listGethAccounts()
       .then((_addresses) => {
-        const addresses = (addresses || []).filter((address) => !accounts[address]);
+        const addresses = (_addresses || []).filter((address) => !accounts[address]);
 
         return Promise
           .all(addresses.map((address) => api.eth.getBalance(address)))

--- a/js/src/modals/CreateAccount/createAccount.js
+++ b/js/src/modals/CreateAccount/createAccount.js
@@ -311,7 +311,7 @@ export default class CreateAccount extends Component {
       return api.parity
         .importGethAccounts(this.state.gethAddresses)
         .then((gethImported) => {
-          console.log('result', gethImported);
+          console.log('importGethAccounts', gethImported);
 
           this.setState({
             gethImported

--- a/js/src/modals/CreateAccount/createAccount.js
+++ b/js/src/modals/CreateAccount/createAccount.js
@@ -139,7 +139,7 @@ export default class CreateAccount extends Component {
       case 2:
         if (createType === 'fromGeth') {
           return (
-            <AccountDetailsGeth addresses={ this.state.gethAddresses } />
+            <AccountDetailsGeth addresses={ this.state.gethImported } />
           );
         }
 
@@ -310,10 +310,14 @@ export default class CreateAccount extends Component {
     if (createType === 'fromGeth') {
       return api.parity
         .importGethAccounts(this.state.gethAddresses)
-        .then((result) => {
-          console.log('result', result);
+        .then((gethImported) => {
+          console.log('result', gethImported);
 
-          return Promise.all(this.state.gethAddresses.map((address) => {
+          this.setState({
+            gethImported
+          });
+
+          return Promise.all(gethImported.map((address) => {
             return api.parity.setAccountName(address, 'Geth Import');
           }));
         })


### PR DESCRIPTION
- Fix `parity_importGethAccounts` (backport of RPC commit in https://github.com/ethcore/parity/pull/4641)
- Iterate through addresses retrieved (applicable master fix ported to beta state)
- Fix available Geth accounts not being shown (s/accounts/_accounts/, applicable fix already in master)