### PR TITLE
Fix Account Selection in Signer

### DIFF
--- a/js/src/ui/Form/Input/input.js
+++ b/js/src/ui/Form/Input/input.js
@@ -46,6 +46,10 @@ const UNDERLINE_FOCUSED = {
 const NAME_ID = ' ';
 
 export default class Input extends Component {
+  static contextTypes = {
+    intl: React.PropTypes.object.isRequired
+  };
+
   static propTypes = {
     allowCopy: PropTypes.oneOfType([
       PropTypes.string,
@@ -79,7 +83,8 @@ export default class Input extends Component {
     style: PropTypes.object,
     value: PropTypes.oneOfType([
       PropTypes.number,
-      PropTypes.string
+      PropTypes.string,
+      PropTypes.node
     ])
   };
 
@@ -135,6 +140,13 @@ export default class Input extends Component {
       ? UNDERLINE_FOCUSED
       : readOnly && typeof focused !== 'boolean' ? { display: 'none' } : null;
 
+    const textValue = typeof value !== 'string' && (value && value.props)
+      ? this.context.intl.formatMessage(
+          value.props,
+          value.props.values || {}
+        )
+      : value;
+
     return (
       <div className={ styles.container } style={ style }>
         { this.renderCopyButton() }
@@ -169,7 +181,7 @@ export default class Input extends Component {
           underlineStyle={ underlineStyle }
           underlineFocusStyle={ underlineFocusStyle }
           underlineShow={ !hideUnderline }
-          value={ value }
+          value={ textValue }
         >
           { children }
         </TextField>

--- a/js/src/views/ParityBar/parityBar.css
+++ b/js/src/views/ParityBar/parityBar.css
@@ -42,6 +42,7 @@ $modalZ: 10001;
 .container {
   display: flex;
   flex-direction: column;
+  width: 100%;
 }
 
 .overlay {
@@ -106,6 +107,7 @@ $modalZ: 10001;
   min-height: 30vh;
   max-height: 80vh;
   max-width: calc(100vw - 2em);
+  width: 960px;
 
   .content {
     flex: 1;


### PR DESCRIPTION
The layout was broken if less than 3 accounts were available.
It also fixes In Status > RPC Enabled input that wasn't displayed correctly (was just `[Object object]` because of `FormattedMessage` passed to `Input`)