### PR TITLE
Safari Dialog scrolling fix

### DIFF
--- a/js/src/ui/Portal/portal.css
+++ b/js/src/ui/Portal/portal.css
@@ -51,7 +51,7 @@ $popoverZ: 3600;
   left: 0;
   right: 0;
   opacity: 0.25;
-  z-index: 0;
+  z-index: -1;
 }
 
 .overlay {


### PR DESCRIPTION
- Move ParityBackground on Portal z-index to -1 (despite being 0/lower, it still overlays in Safari)
- Confirm to fix dialog non-scrolling issues in Safari, also tested on Chrome (no additional effects)
- Evaluated/tested on FirstRun and create dialogs

Fixes https://github.com/ethcore/parity/issues/4890