### PR TITLE
Fix method decoding

### DIFF
--- a/js/src/ui/MethodDecoding/methodDecodingStore.js
+++ b/js/src/ui/MethodDecoding/methodDecodingStore.js
@@ -152,7 +152,6 @@ export default class MethodDecodingStore {
 
     // Contract deployment
     if (!signature || signature === CONTRACT_CREATE || transaction.creates) {
-
       const address = contractAddress || transaction.creates;
 
       return this.isContractCreation(input, address)

--- a/js/src/ui/MethodDecoding/methodDecodingStore.js
+++ b/js/src/ui/MethodDecoding/methodDecodingStore.js
@@ -138,6 +138,10 @@ export default class MethodDecodingStore {
       return Promise.resolve(result);
     }
 
+    if (!transaction.to) {
+      return this.decodeContractCreation(result);
+    }
+
     let signature;
 
     try {
@@ -148,6 +152,7 @@ export default class MethodDecodingStore {
 
     // Contract deployment
     if (!signature || signature === CONTRACT_CREATE || transaction.creates) {
+
       const address = contractAddress || transaction.creates;
 
       return this.isContractCreation(input, address)
@@ -206,7 +211,7 @@ export default class MethodDecodingStore {
       });
   }
 
-  decodeContractCreation (data, contractAddress) {
+  decodeContractCreation (data, contractAddress = '') {
     const result = {
       ...data,
       contract: true,


### PR DESCRIPTION
When deploying a contract, the MethodDecoding in the Signer for the pending request wasn't working...