### PR TITLE
Don't link libsnappy explicitly

### DIFF
--- a/util/src/snappy.rs
+++ b/util/src/snappy.rs
@@ -23,7 +23,6 @@ const SNAPPY_OK: c_int = 0;
 const SNAPPY_INVALID_INPUT: c_int = 1;
 const SNAPPY_BUFFER_TOO_SMALL: c_int = 2;
 
-#[link(name = "snappy", kind = "static")]
 extern {
 	fn snappy_compress(
 		input: *const c_char,


### PR DESCRIPTION
It is already linked by `rocksdb-sys` which is a dependency.
Should help with #4836