### PR TITLE
Adjust selection colours/display

### DIFF
--- a/js/src/ui/AccountCard/accountCard.css
+++ b/js/src/ui/AccountCard/accountCard.css
@@ -110,12 +110,6 @@
     overflow: hidden;
     text-overflow: ellipsis;
     font-size: 0.9em;
-
-    .address {
-      &:hover {
-        cursor: text;
-      }
-    }
   }
 
   .accountName {

--- a/js/src/ui/AccountCard/accountCard.js
+++ b/js/src/ui/AccountCard/accountCard.js
@@ -28,15 +28,15 @@ import styles from './accountCard.css';
 export default class AccountCard extends Component {
   static propTypes = {
     account: PropTypes.object.isRequired,
-    allowAddressClick: PropTypes.bool,
     balance: PropTypes.object,
     className: PropTypes.string,
+    disableAddressClick: PropTypes.bool,
     onClick: PropTypes.func,
     onFocus: PropTypes.func
   };
 
   static defaultProps = {
-    allowAddressClick: false
+    disableAddressClick: false
   };
 
   state = {
@@ -138,14 +138,14 @@ export default class AccountCard extends Component {
   }
 
   handleAddressClick = (event) => {
-    const { allowAddressClick } = this.props;
+    const { disableAddressClick } = this.props;
 
-    // Don't stop the event if address click is allowed
-    if (allowAddressClick) {
-      return this.onClick(event);
+    // Stop the event if address click is disallowed
+    if (disableAddressClick) {
+      return this.preventEvent(event);
     }
 
-    return this.preventEvent(event);
+    return this.onClick(event);
   }
 
   handleKeyDown = (event) => {

--- a/js/src/ui/Form/AddressSelect/addressSelect.js
+++ b/js/src/ui/Form/AddressSelect/addressSelect.js
@@ -348,7 +348,6 @@ class AddressSelect extends Component {
     return (
       <AccountCard
         account={ account }
-        allowAddressClick
         balance={ balance }
         className={ styles.account }
         key={ `account_${index}` }

--- a/js/src/ui/SelectionList/selectionList.css
+++ b/js/src/ui/SelectionList/selectionList.css
@@ -84,6 +84,6 @@
 }
 
 .unselected {
-  filter: grayscale(10%);
+  filter: grayscale(50%);
   opacity: 0.75;
 }

--- a/js/src/ui/SelectionList/selectionList.css
+++ b/js/src/ui/SelectionList/selectionList.css
@@ -25,7 +25,6 @@
   width: 100%;
 
   &:hover {
-    border-color: transparent;
     filter: none;
     opacity: 1;
   }
@@ -35,7 +34,7 @@
     width: 100%;
 
     &:hover {
-      background-color: rgba(255, 255, 255, 0.5);
+      background-color: rgba(255, 255, 255, 0.15);
     }
   }
 
@@ -68,11 +67,11 @@
 }
 
 .selected {
-  border-color: rgba(255, 255, 255, 0.25);
+  border-color: rgb(0, 151, 167);
   filter: none;
 
   &.default {
-    border-color: rgba(255, 255, 255, 0.75);
+    border-color: rgb(167, 151, 0);
   }
 }
 

--- a/js/src/ui/SelectionList/selectionList.css
+++ b/js/src/ui/SelectionList/selectionList.css
@@ -16,7 +16,7 @@
 */
 
 .item {
-  border: 2px solid transparent;
+  border-top: 4px solid transparent;
   cursor: pointer;
   display: flex;
   flex: 1;
@@ -67,11 +67,11 @@
 }
 
 .selected {
-  border-color: rgb(0, 151, 167);
+  border-top-color: rgb(0, 151, 167);
   filter: none;
 
   &.default {
-    border-color: rgb(167, 151, 0);
+    border-top-color: rgb(167, 151, 0);
   }
 }
 

--- a/js/src/ui/SelectionList/selectionList.css
+++ b/js/src/ui/SelectionList/selectionList.css
@@ -16,7 +16,6 @@
 */
 
 .item {
-  border-top: 4px solid transparent;
   cursor: pointer;
   display: flex;
   flex: 1;
@@ -67,11 +66,20 @@
 }
 
 .selected {
-  border-top-color: rgb(0, 151, 167);
   filter: none;
 
-  &.default {
-    border-top-color: rgb(167, 151, 0);
+  &::after {
+    background: rgb(0, 151, 167);
+    content: '';
+    height: 4px;
+    left: 0;
+    position: absolute;
+    right: 0;
+    top: 0;
+  }
+
+  &.default::after {
+    background: rgb(167, 151, 0);
   }
 }
 


### PR DESCRIPTION
Based on feedback regarding selections -

- Use MUI standard colors (alignment, e.g. radio buttons where selects are in-place)
- Simplify display, single thick line to indicate status
- Visibility of selection lines even when hovered
- Adjust hover colours downwards (darker, less jarring)
- Make all addresses (AccountCard) clickable by default, e.g. Vaults (can be overridden)

![parity 2017-03-07 22-53-38](https://cloud.githubusercontent.com/assets/1424473/23679836/6a6c8e34-0389-11e7-8904-a2f825ed8eb7.png)
![parity 2017-03-07 22-54-10](https://cloud.githubusercontent.com/assets/1424473/23679844/6f066a46-0389-11e7-8d30-eadc063dbb7a.png)
![parity 2017-03-07 22-54-35](https://cloud.githubusercontent.com/assets/1424473/23679850/72e26c28-0389-11e7-8445-fe989dce12b0.png)
![parity 2017-03-07 22-54-57](https://cloud.githubusercontent.com/assets/1424473/23679857/7887b444-0389-11e7-90c1-b14ddc49256e.png)
![parity 2017-03-08 10-42-34](https://cloud.githubusercontent.com/assets/1424473/23698512/20ec6a28-03ec-11e7-8464-fe5e2bb614c3.png)
