### PR TITLE
Fix Gas Price Selector Tooltips

### DIFF
--- a/js/src/ui/GasPriceSelector/CustomTooltip/customTooltip.js
+++ b/js/src/ui/GasPriceSelector/CustomTooltip/customTooltip.js
@@ -19,12 +19,17 @@ import { FormattedMessage } from 'react-intl';
 
 export default class CustomTooltip extends Component {
   static propTypes = {
-    active: PropTypes.bool,
     histogram: PropTypes.object.isRequired,
+    intl: PropTypes.object.isRequired,
+    active: PropTypes.bool,
     label: PropTypes.number,
     payload: PropTypes.array,
     type: PropTypes.string
-  }
+  };
+
+  static childContextTypes = {
+    intl: PropTypes.object.isRequired
+  };
 
   render () {
     const { active, label, histogram } = this.props;
@@ -54,5 +59,9 @@ export default class CustomTooltip extends Component {
         </p>
       </div>
     );
+  }
+
+  getChildContext () {
+    return { intl: this.props.intl };
   }
 }

--- a/js/src/ui/GasPriceSelector/gasPriceSelector.js
+++ b/js/src/ui/GasPriceSelector/gasPriceSelector.js
@@ -36,6 +36,10 @@ const TOOL_STYLE = {
 };
 
 export default class GasPriceSelector extends Component {
+  static contextTypes = {
+    intl: PropTypes.object.isRequired
+  };
+
   static propTypes = {
     histogram: PropTypes.object.isRequired,
     onChange: PropTypes.func.isRequired,
@@ -145,7 +149,7 @@ export default class GasPriceSelector extends Component {
                   shape={ <CustomBar selected={ selectedIndex } onClick={ this.onClickprice } /> }stroke={ COLORS.line }
                 />
                 <Tooltip
-                  content={ <CustomTooltip histogram={ histogram } /> }
+                  content={ this.tooltipContentRenderer }
                   cursor={ this.renderCustomCursor() }
                   wrapperStyle={ TOOL_STYLE }
                 />
@@ -165,6 +169,23 @@ export default class GasPriceSelector extends Component {
           </div>
         </div>
       </div>
+    );
+  }
+
+  /**
+   * Passing the `intl` object as a prop
+   * so the CustomTooltip can add for child
+   * context (used by FormattedMessages)
+   */
+  tooltipContentRenderer = (props) => {
+    const { histogram } = this.props;
+
+    return (
+      <CustomTooltip
+        histogram={ histogram }
+        intl={ this.context.intl }
+        { ...props }
+      />
     );
   }
 


### PR DESCRIPTION
The Tooltips weren't working since the introduction of FormattedMessages to the GasPriceSelector