### PR TITLE
[beta] Simple score

### DIFF
--- a/ethcore/src/engines/authority_round.rs
+++ b/ethcore/src/engines/authority_round.rs
@@ -235,9 +235,8 @@ impl Engine for AuthorityRound {
 	}
 
 	fn populate_from_parent(&self, header: &mut Header, parent: &Header, gas_floor_target: U256, _gas_ceil_target: U256) {
-		// Chain scoring: total weight is sqrt(U256::max_value())*height - step
-		let new_difficulty = U256::from(U128::max_value()) + header_step(parent).expect("Header has been verified; qed").into() - self.step.load(AtomicOrdering::SeqCst).into();
-		header.set_difficulty(new_difficulty);
+		// Chain scoring: weak height scoring, backported for compatibility.
+		header.set_difficulty(parent.difficulty().clone());
 		header.set_gas_limit({
 			let gas_limit = parent.gas_limit().clone();
 			let bound_divisor = self.gas_limit_bound_divisor;

--- a/sync/src/tests/consensus.rs
+++ b/sync/src/tests/consensus.rs
@@ -91,6 +91,7 @@ fn authority_round() {
 	assert_eq!(net.peer(1).chain.chain_info().best_block_number, 2);
 
 	// Fork the network with equal height.
+	/* Relies on view scoring, removed for now so that Kovan can be upgraded.
 	net.peer(0).chain.miner().import_own_transaction(&*net.peer(0).chain, new_tx(s0.secret(), 2.into())).unwrap();
 	net.peer(1).chain.miner().import_own_transaction(&*net.peer(1).chain, new_tx(s1.secret(), 2.into())).unwrap();
 	// Let both nodes build one block.
@@ -137,6 +138,7 @@ fn authority_round() {
 	assert_eq!(ci0.best_block_number, 5);
 	assert_eq!(ci1.best_block_number, 5);
 	assert_eq!(ci0.best_block_hash, ci1.best_block_hash);
+	*/
 }
 
 #[test]


### PR DESCRIPTION
A simple height scoring, which should should impose the same partial order on chains as `stable` and `master`.
This will be most likely changed in a future beta release.