### PR TITLE
Allow v1 get & v2 getData for registry

### DIFF
--- a/js/src/contracts/registry.js
+++ b/js/src/contracts/registry.js
@@ -129,9 +129,11 @@ export default class Registry {
     return this
       .getInstance()
       .then((instance) => {
+        const values = this._createGetParams(name, key);
+
         return instance.getData
-          ? instance.getData.call({}, this._createGetParams(name, key))
-          : instance.get.call({}, this._createGetParams(name, key));
+          ? instance.getData.call({}, values)
+          : instance.get.call({}, values);
       });
   }
 }

--- a/js/src/contracts/registry.spec.js
+++ b/js/src/contracts/registry.spec.js
@@ -35,6 +35,9 @@ function create () {
     }
   };
   api = {
+    eth: {
+      getCode: sinon.stub().resolves(0)
+    },
     parity: {
       registryAddress: sinon.stub().resolves('testRegistryAddress')
     },


### PR DESCRIPTION
Currently the fetch data for Kovan paritynews is non-operational.