### PR TITLE
Show token icons on list summary pages

### DIFF
--- a/js/src/ui/AccountCard/accountCard.js
+++ b/js/src/ui/AccountCard/accountCard.js
@@ -87,7 +87,6 @@ export default class AccountCard extends Component {
             balance={ balance }
             className={ styles.balance }
             showOnlyEth
-            showZeroValues
           />
         </div>
 

--- a/js/src/ui/AccountCard/accountCard.spec.js
+++ b/js/src/ui/AccountCard/accountCard.spec.js
@@ -74,9 +74,8 @@ describe('ui/AccountCard', () => {
         expect(balance.length).to.equal(1);
       });
 
-      it('sets showOnlyEth & showZeroValues', () => {
+      it('sets showOnlyEth', () => {
         expect(balance.props().showOnlyEth).to.be.true;
-        expect(balance.props().showZeroValues).to.be.true;
       });
     });
 

--- a/js/src/ui/Balance/balance.css
+++ b/js/src/ui/Balance/balance.css
@@ -17,14 +17,22 @@
 
 .balances {
   display: flex;
-  flex-wrap: wrap;
+  flex-wrap: nowrap;
   margin: 0.75em 0 0 0;
   vertical-align: top;
+
+  &.full {
+    flex-wrap: wrap;
+  }
+
+  &:not(.full) {
+    overflow: hidden;
+  }
 }
 
 .balance,
 .empty {
-  margin: 0.75em 0.5em 0 0;
+  margin: 0.75em 0.5em 4px 0;
 }
 
 .empty {
@@ -37,28 +45,35 @@
 }
 
 .balance {
-  background: rgba(255, 255, 255, 0.07);
+  align-items: center;
   border-radius: 16px;
+  display: flex;
   max-height: 24px;
   max-width: 100%;
-  display: flex;
-  align-items: center;
-}
 
-.balance img {
-  height: 32px;
-  margin: -4px 1em 0 0;
-  width: 32px;
-}
+  &.full {
+    background: rgba(255, 255, 255, 0.07);
 
-.balanceValue {
-  margin: 0 0.5em 0 0;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  overflow: hidden;
-}
+    img {
+      margin-right: 1em;
+    }
+  }
 
-.balanceTag {
-  font-size: 0.85em;
-  padding-right: 0.75rem;
+  img {
+    height: 32px;
+    margin-top: -4px;
+    width: 32px;
+  }
+
+  .tag {
+    padding-right: 0.75rem;
+    font-size: 0.85em;
+  }
+
+  .value {
+    margin: 0 0.5em 0 0;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
 }

--- a/js/src/ui/Balance/balance.css
+++ b/js/src/ui/Balance/balance.css
@@ -17,15 +17,12 @@
 
 .balances {
   display: flex;
-  flex-wrap: nowrap;
+  flex-wrap: wrap;
   margin: 0.75em 0 0 0;
   vertical-align: top;
 
-  &.full {
-    flex-wrap: wrap;
-  }
-
   &:not(.full) {
+    height: 2.5em;
     overflow: hidden;
   }
 }

--- a/js/src/ui/Balance/balance.js
+++ b/js/src/ui/Balance/balance.js
@@ -49,12 +49,10 @@ export default class Balance extends Component {
 
     let body = balance.tokens
       .filter((balance) => {
-        const hasBalance = showZeroValues || new BigNumber(balance.value).gt(0);
-        const isValidToken = !showOnlyEth || (balance.token.tag || '').toLowerCase() === 'eth';
-
-        return hasBalance && isValidToken;
+        return showZeroValues || new BigNumber(balance.value).gt(0);
       })
       .map((balance, index) => {
+        const isFullToken = !showOnlyEth || (balance.token.tag || '').toLowerCase() === 'eth';
         const token = balance.token;
 
         let value;
@@ -77,16 +75,36 @@ export default class Balance extends Component {
           value = api.util.fromWei(balance.value).toFormat(3);
         }
 
+        const classNames = [styles.balance];
+        let details = null;
+
+        if (isFullToken) {
+          classNames.push(styles.full);
+          details = [
+            <div
+              className={ styles.value }
+              key='value'
+            >
+              <span title={ value }>
+                { value }
+              </span>
+            </div>,
+            <div
+              className={ styles.tag }
+              key='tag'
+            >
+              { token.tag }
+            </div>
+          ];
+        }
+
         return (
           <div
-            className={ styles.balance }
+            className={ classNames.join(' ') }
             key={ `${index}_${token.tag}` }
           >
             <TokenImage token={ token } />
-            <div className={ styles.balanceValue }>
-              <span title={ value }> { value } </span>
-            </div>
-            <div className={ styles.balanceTag }> { token.tag } </div>
+            { details }
           </div>
         );
       });
@@ -103,7 +121,17 @@ export default class Balance extends Component {
     }
 
     return (
-      <div className={ [styles.balances, className].join(' ') }>
+      <div
+        className={
+          [
+            styles.balances,
+            showOnlyEth
+              ? ''
+              : styles.full,
+            className
+          ].join(' ')
+        }
+      >
         { body }
       </div>
     );

--- a/js/src/ui/Balance/balance.js
+++ b/js/src/ui/Balance/balance.js
@@ -41,7 +41,7 @@ export default class Balance extends Component {
 
   render () {
     const { api } = this.context;
-    const { balance, className, showZeroValues, showOnlyEth } = this.props;
+    const { balance, className, showOnlyEth } = this.props;
 
     if (!balance || !balance.tokens) {
       return null;
@@ -49,7 +49,10 @@ export default class Balance extends Component {
 
     let body = balance.tokens
       .filter((balance) => {
-        return showZeroValues || new BigNumber(balance.value).gt(0);
+        const isEthToken = (balance.token.tag || '').toLowerCase() === 'eth';
+        const hasBalance = new BigNumber(balance.value).gt(0);
+
+        return hasBalance || isEthToken;
       })
       .map((balance, index) => {
         const isFullToken = !showOnlyEth || (balance.token.tag || '').toLowerCase() === 'eth';

--- a/js/src/ui/Balance/balance.spec.js
+++ b/js/src/ui/Balance/balance.spec.js
@@ -81,7 +81,7 @@ describe('ui/Balance', () => {
   describe('render specifiers', () => {
     it('renders all the tokens with showZeroValues', () => {
       render({ showZeroValues: true });
-      expect(component.find('Connect(TokenImage)')).to.have.length(3);
+      expect(component.find('Connect(TokenImage)')).to.have.length(2);
     });
   });
 });

--- a/js/src/ui/Balance/balance.spec.js
+++ b/js/src/ui/Balance/balance.spec.js
@@ -79,28 +79,9 @@ describe('ui/Balance', () => {
   });
 
   describe('render specifiers', () => {
-    it('renders only the single token with showOnlyEth', () => {
-      render({ showOnlyEth: true });
-      expect(component.find('Connect(TokenImage)')).to.have.length(1);
-    });
-
     it('renders all the tokens with showZeroValues', () => {
       render({ showZeroValues: true });
       expect(component.find('Connect(TokenImage)')).to.have.length(3);
-    });
-
-    it('shows ETH with zero value with showOnlyEth & showZeroValues', () => {
-      render({
-        showOnlyEth: true,
-        showZeroValues: true,
-        balance: {
-          tokens: [
-            { value: '0', token: { tag: 'ETH' } },
-            { value: '345', token: { tag: 'GAV', format: 1 } }
-          ]
-        }
-      });
-      expect(component.find('Connect(TokenImage)')).to.have.length(1);
     });
   });
 });

--- a/js/src/views/Accounts/Summary/summary.js
+++ b/js/src/views/Accounts/Summary/summary.js
@@ -116,7 +116,6 @@ class Summary extends Component {
             { this.renderBalance(false) }
             { this.renderDescription(account.meta) }
             { this.renderOwners() }
-            { this.renderCertifications() }
             { this.renderVault(account.meta) }
           </div>
         }
@@ -155,8 +154,8 @@ class Summary extends Component {
         </div>
         <div className={ styles.summary }>
           { this.renderBalance(true) }
-          { this.renderCertifications(true) }
         </div>
+        { this.renderCertifications(true) }
       </Container>
     );
   }

--- a/js/src/views/Accounts/accounts.css
+++ b/js/src/views/Accounts/accounts.css
@@ -41,18 +41,23 @@
     margin-top: 1.5em;
   }
 
+  .iconCertifications {
+    top: 72px;
+    opacity: 1;
+    position: absolute;
+    left: 88px;
+
+    img {
+      height: 1em !important;
+      width: 1em !important;
+    }
+  }
+
   .summary {
     position: relative;
 
     .ethBalances {
       opacity: 1;
-    }
-
-    .iconCertifications {
-      bottom: -0.25em;
-      opacity: 1;
-      position: absolute;
-      right: 0;
     }
   }
 
@@ -80,10 +85,6 @@
 
   &:hover {
     .ethBalances {
-      opacity: 0;
-    }
-
-    .iconCertifications {
       opacity: 0;
     }
   }

--- a/js/src/views/Accounts/accounts.css
+++ b/js/src/views/Accounts/accounts.css
@@ -57,7 +57,7 @@
   }
 
   .overlay {
-    margin-top: -3.25em;
+    margin-top: -3em;
   }
 
   .owners {

--- a/js/src/views/Accounts/accounts.css
+++ b/js/src/views/Accounts/accounts.css
@@ -62,7 +62,7 @@
   }
 
   .overlay {
-    margin-top: -3em;
+    margin-top: -3.25em;
   }
 
   .owners {


### PR DESCRIPTION
- Show icons for tokens where there are balances (summary)
- Small verification icons, position adjusted
- Align summary & full balances (no jumping on hover)

![parity 2017-03-08 16-36-13](https://cloud.githubusercontent.com/assets/1424473/23710664/cf2f5006-041d-11e7-8900-fe1e7e4a7d58.png)
![parity 2017-03-08 16-36-50](https://cloud.githubusercontent.com/assets/1424473/23710671/d2f31a2e-041d-11e7-9c7e-9b0b2e430ff2.png)
![monosnap 2017-03-08 16-36-22](https://cloud.githubusercontent.com/assets/1424473/23710680/d85a9546-041d-11e7-925d-00b8ca49fea6.png)

