### PR TITLE
Fix invalid props to verification code

### DIFF
--- a/js/src/modals/Verification/store.js
+++ b/js/src/modals/Verification/store.js
@@ -46,7 +46,7 @@ export default class VerificationStore {
   @observable consentGiven = false;
   @observable requestTx = null;
   @observable code = '';
-  @observable isCodeValid = null;
+  @observable isCodeValid = false;
   @observable confirmationTx = null;
 
   constructor (api, abi, certifierName, account, isTestnet) {
@@ -144,7 +144,7 @@ export default class VerificationStore {
     const values = [ sha3.text(code) ];
 
     this.code = code;
-    this.isCodeValid = null;
+    this.isCodeValid = false;
     confirm.estimateGas(options, values)
       .then((gas) => {
         options.gas = gas.mul(1.2).toFixed(0);


### PR DESCRIPTION
- Fixes null being send as a required boolean property, setting to false instead

![parity 2017-03-04 22-22-55](https://cloud.githubusercontent.com/assets/1424473/23582388/53f39fb0-0129-11e7-87af-5947e6a2cdf4.png)
![parity 2017-03-04 22-23-14](https://cloud.githubusercontent.com/assets/1424473/23582389/58fa966c-0129-11e7-91a5-3bae120e19ee.png)
